### PR TITLE
feat(monitoring): add operator metrics and tenant health polling

### DIFF
--- a/deploy/k8s-dev/operator-deployment.yaml
+++ b/deploy/k8s-dev/operator-deployment.yaml
@@ -30,12 +30,39 @@ spec:
           args:
             - "--leader-elect=false"
           ports:
+            - name: metrics
+              containerPort: 8080
+              protocol: TCP
             - name: sts
               containerPort: 4223
               protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: metrics
+            initialDelaySeconds: 10
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: metrics
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
           env:
             - name: RUST_LOG
               value: info
+            - name: OPERATOR_METRICS_ENABLED
+              value: "true"
+            - name: OPERATOR_METRICS_PORT
+              value: "8080"
+            - name: OPERATOR_TENANT_MONITOR_ENABLED
+              value: "true"
+            - name: OPERATOR_TENANT_MONITOR_INTERVAL_SECONDS
+              value: "300"
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/deploy/k8s-dev/operator-metrics-service.yaml
+++ b/deploy/k8s-dev/operator-metrics-service.yaml
@@ -1,0 +1,20 @@
+# Copyright 2025 RustFS Team
+# Operator metrics Service (used by the dev and e2e deployment flows)
+apiVersion: v1
+kind: Service
+metadata:
+  name: rustfs-operator-metrics
+  namespace: rustfs-system
+  labels:
+    app.kubernetes.io/name: rustfs-operator
+    app.kubernetes.io/component: operator
+spec:
+  type: ClusterIP
+  ports:
+    - name: metrics
+      port: 8080
+      targetPort: metrics
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: rustfs-operator
+    app.kubernetes.io/component: operator

--- a/deploy/rustfs-operator/README.md
+++ b/deploy/rustfs-operator/README.md
@@ -47,6 +47,12 @@ The following table lists the configurable parameters of the RustFS Operator cha
 | `operator.resources.requests.memory` | Memory resource requests | `128Mi` |
 | `operator.resources.limits.cpu` | CPU resource limits | `500m` |
 | `operator.resources.limits.memory` | Memory resource limits | `512Mi` |
+| `operator.metrics.enabled` | Enable operator `/metrics`, `/healthz`, and `/readyz` endpoint | `true` |
+| `operator.metrics.port` | Operator observability container port | `8080` |
+| `operator.serviceMonitor.enabled` | Create a Prometheus Operator ServiceMonitor | `false` |
+| `operator.prometheusRule.enabled` | Create Prometheus alert rules for operator and tenant storage health | `false` |
+| `operator.tenantMonitor.enabled` | Poll RustFS tenant storage health and capacity metrics | `true` |
+| `operator.tenantMonitor.intervalSeconds` | Tenant storage monitor interval | `300` |
 | `operator.env` | Environment variables | `[{name: RUST_LOG, value: info}]` |
 | `operator.nodeSelector` | Node selector for pod placement | `{}` |
 | `operator.tolerations` | Tolerations for pod scheduling | `[]` |
@@ -77,6 +83,8 @@ The STS service is HTTPS by default. When `sts.tls.auto=true`, the operator crea
 STS only issues credentials for TLS-enabled Tenants. For Tenant upstream calls, the operator selects the Tenant HTTPS service endpoint and trusts the CA recorded in `status.certificates.tls.caSecretRef`.
 
 Operator STS does not present a client certificate when calling the Tenant. Tenants configured with `spec.tls.certManager.caTrust.clientCaSecretRef` continue to run with server-side mTLS enabled, but Operator STS rejects those Tenants with HTTP 400 and `TenantTlsClientCertificateUnsupported`.
+
+When `operator.serviceMonitor.enabled=true`, the chart creates scrape targets for both the operator observability endpoint and the Console API `/metrics` endpoint.
 
 ### Tenant Provisioning
 

