### PR TITLE
[codex] Fix clippy node role label iteration

### DIFF
--- a/src/console/handlers/cluster.rs
+++ b/src/console/handlers/cluster.rs
@@ -58,8 +58,8 @@ pub async fn list_nodes(Extension(claims): Extension<Claims>) -> Result<Json<Nod
                 .as_ref()
                 .map(|labels| {
                     labels
-                        .iter()
-                        .filter_map(|(k, _)| {
+                        .keys()
+                        .filter_map(|k| {
                             if k.starts_with("node-role.kubernetes.io/") {
                                 Some(k.trim_start_matches("node-role.kubernetes.io/").to_string())
                             } else {

--- a/src/console/handlers/topology.rs
+++ b/src/console/handlers/topology.rs
@@ -85,8 +85,8 @@ pub async fn get_topology_overview(
                 .as_ref()
                 .map(|labels| {
                     labels
-                        .iter()
-                        .filter_map(|(k, _)| {
+                        .keys()
+                        .filter_map(|k| {
                             k.strip_prefix("node-role.kubernetes.io/")
                                 .map(|r| r.to_string())
                         })


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [x] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
N/A

## Summary of Changes
Fixes the clippy `iter_kv_map` warning reported by CI with Rust/clippy 1.95.

The node role label extraction now iterates over map keys directly with `labels.keys()` instead of iterating key-value pairs and ignoring the values.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit` (fmt-check + clippy + test + console-lint + console-fmt-check)
- [ ] Added/updated necessary tests (N/A: lint-only code cleanup)
- [ ] Documentation updated (if needed) (N/A)
- [ ] CHANGELOG.md updated under `[Unreleased]` (if user-visible change) (N/A)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (CRD/API compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact: restores compatibility with newer clippy warnings treated as errors

## Verification
```bash
make pre-commit
```

## Additional Notes
This follows up on the CI failure observed in PR #115 after GitHub Actions used Rust/clippy 1.95.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.