### PR TITLE
fix(examples): correct pool name in simple-tenant.yaml RUSTFS_VOLUMES…

### DIFF
--- a/examples/simple-tenant.yaml
+++ b/examples/simple-tenant.yaml
@@ -104,7 +104,7 @@ spec:
   # for multi-node, multi-disk distributed storage communication.
   #
   # For this configuration, the generated RUSTFS_VOLUMES will be:
-  # http://example-tenant-pool-0-{0...1}.example-tenant-hl.rustfs-system.svc.cluster.local:9000/data/rustfs{0...1}
+  # http://example-tenant-primary-{0...1}.example-tenant-hl.rustfs-system.svc.cluster.local:9000/data/rustfs{0...1}
   #
   # This configures RustFS to:
   # - Communicate with 2 nodes (servers: 2)


### PR DESCRIPTION
… comment

The comment referenced 'pool-0' but the actual pool name in the manifest is 'primary'. Update the RUSTFS_VOLUMES example to match the real StatefulSet naming pattern: {tenant}-{pool}-{ordinal}.

<!--
Pull Request Template for RustFS Operator
-->

## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [x] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
<!-- List related Issue numbers, e.g. #123 -->

## Summary of Changes
<!-- Briefly describe the main changes and motivation for this PR -->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Passed `make pre-commit` (fmt-check + clippy + test + console-lint + console-fmt-check)
- [ ] Added/updated necessary tests
- [ ] Documentation updated (if needed)
- [ ] CHANGELOG.md updated under `[Unreleased]` (if user-visible change)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (CRD/API compatibility)
- [ ] Requires doc/config/deployment update
- [ ] Other impact:

## Verification
<!-- Include commands reviewers can run to verify the change -->
```bash
make pre-commit
```

## Additional Notes
<!-- Any extra information for reviewers -->

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