--- a/deploy/rustfs-operator/templates/console-servicemonitor.yaml
+++ b/deploy/rustfs-operator/templates/console-servicemonitor.yaml
@@ -1,0 +1,30 @@
+{{- if and .Values.console.enabled .Values.operator.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "rustfs-operator.fullname" . }}-console
+  namespace: {{ include "rustfs-operator.namespace" . }}
+  labels:
+    {{- include "rustfs-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: console
+    {{- with .Values.operator.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.operator.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ include "rustfs-operator.namespace" . }}
+  selector:
+    matchLabels:
+      {{- include "rustfs-operator.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: console
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: {{ .Values.operator.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.operator.serviceMonitor.scrapeTimeout }}
+{{- end }}

--- a/deploy/rustfs-operator/templates/deployment.yaml
+++ b/deploy/rustfs-operator/templates/deployment.yaml
@@ -1,3 +1,8 @@
+{{- $livenessProbe := default dict .Values.operator.livenessProbe -}}
+{{- $readinessProbe := default dict .Values.operator.readinessProbe -}}
+{{- if and (not .Values.operator.metrics.enabled) (or (hasKey $livenessProbe "httpGet") (hasKey $readinessProbe "httpGet")) -}}
+{{- fail "operator.metrics.enabled=false requires overriding operator.livenessProbe and operator.readinessProbe because the chart defaults use the metrics port" -}}
+{{- end -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -44,11 +49,18 @@ spec:
           {{- end }}
           args:
             - --leader-elect={{ ternary "true" "false" $leaderElect }}
-          {{- if .Values.sts.enabled }}
+          {{- if or .Values.sts.enabled .Values.operator.metrics.enabled }}
           ports:
+          {{- if .Values.operator.metrics.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.operator.metrics.port }}
+              protocol: TCP
+          {{- end }}
+          {{- if .Values.sts.enabled }}
             - name: sts
               containerPort: {{ .Values.sts.port }}
               protocol: TCP
+          {{- end }}
           {{- end }}
           {{- with .Values.operator.livenessProbe }}
           livenessProbe:
@@ -59,6 +71,14 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
+            - name: OPERATOR_METRICS_ENABLED
+              value: {{ .Values.operator.metrics.enabled | quote }}
+            - name: OPERATOR_METRICS_PORT
+              value: {{ .Values.operator.metrics.port | quote }}
+            - name: OPERATOR_TENANT_MONITOR_ENABLED
+              value: {{ .Values.operator.tenantMonitor.enabled | quote }}
+            - name: OPERATOR_TENANT_MONITOR_INTERVAL_SECONDS
+              value: {{ .Values.operator.tenantMonitor.intervalSeconds | quote }}
             - name: OPERATOR_STS_ENABLED
               value: {{ .Values.sts.enabled | quote }}
             - name: OPERATOR_STS_AUDIENCE

--- a/deploy/rustfs-operator/templates/operator-metrics-service.yaml
+++ b/deploy/rustfs-operator/templates/operator-metrics-service.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.operator.metrics.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "rustfs-operator.fullname" . }}-metrics
+  namespace: {{ include "rustfs-operator.namespace" . }}
+  labels:
+    {{- include "rustfs-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: operator-metrics
+  {{- with .Values.operator.metrics.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.operator.metrics.service.type }}
+  {{- if and (eq .Values.operator.metrics.service.type "ClusterIP") .Values.operator.metrics.service.clusterIP }}
+  clusterIP: {{ .Values.operator.metrics.service.clusterIP }}
+  {{- end }}
+  ports:
+    - port: {{ .Values.operator.metrics.service.port }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+  selector:
+    {{- include "rustfs-operator.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: operator
+{{- end }}

--- a/deploy/rustfs-operator/templates/prometheusrule.yaml
+++ b/deploy/rustfs-operator/templates/prometheusrule.yaml
@@ -1,0 +1,45 @@
+{{- if and .Values.operator.metrics.enabled .Values.operator.prometheusRule.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "rustfs-operator.fullname" . }}
+  namespace: {{ include "rustfs-operator.namespace" . }}
+  labels:
+    {{- include "rustfs-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: operator
+    {{- with .Values.operator.prometheusRule.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.operator.prometheusRule.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  groups:
+    - name: rustfs-operator.rules
+      rules:
+        - alert: RustfsOperatorReconcileErrors
+          expr: sum(increase(rustfs_operator_reconcile_total{result="error"}[10m])) > 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: RustFS Operator reconcile errors
+            description: RustFS Operator has reported reconcile errors in the last 10 minutes.
+        - alert: RustfsTenantStorageUnhealthy
+          expr: rustfs_operator_tenant_storage_poll_success == 1 and rustfs_operator_tenant_storage_healthy == 0
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: RustFS tenant storage is unhealthy
+            description: A RustFS tenant has offline, healing, or quorum-risk storage.
+        - alert: RustfsTenantStoragePollFailed
+          expr: rustfs_operator_tenant_storage_poll_success == 0
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: RustFS tenant storage monitor poll failed
+            description: The operator cannot collect storage health for a RustFS tenant.
+{{- end }}

--- a/deploy/rustfs-operator/templates/servicemonitor.yaml
+++ b/deploy/rustfs-operator/templates/servicemonitor.yaml
@@ -1,0 +1,30 @@
+{{- if and .Values.operator.metrics.enabled .Values.operator.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "rustfs-operator.fullname" . }}
+  namespace: {{ include "rustfs-operator.namespace" . }}
+  labels:
+    {{- include "rustfs-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: operator
+    {{- with .Values.operator.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.operator.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ include "rustfs-operator.namespace" . }}
+  selector:
+    matchLabels:
+      {{- include "rustfs-operator.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: operator-metrics
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ .Values.operator.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.operator.serviceMonitor.scrapeTimeout }}
+{{- end }}

--- a/deploy/rustfs-operator/values.yaml
+++ b/deploy/rustfs-operator/values.yaml
@@ -25,22 +25,46 @@ operator:
       cpu: 500m
       memory: 512Mi
 
+  metrics:
+    # Enable the operator observability HTTP endpoint.
+    enabled: true
+    port: 8080
+    service:
+      type: ClusterIP
+      port: 8080
+      clusterIP: ""
+      annotations: {}
+
+  serviceMonitor:
+    enabled: false
+    interval: 30s
+    scrapeTimeout: 10s
+    labels: {}
+    annotations: {}
+
+  prometheusRule:
+    enabled: false
+    labels: {}
+    annotations: {}
+
+  tenantMonitor:
+    enabled: true
+    intervalSeconds: 300
+
   # Basic process probes. Override these for stricter platform-specific checks.
   livenessProbe:
-    exec:
-      command:
-        - ./operator
-        - --version
+    httpGet:
+      path: /healthz
+      port: metrics
     initialDelaySeconds: 10
     periodSeconds: 20
     timeoutSeconds: 5
     failureThreshold: 3
 
   readinessProbe:
-    exec:
-      command:
-        - ./operator
-        - --version
+    httpGet:
+      path: /readyz
+      port: metrics
     initialDelaySeconds: 5
     periodSeconds: 10
     timeoutSeconds: 5

--- a/src/console/middleware/auth.rs
+++ b/src/console/middleware/auth.rs
@@ -38,6 +38,7 @@ pub async fn auth_middleware(
     let path = request.uri().path();
     if path == "/healthz"
         || path == "/readyz"
+        || path == "/metrics"
         || path.starts_with("/api/v1/login")
         || path.starts_with("/swagger-ui")
         || path.starts_with("/api-docs")

--- a/src/console/server.rs
+++ b/src/console/server.rs
@@ -40,6 +40,7 @@ fn cors_allowed_origins() -> Vec<HeaderValue> {
 /// Start the Console HTTP server (Axum).
 pub async fn run(port: u16) -> Result<(), Box<dyn std::error::Error>> {
     crate::install_rustls_crypto_provider();
+    crate::init_tracing();
 
     tracing::info!("Starting RustFS Operator Console on port {}", port);
 
@@ -66,6 +67,7 @@ pub async fn run(port: u16) -> Result<(), Box<dyn std::error::Error>> {
         // Liveness (unauthenticated)
         .route("/healthz", get(health_check))
         .route("/readyz", get(ready_check))
+        .route("/metrics", get(crate::metrics::handler))
         // OpenAPI / Swagger (unauthenticated)
         .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", ApiDoc::openapi()))
         // REST API v1
@@ -91,7 +93,8 @@ pub async fn run(port: u16) -> Result<(), Box<dyn std::error::Error>> {
                 .allow_credentials(true),
         )
         .layer(CompressionLayer::new())
-        .layer(TraceLayer::new_for_http());
+        .layer(TraceLayer::new_for_http())
+        .layer(middleware::from_fn(crate::metrics::record_console_http));
 
     // Bind and serve
     let addr = std::net::SocketAddr::from(([0, 0, 0, 0], port));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,10 @@ use crate::context::Context;
 use crate::reconcile::{error_policy, reconcile_rustfs};
 use crate::types::v1alpha1::policy_binding::PolicyBinding;
 use crate::types::v1alpha1::tenant::Tenant;
-use axum::{Router, body::Body};
+use axum::{
+    Router, body::Body, extract::State, http::StatusCode, middleware, response::IntoResponse,
+    routing::get,
+};
 use futures::StreamExt;
 use hyper::body::Incoming;
 use hyper_util::rt::{TokioExecutor, TokioIo};
@@ -30,15 +33,16 @@ use k8s_openapi::apimachinery::pkg::apis::meta::v1 as metav1;
 use kube::core::{ApiResource, DynamicObject, GroupVersionKind};
 use kube::runtime::reflector::ObjectRef;
 use kube::runtime::{Controller, watcher};
-use kube::{Api, Client, CustomResourceExt, Resource};
+use kube::{Api, Client, CustomResourceExt, Resource, api::ListParams};
 use kube_leader_election::{
     LeaderCallbacks, LeaderElector, LeaderElectorConfig, LeaseLock, SystemClock,
 };
 use std::collections::BTreeMap;
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{Arc, Once};
 use std::time::Duration;
 use tokio::io::{AsyncWrite, AsyncWriteExt};
+use tokio::task::JoinHandle;
 use tokio_rustls::TlsAcceptor;
 use tokio_util::sync::CancellationToken;
 use tower::ServiceExt as _;
@@ -66,9 +70,24 @@ pub fn install_rustls_crypto_provider() {
     let _ = rustls::crypto::ring::default_provider().install_default();
 }
 
+pub fn init_tracing() {
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .with_level(true)
+            .with_file(true)
+            .with_line_number(true)
+            .with_target(true)
+            .try_init();
+    });
+}
+
 mod context;
+pub mod metrics;
 pub mod reconcile;
 mod status;
+mod tenant_monitor;
 pub mod types;
 pub mod utils;
 
@@ -81,16 +100,23 @@ pub mod tests;
 
 pub async fn run(options: ServerOptions) -> Result<(), Box<dyn std::error::Error>> {
     install_rustls_crypto_provider();
-
-    tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .with_level(true)
-        .with_file(true)
-        .with_line_number(true)
-        .with_target(true)
-        .init();
+    init_tracing();
 
     let client = Client::try_default().await?;
+    if operator_metrics_enabled() {
+        let metrics_port = operator_metrics_port();
+        let metrics_client = client.clone();
+        tokio::spawn(async move {
+            if let Err(error) =
+                run_operator_observability_server(metrics_client, metrics_port).await
+            {
+                warn!(%error, "operator observability server stopped unexpectedly");
+            }
+        });
+    } else {
+        info!("operator metrics server disabled by OPERATOR_METRICS_ENABLED=false");
+    }
+
     if operator_sts_enabled() {
         let sts_port = operator_sts_port();
         let sts_state =
@@ -147,7 +173,9 @@ pub async fn run(options: ServerOptions) -> Result<(), Box<dyn std::error::Error
         elector.run(callbacks, cancel).await?;
     } else {
         info!("starting with leader election disabled");
-        run_controller(client, CancellationToken::new()).await;
+        metrics::set_operator_leader(true);
+        run_active_leader_tasks(client, CancellationToken::new()).await;
+        metrics::set_operator_leader(false);
     }
 
     Ok(())
@@ -202,7 +230,11 @@ async fn run_controller(client: Client, cancel: CancellationToken) {
     };
 
     let mut reconcile_stream = controller
-        .run(reconcile_rustfs, error_policy, Arc::new(context))
+        .run(
+            instrumented_reconcile_rustfs,
+            error_policy,
+            Arc::new(context),
+        )
         .boxed();
 
     tokio::select! {
@@ -220,6 +252,69 @@ async fn run_controller(client: Client, cancel: CancellationToken) {
     }
 }
 
+async fn instrumented_reconcile_rustfs(
+    tenant: Arc<Tenant>,
+    ctx: Arc<Context>,
+) -> Result<kube::runtime::controller::Action, reconcile::Error> {
+    let started = metrics::reconcile_started();
+    let result = reconcile_rustfs(tenant, ctx).await;
+    metrics::reconcile_finished(result.is_ok(), started.elapsed());
+    result
+}
+
+async fn run_active_leader_tasks(client: Client, cancel: CancellationToken) {
+    let tasks_cancel = CancellationToken::new();
+    let controller_client = client.clone();
+    let controller_cancel = tasks_cancel.clone();
+    let mut controller_handle = tokio::spawn(async move {
+        run_controller(controller_client, controller_cancel).await;
+    });
+
+    let mut monitor_handle = if tenant_monitor::is_enabled() {
+        let monitor_cancel = tasks_cancel.clone();
+        Some(tokio::spawn(async move {
+            tenant_monitor::run(client, monitor_cancel).await;
+        }))
+    } else {
+        info!("tenant storage monitor disabled by OPERATOR_TENANT_MONITOR_ENABLED=false");
+        None
+    };
+
+    let mut controller_finished = false;
+    tokio::select! {
+        result = &mut controller_handle => {
+            controller_finished = true;
+            if let Err(error) = result {
+                warn!(%error, "controller task failed");
+            } else {
+                info!("controller finished");
+            }
+        }
+        _ = cancel.cancelled() => {
+            info!("leader task cancellation requested");
+        }
+    }
+
+    tasks_cancel.cancel();
+    if !controller_finished {
+        stop_task("controller", controller_handle).await;
+    }
+    if let Some(handle) = monitor_handle.take() {
+        stop_task("tenant storage monitor", handle).await;
+    }
+}
+
+async fn stop_task(name: &str, mut handle: JoinHandle<()>) {
+    if tokio::time::timeout(Duration::from_secs(5), &mut handle)
+        .await
+        .is_err()
+    {
+        warn!(task = name, "task stop timed out, forcing shutdown");
+        handle.abort();
+        let _ = handle.await;
+    }
+}
+
 /// Callbacks for running the controller inside leader election.
 struct ControllerCallbacks {
     client: Client,
@@ -228,41 +323,109 @@ struct ControllerCallbacks {
 #[async_trait::async_trait]
 impl LeaderCallbacks for ControllerCallbacks {
     async fn on_started_leading(&self, cancel: CancellationToken) {
-        info!("acquired leader lease, starting controller");
-        let client = self.client.clone();
-        let controller_cancel = CancellationToken::new();
-        let run_cancel = controller_cancel.clone();
-        // Run the controller in a separate task so we can select on the cancel token.
-        let controller_handle = tokio::spawn(async move {
-            run_controller(client, run_cancel).await;
-        });
-        tokio::pin!(controller_handle);
-
-        tokio::select! {
-            _ = &mut controller_handle => {
-                info!("controller finished");
-            }
-            _ = cancel.cancelled() => {
-                info!("lost leader lease, stopping controller");
-                controller_cancel.cancel();
-                if tokio::time::timeout(Duration::from_secs(5), &mut controller_handle)
-                    .await
-                    .is_err()
-                {
-                    warn!("controller stop timed out, forcing shutdown");
-                    controller_handle.abort();
-                }
-                let _ = controller_handle.await;
-            }
-        }
+        info!("acquired leader lease, starting active leader tasks");
+        metrics::set_operator_leader(true);
+        run_active_leader_tasks(self.client.clone(), cancel).await;
+        metrics::set_operator_leader(false);
     }
 
     async fn on_stopped_leading(&self) {
+        metrics::set_operator_leader(false);
         warn!("stopped leading");
     }
 
     async fn on_new_leader(&self, identity: String) {
         info!(new_leader = %identity, "observed new leader");
+    }
+}
+
+#[derive(Clone)]
+struct OperatorObservabilityState {
+    client: Client,
+}
+
+async fn run_operator_observability_server(
+    client: Client,
+    port: u16,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let state = OperatorObservabilityState { client };
+    let app = Router::new()
+        .route("/metrics", get(metrics::handler))
+        .route("/healthz", get(operator_health_check))
+        .route("/readyz", get(operator_ready_check))
+        .with_state(state)
+        .layer(middleware::from_fn(metrics::record_operator_http));
+
+    let addr = std::net::SocketAddr::from(([0, 0, 0, 0], port));
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    info!("operator observability server listening on http://{}", addr);
+    axum::serve(listener, app).await?;
+    Ok(())
+}
+
+async fn operator_health_check() -> impl IntoResponse {
+    let since_epoch = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    (StatusCode::OK, format!("OK: {}", since_epoch.as_secs()))
+}
+
+async fn operator_ready_check(
+    State(state): State<OperatorObservabilityState>,
+) -> impl IntoResponse {
+    match check_operator_control_plane(&state.client).await {
+        Ok(()) => (StatusCode::OK, "Ready".to_string()),
+        Err(error) => {
+            warn!(%error, "operator readiness check failed");
+            (
+                StatusCode::SERVICE_UNAVAILABLE,
+                format!("Not ready: {error}"),
+            )
+        }
+    }
+}
+
+async fn check_operator_control_plane(client: &Client) -> Result<(), String> {
+    let tenants: Api<Tenant> = Api::all(client.clone());
+    tenants
+        .list(&ListParams::default().limit(1))
+        .await
+        .map_err(|error| format!("Tenant API: {error}"))?;
+    Ok(())
+}
+
+fn operator_metrics_port() -> u16 {
+    let default_port: u16 = 8080;
+    match std::env::var("OPERATOR_METRICS_PORT") {
+        Ok(raw_port) => match raw_port.parse::<u16>() {
+            Ok(port) => port,
+            Err(error) => {
+                warn!(
+                    %error,
+                    raw_port,
+                    "invalid OPERATOR_METRICS_PORT value, using default"
+                );
+                default_port
+            }
+        },
+        Err(_) => default_port,
+    }
+}
+
+fn operator_metrics_enabled() -> bool {
+    match std::env::var("OPERATOR_METRICS_ENABLED") {
+        Ok(value) => match value.trim().to_ascii_lowercase().as_str() {
+            "1" | "true" | "yes" | "on" => true,
+            "0" | "false" | "no" | "off" => false,
+            _ => {
+                warn!(
+                    value,
+                    "invalid OPERATOR_METRICS_ENABLED value, defaulting to enabled"
+                );
+                true
+            }
+        },
+        Err(_) => true,
     }
 }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,637 @@
+// Copyright 2025 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use axum::{
+    extract::Request,
+    http::{HeaderMap, HeaderValue, StatusCode, header},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::{
+        Mutex, OnceLock,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
+
+const PROMETHEUS_CONTENT_TYPE: &str = "text/plain; version=0.0.4; charset=utf-8";
+
+#[derive(Default)]
+struct Metrics {
+    reconcile_total: Mutex<BTreeMap<String, u64>>,
+    reconcile_duration: Mutex<BTreeMap<String, DurationSummary>>,
+    reconcile_requeues_total: Mutex<BTreeMap<String, u64>>,
+    reconcile_inflight: AtomicU64,
+    operator_leader: AtomicU64,
+    sts_requests_total: Mutex<BTreeMap<String, u64>>,
+    sts_request_duration: Mutex<BTreeMap<String, DurationSummary>>,
+    http_requests_total: Mutex<BTreeMap<HttpKey, u64>>,
+    http_request_duration: Mutex<BTreeMap<HttpKey, DurationSummary>>,
+    tenant_monitor_polls_total: Mutex<BTreeMap<String, u64>>,
+    tenant_monitor_poll_duration: Mutex<BTreeMap<String, DurationSummary>>,
+    tenant_storage: Mutex<BTreeMap<TenantKey, TenantStorageSnapshot>>,
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct HttpKey {
+    component: String,
+    method: String,
+    status: String,
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct TenantKey {
+    namespace: String,
+    tenant: String,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct DurationSummary {
+    count: u64,
+    sum_seconds: f64,
+}
+
+impl DurationSummary {
+    fn observe(&mut self, duration: Duration) {
+        self.count += 1;
+        self.sum_seconds += duration.as_secs_f64();
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct TenantStorageSnapshot {
+    poll_success: bool,
+    last_poll_timestamp_seconds: u64,
+    online_drives: u64,
+    offline_drives: u64,
+    healing_drives: u64,
+    raw_capacity_bytes: u64,
+    raw_used_bytes: u64,
+    object_usage_bytes: u64,
+    write_quorum_drives: u64,
+    healthy: bool,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct TenantStorageMetrics {
+    pub online_drives: u64,
+    pub offline_drives: u64,
+    pub healing_drives: u64,
+    pub raw_capacity_bytes: u64,
+    pub raw_used_bytes: u64,
+    pub object_usage_bytes: u64,
+    pub write_quorum_drives: u64,
+    pub healthy: bool,
+}
+
+fn metrics() -> &'static Metrics {
+    static METRICS: OnceLock<Metrics> = OnceLock::new();
+    METRICS.get_or_init(Metrics::default)
+}
+
+pub fn set_operator_leader(is_leader: bool) {
+    metrics()
+        .operator_leader
+        .store(u64::from(is_leader), Ordering::Relaxed);
+}
+
+pub fn reconcile_started() -> Instant {
+    metrics().reconcile_inflight.fetch_add(1, Ordering::Relaxed);
+    Instant::now()
+}
+
+pub fn reconcile_finished(success: bool, duration: Duration) {
+    let result = result_label(success);
+    metrics().reconcile_inflight.fetch_sub(1, Ordering::Relaxed);
+    increment_string_counter(&metrics().reconcile_total, result);
+    observe_string_duration(&metrics().reconcile_duration, result, duration);
+}
+
+pub fn record_reconcile_requeue(duration: Duration) {
+    let delay = duration.as_secs().to_string();
+    increment_string_counter(&metrics().reconcile_requeues_total, &delay);
+}
+
+pub fn record_sts_request(success: bool, duration: Duration) {
+    let result = result_label(success);
+    increment_string_counter(&metrics().sts_requests_total, result);
+    observe_string_duration(&metrics().sts_request_duration, result, duration);
+}
+
+pub fn record_http_request(component: &str, method: &str, status: StatusCode, duration: Duration) {
+    let key = HttpKey {
+        component: component.to_string(),
+        method: method.to_string(),
+        status: status_class(status).to_string(),
+    };
+
+    {
+        let mut counters = metrics()
+            .http_requests_total
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *counters.entry(key.clone()).or_default() += 1;
+    }
+
+    let mut summaries = metrics()
+        .http_request_duration
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    summaries.entry(key).or_default().observe(duration);
+}
+
+pub async fn record_console_http(request: Request, next: Next) -> Response {
+    record_component_http("console", request, next).await
+}
+
+pub async fn record_operator_http(request: Request, next: Next) -> Response {
+    record_component_http("operator", request, next).await
+}
+
+async fn record_component_http(component: &'static str, request: Request, next: Next) -> Response {
+    let method = request.method().as_str().to_string();
+    let started = Instant::now();
+    let response = next.run(request).await;
+    record_http_request(component, &method, response.status(), started.elapsed());
+    response
+}
+
+pub fn record_tenant_monitor_poll(result: &str, duration: Duration) {
+    increment_string_counter(&metrics().tenant_monitor_polls_total, result);
+    observe_string_duration(&metrics().tenant_monitor_poll_duration, result, duration);
+}
+
+pub fn record_tenant_monitor_skipped(namespace: &str, tenant: &str, duration: Duration) {
+    record_tenant_monitor_poll("skipped", duration);
+    update_tenant_storage_snapshot(
+        namespace,
+        tenant,
+        TenantStorageSnapshot {
+            poll_success: false,
+            last_poll_timestamp_seconds: unix_timestamp_seconds(),
+            ..Default::default()
+        },
+    );
+}
+
+pub fn record_tenant_storage(namespace: &str, tenant: &str, storage: TenantStorageMetrics) {
+    update_tenant_storage_snapshot(
+        namespace,
+        tenant,
+        TenantStorageSnapshot {
+            poll_success: true,
+            last_poll_timestamp_seconds: unix_timestamp_seconds(),
+            online_drives: storage.online_drives,
+            offline_drives: storage.offline_drives,
+            healing_drives: storage.healing_drives,
+            raw_capacity_bytes: storage.raw_capacity_bytes,
+            raw_used_bytes: storage.raw_used_bytes,
+            object_usage_bytes: storage.object_usage_bytes,
+            write_quorum_drives: storage.write_quorum_drives,
+            healthy: storage.healthy,
+        },
+    );
+}
+
+pub fn record_tenant_storage_error(namespace: &str, tenant: &str) {
+    let key = TenantKey {
+        namespace: namespace.to_string(),
+        tenant: tenant.to_string(),
+    };
+    let mut snapshots = metrics()
+        .tenant_storage
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let snapshot = snapshots.entry(key).or_default();
+    snapshot.poll_success = false;
+    snapshot.last_poll_timestamp_seconds = unix_timestamp_seconds();
+}
+
+pub fn prune_tenant_storage(active_tenants: &[(String, String)]) {
+    let active_tenants = active_tenants
+        .iter()
+        .map(|(namespace, tenant)| TenantKey {
+            namespace: namespace.clone(),
+            tenant: tenant.clone(),
+        })
+        .collect::<BTreeSet<_>>();
+
+    let mut snapshots = metrics()
+        .tenant_storage
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    snapshots.retain(|key, _| active_tenants.contains(key));
+}
+
+pub async fn handler() -> impl IntoResponse {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static(PROMETHEUS_CONTENT_TYPE),
+    );
+    (headers, render())
+}
+
+pub fn render() -> String {
+    let mut output = String::new();
+
+    render_string_counter(
+        &mut output,
+        "rustfs_operator_reconcile_total",
+        "Total number of Tenant reconcile attempts by result.",
+        "result",
+        &metrics().reconcile_total,
+    );
+    render_string_duration_summary(
+        &mut output,
+        "rustfs_operator_reconcile_duration_seconds",
+        "Tenant reconcile handler duration by result.",
+        "result",
+        &metrics().reconcile_duration,
+    );
+    render_gauge(
+        &mut output,
+        "rustfs_operator_reconcile_inflight",
+        "Number of reconcile handlers currently running.",
+        metrics().reconcile_inflight.load(Ordering::Relaxed) as f64,
+    );
+    render_string_counter(
+        &mut output,
+        "rustfs_operator_reconcile_requeues_total",
+        "Total number of error-policy reconcile requeues by delay in seconds.",
+        "delay_seconds",
+        &metrics().reconcile_requeues_total,
+    );
+    render_gauge(
+        &mut output,
+        "rustfs_operator_leader",
+        "Whether this process is the active operator leader.",
+        metrics().operator_leader.load(Ordering::Relaxed) as f64,
+    );
+
+    render_string_counter(
+        &mut output,
+        "rustfs_operator_sts_requests_total",
+        "Total number of operator STS requests by result.",
+        "result",
+        &metrics().sts_requests_total,
+    );
+    render_string_duration_summary(
+        &mut output,
+        "rustfs_operator_sts_request_duration_seconds",
+        "Operator STS request duration by result.",
+        "result",
+        &metrics().sts_request_duration,
+    );
+
+    render_http_counter(&mut output);
+    render_http_duration_summary(&mut output);
+
+    render_string_counter(
+        &mut output,
+        "rustfs_operator_tenant_monitor_polls_total",
+        "Total number of tenant storage monitor polls by result.",
+        "result",
+        &metrics().tenant_monitor_polls_total,
+    );
+    render_string_duration_summary(
+        &mut output,
+        "rustfs_operator_tenant_monitor_poll_duration_seconds",
+        "Tenant storage monitor poll duration by result.",
+        "result",
+        &metrics().tenant_monitor_poll_duration,
+    );
+    render_tenant_storage(&mut output);
+
+    output
+}
+
+fn update_tenant_storage_snapshot(namespace: &str, tenant: &str, snapshot: TenantStorageSnapshot) {
+    let key = TenantKey {
+        namespace: namespace.to_string(),
+        tenant: tenant.to_string(),
+    };
+    let mut snapshots = metrics()
+        .tenant_storage
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    snapshots.insert(key, snapshot);
+}
+
+fn increment_string_counter(counters: &Mutex<BTreeMap<String, u64>>, label_value: &str) {
+    let mut counters = counters
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    *counters.entry(label_value.to_string()).or_default() += 1;
+}
+
+fn observe_string_duration(
+    summaries: &Mutex<BTreeMap<String, DurationSummary>>,
+    label_value: &str,
+    duration: Duration,
+) {
+    let mut summaries = summaries
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    summaries
+        .entry(label_value.to_string())
+        .or_default()
+        .observe(duration);
+}
+
+fn render_string_counter(
+    output: &mut String,
+    name: &str,
+    help: &str,
+    label_name: &str,
+    counters: &Mutex<BTreeMap<String, u64>>,
+) {
+    output.push_str(&format!("# HELP {name} {help}\n# TYPE {name} counter\n"));
+    let counters = counters
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    for (label_value, value) in counters.iter() {
+        output.push_str(&format!(
+            "{name}{{{}}} {}\n",
+            labels(&[(label_name, label_value)]),
+            value
+        ));
+    }
+}
+
+fn render_string_duration_summary(
+    output: &mut String,
+    name: &str,
+    help: &str,
+    label_name: &str,
+    summaries: &Mutex<BTreeMap<String, DurationSummary>>,
+) {
+    output.push_str(&format!("# HELP {name} {help}\n# TYPE {name} summary\n"));
+    let summaries = summaries
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    for (label_value, summary) in summaries.iter() {
+        let label = labels(&[(label_name, label_value)]);
+        output.push_str(&format!(
+            "{name}_count{{{label}}} {}\n{name}_sum{{{label}}} {:.6}\n",
+            summary.count, summary.sum_seconds
+        ));
+    }
+}
+
+fn render_gauge(output: &mut String, name: &str, help: &str, value: f64) {
+    output.push_str(&format!(
+        "# HELP {name} {help}\n# TYPE {name} gauge\n{name} {:.6}\n",
+        value
+    ));
+}
+
+fn render_http_counter(output: &mut String) {
+    let name = "rustfs_operator_http_requests_total";
+    output.push_str(&format!(
+        "# HELP {name} Total number of HTTP requests served by operator components.\n# TYPE {name} counter\n"
+    ));
+    let counters = metrics()
+        .http_requests_total
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    for (key, value) in counters.iter() {
+        output.push_str(&format!(
+            "{name}{{{}}} {}\n",
+            labels(&[
+                ("component", &key.component),
+                ("method", &key.method),
+                ("status", &key.status),
+            ]),
+            value
+        ));
+    }
+}
+
+fn render_http_duration_summary(output: &mut String) {
+    let name = "rustfs_operator_http_request_duration_seconds";
+    output.push_str(&format!(
+        "# HELP {name} HTTP request duration served by operator components.\n# TYPE {name} summary\n"
+    ));
+    let summaries = metrics()
+        .http_request_duration
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    for (key, summary) in summaries.iter() {
+        let label = labels(&[
+            ("component", &key.component),
+            ("method", &key.method),
+            ("status", &key.status),
+        ]);
+        output.push_str(&format!(
+            "{name}_count{{{label}}} {}\n{name}_sum{{{label}}} {:.6}\n",
+            summary.count, summary.sum_seconds
+        ));
+    }
+}
+
+fn render_tenant_storage(output: &mut String) {
+    let snapshots = metrics()
+        .tenant_storage
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    render_tenant_gauge_family(
+        output,
+        "rustfs_operator_tenant_storage_poll_success",
+        "Whether the last tenant storage poll succeeded.",
+        snapshots
+            .iter()
+            .map(|(key, snapshot)| (key, if snapshot.poll_success { 1.0 } else { 0.0 })),
+    );
+    render_tenant_gauge_family(
+        output,
+        "rustfs_operator_tenant_storage_last_poll_timestamp_seconds",
+        "Unix timestamp of the last tenant storage poll.",
+        snapshots
+            .iter()
+            .map(|(key, snapshot)| (key, snapshot.last_poll_timestamp_seconds as f64)),
+    );
+    render_tenant_gauge_family(
+        output,
+        "rustfs_operator_tenant_drives_online",
+        "Number of RustFS drives reported online for a tenant.",
+        snapshots
+            .iter()
+            .map(|(key, snapshot)| (key, snapshot.online_drives as f64)),
+    );
+    render_tenant_gauge_family(
+        output,
+        "rustfs_operator_tenant_drives_offline",
+        "Number of RustFS drives reported offline for a tenant.",
+        snapshots
+            .iter()
+            .map(|(key, snapshot)| (key, snapshot.offline_drives as f64)),
+    );
+    render_tenant_gauge_family(
+        output,
+        "rustfs_operator_tenant_drives_healing",
+        "Number of RustFS drives currently healing for a tenant.",
+        snapshots
+            .iter()
+            .map(|(key, snapshot)| (key, snapshot.healing_drives as f64)),
+    );
+    render_tenant_gauge_family(
+        output,
+        "rustfs_operator_tenant_raw_capacity_bytes",
+        "Raw RustFS capacity in bytes for a tenant.",
+        snapshots
+            .iter()
+            .map(|(key, snapshot)| (key, snapshot.raw_capacity_bytes as f64)),
+    );
+    render_tenant_gauge_family(
+        output,
+        "rustfs_operator_tenant_raw_used_bytes",
+        "Raw RustFS used capacity in bytes for a tenant.",
+        snapshots
+            .iter()
+            .map(|(key, snapshot)| (key, snapshot.raw_used_bytes as f64)),
+    );
+    render_tenant_gauge_family(
+        output,
+        "rustfs_operator_tenant_object_usage_bytes",
+        "Object usage in bytes reported by RustFS for a tenant.",
+        snapshots
+            .iter()
+            .map(|(key, snapshot)| (key, snapshot.object_usage_bytes as f64)),
+    );
+    render_tenant_gauge_family(
+        output,
+        "rustfs_operator_tenant_erasure_write_quorum_drives",
+        "Estimated write quorum drive count implied by RustFS erasure parity.",
+        snapshots
+            .iter()
+            .map(|(key, snapshot)| (key, snapshot.write_quorum_drives as f64)),
+    );
+    render_tenant_gauge_family(
+        output,
+        "rustfs_operator_tenant_storage_healthy",
+        "Whether tenant storage is online, not healing, and satisfies write quorum.",
+        snapshots
+            .iter()
+            .map(|(key, snapshot)| (key, if snapshot.healthy { 1.0 } else { 0.0 })),
+    );
+}
+
+fn render_tenant_gauge_family<'a>(
+    output: &mut String,
+    name: &str,
+    help: &str,
+    values: impl Iterator<Item = (&'a TenantKey, f64)>,
+) {
+    output.push_str(&format!("# HELP {name} {help}\n# TYPE {name} gauge\n"));
+    for (key, value) in values {
+        output.push_str(&format!(
+            "{name}{{{}}} {:.6}\n",
+            labels(&[("namespace", &key.namespace), ("tenant", &key.tenant)]),
+            value
+        ));
+    }
+}
+
+fn labels(pairs: &[(&str, &str)]) -> String {
+    pairs
+        .iter()
+        .map(|(key, value)| format!("{key}=\"{}\"", escape_label_value(value)))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn escape_label_value(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('\n', "\\n")
+        .replace('"', "\\\"")
+}
+
+fn status_class(status: StatusCode) -> &'static str {
+    match status.as_u16() {
+        100..=199 => "1xx",
+        200..=299 => "2xx",
+        300..=399 => "3xx",
+        400..=499 => "4xx",
+        500..=599 => "5xx",
+        _ => "unknown",
+    }
+}
+
+fn result_label(success: bool) -> &'static str {
+    if success { "success" } else { "error" }
+}
+
+fn unix_timestamp_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn labels_escape_prometheus_special_characters() {
+        assert_eq!(
+            labels(&[("tenant", "a\"b\\c\nd")]),
+            "tenant=\"a\\\"b\\\\c\\nd\""
+        );
+    }
+
+    #[test]
+    fn status_class_groups_http_codes() {
+        assert_eq!(status_class(StatusCode::OK), "2xx");
+        assert_eq!(status_class(StatusCode::NOT_FOUND), "4xx");
+        assert_eq!(status_class(StatusCode::INTERNAL_SERVER_ERROR), "5xx");
+    }
+
+    #[test]
+    fn prune_tenant_storage_removes_absent_snapshots() {
+        let active = "prune-active";
+        let stale = "prune-stale";
+        let namespace = "prune-namespace";
+
+        record_tenant_storage(
+            namespace,
+            active,
+            TenantStorageMetrics {
+                online_drives: 4,
+                healthy: true,
+                ..Default::default()
+            },
+        );
+        record_tenant_storage(
+            namespace,
+            stale,
+            TenantStorageMetrics {
+                online_drives: 4,
+                healthy: true,
+                ..Default::default()
+            },
+        );
+
+        prune_tenant_storage(&[(namespace.to_string(), active.to_string())]);
+
+        let rendered = render();
+        assert!(rendered.contains("tenant=\"prune-active\""));
+        assert!(!rendered.contains("tenant=\"prune-stale\""));
+    }
+}

--- a/src/reconcile.rs
+++ b/src/reconcile.rs
@@ -511,6 +511,11 @@ fn is_node_down(node: &corev1::Node) -> bool {
     false
 }
 
+fn requeue_after(duration: Duration) -> Action {
+    crate::metrics::record_reconcile_requeue(duration);
+    Action::requeue(duration)
+}
+
 pub fn error_policy(_object: Arc<Tenant>, error: &Error, _ctx: Arc<Context>) -> Action {
     error!("error_policy: {:?}", error);
 
@@ -532,16 +537,16 @@ pub fn error_policy(_object: Arc<Tenant>, error: &Error, _ctx: Arc<Context>) -> 
             | context::Error::CredentialSecretTooShort { .. }
             | context::Error::KmsSecretNotFound { .. }
             | context::Error::KmsSecretMissingKey { .. }
-            | context::Error::KmsConfigInvalid { .. } => Action::requeue(Duration::from_secs(60)),
+            | context::Error::KmsConfigInvalid { .. } => requeue_after(Duration::from_secs(60)),
 
             // Kubernetes API errors - might be transient (network, API server issues)
             // Use shorter requeue for faster recovery
             context::Error::Kube { .. } | context::Error::Record { .. } => {
-                Action::requeue(Duration::from_secs(5))
+                requeue_after(Duration::from_secs(5))
             }
 
             // Other context errors - use moderate requeue
-            _ => Action::requeue(Duration::from_secs(15)),
+            _ => requeue_after(Duration::from_secs(15)),
         },
 
         // Type errors - validation issues, use moderate requeue
@@ -551,15 +556,15 @@ pub fn error_policy(_object: Arc<Tenant>, error: &Error, _ctx: Arc<Context>) -> 
             types::error::Error::ImmutableFieldModified { .. }
             | types::error::Error::InvalidTenantName { .. }
             | types::error::Error::PoolDeleteBlocked { .. } => {
-                Action::requeue(Duration::from_secs(60))
+                requeue_after(Duration::from_secs(60))
             }
 
             // Other type errors - use moderate requeue
-            _ => Action::requeue(Duration::from_secs(15)),
+            _ => requeue_after(Duration::from_secs(15)),
         },
 
-        Error::TlsBlocked { .. } => Action::requeue(Duration::from_secs(60)),
-        Error::TlsPending { .. } => Action::requeue(Duration::from_secs(20)),
+        Error::TlsBlocked { .. } => requeue_after(Duration::from_secs(60)),
+        Error::TlsPending { .. } => requeue_after(Duration::from_secs(20)),
     }
 }
 

--- a/src/sts/admin_ops.rs
+++ b/src/sts/admin_ops.rs
@@ -22,7 +22,7 @@ use super::helpers::{body_mentions_not_found, build_query_pairs, extract_canned_
 use super::{
     ADD_CANNED_POLICY_PATH, ADD_USER_PATH, ADMIN_SIGNING_SERVICE, INFO_CANNED_POLICY_PATH,
     JSON_CONTENT_TYPE, LIST_CANNED_POLICIES_PATH, RustfsAdminClient, RustfsClientError,
-    SET_POLICY_PATH, USER_INFO_PATH,
+    RustfsServerInfo, SERVER_INFO_PATH, SET_POLICY_PATH, USER_INFO_PATH,
 };
 use reqwest::StatusCode;
 use serde_json::Value;
@@ -135,6 +135,14 @@ impl RustfsAdminClient {
                     .map_err(|_| RustfsClientError::ParseResponseFailed)
             })
             .collect()
+    }
+
+    pub async fn server_info(&self) -> Result<RustfsServerInfo, RustfsClientError> {
+        let body = self
+            .send_admin_request("GET", SERVER_INFO_PATH, "", "", None)
+            .await?;
+        serde_json::from_str::<RustfsServerInfo>(&body)
+            .map_err(|_| RustfsClientError::ParseResponseFailed)
     }
 
     pub async fn user_exists(&self, access_key: &str) -> Result<bool, RustfsClientError> {

--- a/src/sts/rustfs_client.rs
+++ b/src/sts/rustfs_client.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::time::Duration;
+use std::{collections::BTreeMap, time::Duration};
 
 use k8s_openapi::api::core::v1 as corev1;
 use kube::{Api, Client};
@@ -48,6 +48,7 @@ const SET_POLICY_PATH: &str = "/rustfs/admin/v3/set-policy";
 const LIST_CANNED_POLICIES_PATH: &str = "/rustfs/admin/v3/list-canned-policies";
 const ADD_CANNED_POLICY_PATH: &str = "/rustfs/admin/v3/add-canned-policy";
 const INFO_CANNED_POLICY_PATH: &str = "/rustfs/admin/v3/info-canned-policy";
+const SERVER_INFO_PATH: &str = "/rustfs/admin/v3/info";
 const POOLS_LIST_PATH: &str = "/rustfs/admin/v3/pools/list";
 const POOLS_STATUS_PATH: &str = "/rustfs/admin/v3/pools/status";
 const POOLS_DECOMMISSION_PATH: &str = "/rustfs/admin/v3/pools/decommission";
@@ -121,6 +122,50 @@ pub struct RustfsPoolDecommissionInfo {
     pub bytes_decommissioned: Option<u64>,
     #[serde(rename = "bytesDecommissionedFailed")]
     pub bytes_decommissioned_failed: Option<u64>,
+}
+
+#[derive(Debug, Clone, Default, serde::Deserialize, PartialEq)]
+pub struct RustfsServerInfo {
+    #[serde(default)]
+    pub usage: Option<RustfsServerUsage>,
+    #[serde(default)]
+    pub backend: Option<RustfsErasureBackend>,
+    #[serde(default)]
+    pub pools: Option<BTreeMap<String, BTreeMap<String, RustfsErasureSetInfo>>>,
+}
+
+#[derive(Debug, Clone, Default, serde::Deserialize, PartialEq)]
+pub struct RustfsServerUsage {
+    #[serde(default)]
+    pub size: u64,
+}
+
+#[derive(Debug, Clone, Default, serde::Deserialize, PartialEq)]
+pub struct RustfsErasureBackend {
+    #[serde(default, rename = "onlineDisks")]
+    pub online_disks: u64,
+    #[serde(default, rename = "offlineDisks")]
+    pub offline_disks: u64,
+    #[serde(default, rename = "standardSCParity", alias = "StandardSCParity")]
+    pub standard_sc_parity: Option<u64>,
+    #[serde(default, rename = "totalSets")]
+    pub total_sets: Vec<u64>,
+    #[serde(default, rename = "totalDrivesPerSet", alias = "drivesPerSet")]
+    pub drives_per_set: Vec<u64>,
+}
+
+#[derive(Debug, Clone, Default, serde::Deserialize, PartialEq)]
+pub struct RustfsErasureSetInfo {
+    #[serde(default, rename = "rawUsage")]
+    pub raw_usage: u64,
+    #[serde(default, rename = "rawCapacity")]
+    pub raw_capacity: u64,
+    #[serde(default)]
+    pub usage: u64,
+    #[serde(default, rename = "objectsCount")]
+    pub objects_count: u64,
+    #[serde(default, rename = "healDisks")]
+    pub heal_disks: u64,
 }
 
 /// Error type for RustFS admin/STS client operations.

--- a/src/sts/server.rs
+++ b/src/sts/server.rs
@@ -22,6 +22,7 @@ use axum::{
 };
 use k8s_openapi::api::authentication::v1::{TokenReview, TokenReviewSpec};
 use kube::{Api, Client, api::ListParams};
+use std::time::Instant;
 
 use crate::console::state::AppState;
 use crate::sts::binding;
@@ -51,7 +52,10 @@ async fn assume_role_with_web_identity_for_tenant(
     Path((tenant_namespace, tenant_name)): Path<(String, String)>,
     Form(form): Form<AssumeRoleWithWebIdentityForm>,
 ) -> Response {
-    assume_role_with_web_identity(state, tenant_namespace, tenant_name, form).await
+    let started = Instant::now();
+    let response = assume_role_with_web_identity(state, tenant_namespace, tenant_name, form).await;
+    crate::metrics::record_sts_request(response.status().is_success(), started.elapsed());
+    response
 }
 
 async fn assume_role_with_web_identity(

--- a/src/sts/tests.rs
+++ b/src/sts/tests.rs
@@ -28,7 +28,7 @@ use tokio::sync::Mutex;
 
 use super::{
     ADD_USER_PATH, CreateBucketResult, POOLS_DECOMMISSION_PATH, POOLS_LIST_PATH, POOLS_STATUS_PATH,
-    RustfsAdminClient, RustfsClientError, SET_POLICY_PATH,
+    RustfsAdminClient, RustfsClientError, SERVER_INFO_PATH, SET_POLICY_PATH,
     helpers::{extract_canned_policy_document, extract_credentials, parse_assume_role_response},
 };
 
@@ -302,6 +302,84 @@ async fn add_canned_policy_uses_expected_path_query_body_and_admin_signing() {
     );
     assert!(capture.query.lock().await.contains("name=tenant-policy"));
     assert_eq!(&*capture.body.lock().await, policy);
+    assert!(
+        capture
+            .authorization
+            .lock()
+            .await
+            .contains("/s3/aws4_request")
+    );
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn server_info_uses_expected_path_and_parses_health_fields() {
+    let capture = Capture::default();
+    let route_capture = capture.clone();
+
+    let router = Router::new()
+        .route(
+            SERVER_INFO_PATH,
+            get(
+                move |State(c): State<Capture>, req: Request<Body>| async move {
+                    let path = req.uri().path().to_string();
+                    let authorization = req
+                        .headers()
+                        .get("authorization")
+                        .and_then(|value| value.to_str().ok())
+                        .unwrap_or("")
+                        .to_string();
+
+                    *c.path.lock().await = path;
+                    *c.authorization.lock().await = authorization;
+
+                    (
+                        StatusCode::OK,
+                        serde_json::json!({
+                            "usage": {"size": 42},
+                            "backend": {
+                                "onlineDisks": 3,
+                                "offlineDisks": 1,
+                                "standardSCParity": 2,
+                                "totalSets": [1],
+                                "totalDrivesPerSet": [4]
+                            },
+                            "pools": {
+                                "0": {
+                                    "0": {
+                                        "rawUsage": 100,
+                                        "rawCapacity": 400,
+                                        "usage": 50,
+                                        "objectsCount": 2,
+                                        "healDisks": 1
+                                    }
+                                }
+                            }
+                        })
+                        .to_string(),
+                    )
+                },
+            ),
+        )
+        .with_state(route_capture.clone());
+
+    let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+        .await
+        .unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
+
+    let client = RustfsAdminClient::new_with_base_url(format!("http://{addr}"), "access", "secret");
+    let info = client.server_info().await.unwrap();
+
+    let backend = info.backend.unwrap();
+    assert_eq!(backend.online_disks, 3);
+    assert_eq!(backend.offline_disks, 1);
+    assert_eq!(backend.standard_sc_parity, Some(2));
+    assert_eq!(info.usage.unwrap().size, 42);
+    assert_eq!(info.pools.unwrap()["0"]["0"].raw_capacity, 400);
+    assert_eq!(&*capture.path.lock().await, SERVER_INFO_PATH);
     assert!(
         capture
             .authorization

--- a/src/tenant_monitor.rs
+++ b/src/tenant_monitor.rs
@@ -1,0 +1,300 @@
+// Copyright 2025 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{
+    metrics::{self, TenantStorageMetrics},
+    sts::rustfs_client::{RustfsAdminClient, RustfsServerInfo},
+    types::v1alpha1::tenant::Tenant,
+};
+use futures::{StreamExt, stream};
+use kube::{Api, Client, api::ListParams};
+use std::time::{Duration, Instant};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+
+const DEFAULT_MONITOR_INTERVAL: Duration = Duration::from_secs(300);
+const MAX_CONCURRENT_TENANT_POLLS: usize = 4;
+const TENANT_LIST_PAGE_SIZE: u32 = 500;
+
+pub fn is_enabled() -> bool {
+    env_bool("OPERATOR_TENANT_MONITOR_ENABLED", true)
+}
+
+pub fn interval() -> Duration {
+    match std::env::var("OPERATOR_TENANT_MONITOR_INTERVAL_SECONDS") {
+        Ok(value) => match value.trim().parse::<u64>() {
+            Ok(seconds) if seconds > 0 => Duration::from_secs(seconds),
+            Ok(_) | Err(_) => {
+                warn!(
+                    value,
+                    "invalid OPERATOR_TENANT_MONITOR_INTERVAL_SECONDS value, using default"
+                );
+                DEFAULT_MONITOR_INTERVAL
+            }
+        },
+        Err(_) => DEFAULT_MONITOR_INTERVAL,
+    }
+}
+
+pub async fn run(client: Client, cancel: CancellationToken) {
+    let interval = interval();
+    info!(
+        interval_seconds = interval.as_secs(),
+        "tenant storage monitor started"
+    );
+
+    loop {
+        poll_all_tenants(client.clone()).await;
+
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                info!("tenant storage monitor cancellation requested");
+                break;
+            }
+            _ = tokio::time::sleep(interval) => {}
+        }
+    }
+}
+
+async fn poll_all_tenants(client: Client) {
+    let started = Instant::now();
+    let tenants = match list_all_tenants(client.clone()).await {
+        Ok(tenants) => tenants,
+        Err(error) => {
+            warn!(%error, "tenant storage monitor failed listing tenants");
+            metrics::record_tenant_monitor_poll("error", started.elapsed());
+            return;
+        }
+    };
+    let active_tenants = tenants
+        .iter()
+        .filter_map(|tenant| {
+            tenant
+                .namespace()
+                .ok()
+                .map(|namespace| (namespace, tenant.name()))
+        })
+        .collect::<Vec<_>>();
+    metrics::prune_tenant_storage(&active_tenants);
+
+    stream::iter(tenants)
+        .for_each_concurrent(MAX_CONCURRENT_TENANT_POLLS, |tenant| {
+            let client = client.clone();
+            async move {
+                poll_tenant(client, tenant).await;
+            }
+        })
+        .await;
+}
+
+async fn poll_tenant(client: Client, tenant: Tenant) {
+    let started = Instant::now();
+    let tenant_name = tenant.name();
+    let namespace = match tenant.namespace() {
+        Ok(namespace) => namespace,
+        Err(error) => {
+            warn!(tenant = %tenant_name, %error, "tenant storage monitor skipped tenant without namespace");
+            metrics::record_tenant_monitor_poll("skipped", started.elapsed());
+            return;
+        }
+    };
+
+    if tenant.spec.creds_secret.is_none() {
+        debug!(
+            namespace = %namespace,
+            tenant = %tenant_name,
+            "tenant storage monitor skipped tenant without credsSecret"
+        );
+        metrics::record_tenant_monitor_skipped(&namespace, &tenant_name, started.elapsed());
+        return;
+    }
+
+    match poll_tenant_storage(&client, &tenant).await {
+        Ok(storage) => {
+            metrics::record_tenant_storage(&namespace, &tenant_name, storage);
+            metrics::record_tenant_monitor_poll("success", started.elapsed());
+        }
+        Err(error) => {
+            warn!(
+                namespace = %namespace,
+                tenant = %tenant_name,
+                %error,
+                "tenant storage monitor poll failed"
+            );
+            metrics::record_tenant_storage_error(&namespace, &tenant_name);
+            metrics::record_tenant_monitor_poll("error", started.elapsed());
+        }
+    }
+}
+
+async fn list_all_tenants(client: Client) -> Result<Vec<Tenant>, kube::Error> {
+    let tenants_api = Api::<Tenant>::all(client);
+    let mut tenants = Vec::new();
+    let mut continue_token = None;
+
+    loop {
+        let mut params = ListParams::default().limit(TENANT_LIST_PAGE_SIZE);
+        if let Some(token) = continue_token.as_deref() {
+            params = params.continue_token(token);
+        }
+        let page = tenants_api.list(&params).await?;
+        tenants.extend(page.items);
+
+        continue_token = page
+            .metadata
+            .continue_
+            .filter(|token| !token.trim().is_empty());
+        if continue_token.is_none() {
+            return Ok(tenants);
+        }
+    }
+}
+
+async fn poll_tenant_storage(
+    client: &Client,
+    tenant: &Tenant,
+) -> Result<TenantStorageMetrics, Box<dyn std::error::Error + Send + Sync>> {
+    let credentials = RustfsAdminClient::load_tenant_credentials(client, tenant).await?;
+    let rustfs_client = if tenant.spec.tls.as_ref().is_some_and(|tls| tls.is_enabled()) {
+        RustfsAdminClient::from_tls_tenant_for_sts(client, tenant, credentials).await?
+    } else {
+        RustfsAdminClient::from_tenant(tenant, credentials)?
+    };
+    let info = rustfs_client.server_info().await?;
+
+    Ok(storage_metrics_from_info(&info))
+}
+
+fn storage_metrics_from_info(info: &RustfsServerInfo) -> TenantStorageMetrics {
+    let (online_drives, offline_drives, write_quorum_drives) = info
+        .backend
+        .as_ref()
+        .map(|backend| {
+            (
+                backend.online_disks,
+                backend.offline_disks,
+                write_quorum_from_backend(backend),
+            )
+        })
+        .unwrap_or_default();
+
+    let mut healing_drives = 0u64;
+    let mut raw_capacity_bytes = 0u64;
+    let mut raw_used_bytes = 0u64;
+    let mut pool_usage_bytes = 0u64;
+
+    if let Some(pools) = &info.pools {
+        for sets in pools.values() {
+            for set in sets.values() {
+                healing_drives = healing_drives.saturating_add(set.heal_disks);
+                raw_capacity_bytes = raw_capacity_bytes.saturating_add(set.raw_capacity);
+                raw_used_bytes = raw_used_bytes.saturating_add(set.raw_usage);
+                pool_usage_bytes = pool_usage_bytes.saturating_add(set.usage);
+            }
+        }
+    }
+
+    let object_usage_bytes = info
+        .usage
+        .as_ref()
+        .map(|usage| usage.size)
+        .unwrap_or(pool_usage_bytes);
+
+    TenantStorageMetrics {
+        online_drives,
+        offline_drives,
+        healing_drives,
+        raw_capacity_bytes,
+        raw_used_bytes,
+        object_usage_bytes,
+        write_quorum_drives,
+        healthy: online_drives > 0
+            && offline_drives == 0
+            && healing_drives == 0
+            && (write_quorum_drives == 0 || online_drives >= write_quorum_drives),
+    }
+}
+
+fn write_quorum_from_backend(backend: &crate::sts::rustfs_client::RustfsErasureBackend) -> u64 {
+    let parity = backend.standard_sc_parity.unwrap_or_default();
+    backend
+        .total_sets
+        .iter()
+        .zip(backend.drives_per_set.iter())
+        .map(|(sets, drives_per_set)| sets.saturating_mul(drives_per_set.saturating_sub(parity)))
+        .sum()
+}
+
+fn env_bool(name: &str, default: bool) -> bool {
+    match std::env::var(name) {
+        Ok(value) => match value.trim().to_ascii_lowercase().as_str() {
+            "1" | "true" | "yes" | "on" => true,
+            "0" | "false" | "no" | "off" => false,
+            _ => {
+                warn!(name, value, "invalid boolean env value, using default");
+                default
+            }
+        },
+        Err(_) => default,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sts::rustfs_client::{
+        RustfsErasureBackend, RustfsErasureSetInfo, RustfsServerUsage,
+    };
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn storage_metrics_capture_capacity_healing_and_quorum() {
+        let mut sets = BTreeMap::new();
+        sets.insert(
+            "0".to_string(),
+            RustfsErasureSetInfo {
+                raw_usage: 100,
+                raw_capacity: 400,
+                usage: 70,
+                heal_disks: 1,
+                ..Default::default()
+            },
+        );
+        let mut pools = BTreeMap::new();
+        pools.insert("0".to_string(), sets);
+
+        let info = RustfsServerInfo {
+            usage: Some(RustfsServerUsage { size: 80 }),
+            backend: Some(RustfsErasureBackend {
+                online_disks: 3,
+                offline_disks: 1,
+                standard_sc_parity: Some(2),
+                total_sets: vec![1],
+                drives_per_set: vec![4],
+            }),
+            pools: Some(pools),
+        };
+
+        let metrics = storage_metrics_from_info(&info);
+
+        assert_eq!(metrics.online_drives, 3);
+        assert_eq!(metrics.offline_drives, 1);
+        assert_eq!(metrics.healing_drives, 1);
+        assert_eq!(metrics.raw_capacity_bytes, 400);
+        assert_eq!(metrics.raw_used_bytes, 100);
+        assert_eq!(metrics.object_usage_bytes, 80);
+        assert_eq!(metrics.write_quorum_drives, 2);
+        assert!(!metrics.healthy);
+    }
+}


### PR DESCRIPTION
## Type of Change
- [x] New Feature
- [ ] Bug Fix
- [x] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
N/A

## Summary of Changes
Adds production-oriented monitoring for RustFS Operator and Console, aligned with MinIO Operator-style storage health visibility.

- Adds Prometheus text exposition for reconcile count, duration, errors, requeues, in-flight work, leader state, STS requests, HTTP requests, and tenant storage health.
- Adds an operator observability server with `/metrics`, `/healthz`, and a real Kubernetes control-plane `/readyz` check.
- Adds tenant storage health polling through RustFS admin `/rustfs/admin/v3/info`, including online/offline/healing drives, raw capacity/usage, object usage, write quorum, and health gauges.
- Adds Console `/metrics` and initializes tracing for the Console server path.
- Adds Helm values, metrics Service, optional ServiceMonitor resources, optional PrometheusRule alerts, and dev metrics Service manifests.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit` (fmt-check + clippy + test + console-lint + console-fmt-check)
- [x] Added/updated necessary tests
- [x] Documentation updated (if needed)
- [x] CHANGELOG.md updated under `[Unreleased]` (N/A: this repository does not currently include `CHANGELOG.md`)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (CRD/API compatibility)
- [x] Requires doc/config/deployment update
- [x] Other impact: exposes new operator metrics port `8080` by default and optional Prometheus Operator resources.

## Verification
```bash
cargo check
cargo test
make pre-commit
```

## Additional Notes
- The controller queue metric is represented by `rustfs_operator_reconcile_inflight` and `rustfs_operator_reconcile_requeues_total`; kube-runtime does not expose internal queue depth through a stable public API.
- `helm template` was not run locally because `helm` is not installed in this environment.
