### PR TITLE
Fix Tenant CRD validation cost and e2e cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,3 +130,18 @@ jobs:
           pnpm run lint
           pnpm run build
           pnpm run format:check
+
+  docker-build:
+    name: Docker Build
+    needs: skip-check
+    if: needs.skip-check.outputs.should_skip != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Build unified operator image
+        env:
+          DOCKER_BUILDKIT: 1
+        run: docker build -t rustfs/operator:ci .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
   docker-build:
     name: Docker Build
     needs: skip-check
-    if: needs.skip-check.outputs.should_skip != 'true'
+    if: github.event_name != 'pull_request' && needs.skip-check.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -987,6 +987,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2735,8 +2741,13 @@ dependencies = [
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
  "iri-string",
  "mime",
+ "mime_guess",
+ "percent-encoding",
  "pin-project-lite",
  "tokio",
  "tokio-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ axum = { version = "0.7", features = ["macros", "json"] }
 hyper = "1"
 hyper-util = { version = "0.1", features = ["server-auto", "service", "tokio"] }
 tower = "0.5"
-tower-http = { version = "0.6", features = ["cors", "trace", "compression-gzip"] }
+tower-http = { version = "0.6", features = ["cors", "trace", "compression-gzip", "fs"] }
 http = "1.2"
 utoipa = { version = "5", features = ["chrono"] }
 utoipa-swagger-ui = { version = "8", features = ["axum", "vendored"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,12 @@ ARG BASE_IMAGE=debian:bookworm-slim
 # Use rust:bookworm so the binary is linked against glibc 2.36, matching final image.
 ARG RUST_BUILD_IMAGE=rust:bookworm
 
+# Build image for the static Console frontend.
+ARG NODE_BUILD_IMAGE=node:24-alpine
+
 # cargo-chef version (pin for reproducible builds; override if needed)
 ARG CARGO_CHEF_VERSION=0.1.77
+ARG PNPM_VERSION=10.28.1
 
 # When Docker build cannot reach crates.io (DNS/network), try:
 #   docker build --network=host -t rustfs/operator:dev .
@@ -51,9 +55,22 @@ COPY --from=cacher /app/target target
 COPY --from=cacher /usr/local/cargo /usr/local/cargo
 RUN cargo build --release
 
+# Stage 4: Build the static Console frontend
+FROM ${NODE_BUILD_IMAGE} AS console-web-builder
+ARG PNPM_VERSION
+WORKDIR /app/console-web
+RUN npm install -g pnpm@${PNPM_VERSION}
+COPY console-web/package.json console-web/pnpm-lock.yaml console-web/pnpm-workspace.yaml ./
+RUN pnpm install --frozen-lockfile
+COPY console-web/ ./
+ARG NEXT_PUBLIC_API_BASE_URL=
+ENV NEXT_PUBLIC_API_BASE_URL=${NEXT_PUBLIC_API_BASE_URL}
+RUN pnpm build
+
 # Final image
 FROM ${BASE_IMAGE}
 
 WORKDIR /app
 COPY --from=builder /app/target/release/operator .
+COPY --from=console-web-builder /app/console-web/out ./console-web
 ENTRYPOINT ["./operator"]

--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,9 @@ help:
 	@echo "  make clippy           - Run clippy checks"
 	@echo "  make test             - Run Rust tests"
 	@echo "  make build            - Build the project"
-	@echo "  make docker-build-operator  - Build the operator image (IMAGE_REPO?=rustfs/operator IMAGE_TAG?=dev)"
-	@echo "  make docker-build-console-web - Build the console-web frontend image (CONSOLE_WEB_IMAGE_REPO?=rustfs/console-web CONSOLE_WEB_IMAGE_TAG?=dev)"
-	@echo "  make docker-build-all       - Build both operator and console-web images"
+	@echo "  make docker-build-operator  - Build the unified operator + console image (IMAGE_REPO?=rustfs/operator IMAGE_TAG?=dev)"
+	@echo "  make docker-build-console-web - Build the legacy split console-web image (CONSOLE_WEB_IMAGE_REPO?=rustfs/console-web CONSOLE_WEB_IMAGE_TAG?=dev)"
+	@echo "  make docker-build-all       - Build both unified operator and legacy console-web images"
 	@echo "  make console-lint     - Run frontend ESLint checks (console-web)"
 	@echo "  make console-build    - Build frontend static assets (console-web)"
 	@echo "  make console-fmt     - Format frontend code with Prettier (console-web)"
@@ -144,8 +144,9 @@ e2e-live-delete:
 	$(E2E_LIVE_ENV) $(E2E_BIN) kind-delete
 
 
-# Build Docker images. The operator image includes the controller and Console API;
-# the console-web image contains the frontend static assets.
+# Build Docker images. The operator image includes the controller, Console API,
+# and embedded console-web static assets. The console-web image is retained for
+# legacy split frontend deployments.
 docker-build-operator:
 	docker build -t $(IMAGE_REPO):$(IMAGE_TAG) .
 

--- a/console-web/README.md
+++ b/console-web/README.md
@@ -33,17 +33,17 @@ Static output is in `out/`. The default API base URL is **`/api/v1`** (relative)
 
 ## Deployment (Kubernetes)
 
-When frontend and backend are deployed in the same cluster and exposed under **one host** (recommended):
+The default `rustfs/operator` image embeds this static frontend and the Rust
+Console API. Enable the Console and Ingress in the Helm chart; the Console
+service serves both `/` and `/api/v1` from one pod.
 
-1. Build the Docker image (from repo root):
+Do **not** set `NEXT_PUBLIC_API_BASE_URL` (or set it to `/api/v1`). The browser
+will send requests to the same origin, so cookies and CORS work without extra
+config. Production deployments should serve the host over HTTPS because Console
+session cookies are `Secure` by default.
 
-   ```bash
-   docker build -t your-registry/console-web:latest console-web/
-   ```
-
-2. Enable the console frontend in the Helm chart and Ingress (see [deploy/rustfs-operator/README.md](../deploy/rustfs-operator/README.md#console-ui-frontend--backend-in-k8s)). The Ingress will serve `/` from this app and `/api` from the backend.
-
-3. Do **not** set `NEXT_PUBLIC_API_BASE_URL` (or set it to `/api/v1`). The browser will send requests to the same origin, so cookies and CORS work without extra config. Production deployments should serve the host over HTTPS because Console session cookies are `Secure` by default.
+The standalone `console-web/Dockerfile` remains available for legacy split
+frontend deployments that intentionally use a separate frontend image.
 
 If the frontend is served from a **different host** than the API, set at build time:
 

--- a/console-web/app/(dashboard)/tenants/new/page.tsx
+++ b/console-web/app/(dashboard)/tenants/new/page.tsx
@@ -27,6 +27,8 @@ import { ApiError } from "@/lib/api-client"
 
 type CreateMode = "form" | "yaml"
 
+const DEFAULT_RUSTFS_IMAGE = "rustfs/rustfs:latest"
+
 const defaultPool: CreatePoolRequest = {
   name: "pool-0",
   servers: 2,
@@ -41,7 +43,7 @@ metadata:
   name: my-tenant
   namespace: default
 spec:
-  image: rustfs/rustfs:latest
+  image: ${DEFAULT_RUSTFS_IMAGE}
   credsSecret:
     name: rustfs-creds
   pools:
@@ -95,7 +97,7 @@ export default function TenantCreatePage() {
   const [name, setName] = useState("")
   const [namespace, setNamespace] = useState("default")
   const [pools, setPools] = useState<CreatePoolRequest[]>([{ ...defaultPool }])
-  const [image, setImage] = useState("")
+  const [image, setImage] = useState(DEFAULT_RUSTFS_IMAGE)
   const [credsSecret, setCredsSecret] = useState("")
   const [securityContext, setSecurityContext] = useState({
     runAsUser: "",
@@ -300,6 +302,11 @@ export default function TenantCreatePage() {
           toast.warning(t("Namespace is required"))
           return
         }
+        const trimmedImage = image.trim()
+        if (!trimmedImage) {
+          toast.warning(t("Image is required"))
+          return
+        }
         requestBody = {
           name: name.trim(),
           namespace: namespace.trim(),
@@ -307,7 +314,7 @@ export default function TenantCreatePage() {
             ...p,
             storage_class: p.storage_class || undefined,
           })),
-          image: image.trim() || undefined,
+          image: trimmedImage,
           creds_secret: credsSecret.trim() || undefined,
           security_context: {
             runAsUser: securityContext.runAsUser ? parseInt(securityContext.runAsUser, 10) : undefined,
@@ -388,11 +395,10 @@ export default function TenantCreatePage() {
                   </div>
                 </div>
                 <div className="space-y-2">
-                  <Label htmlFor="image">
-                    {t("Image")} ({t("Optional")})
-                  </Label>
+                  <Label htmlFor="image">{t("Image")}</Label>
                   <Input
                     id="image"
+                    required
                     value={image}
                     onChange={(e) => setImage(e.target.value)}
                     placeholder="rustfs/rustfs:latest"

--- a/console-web/i18n/locales/en-US.json
+++ b/console-web/i18n/locales/en-US.json
@@ -146,6 +146,7 @@
   "YAML bucket provisioning fields are invalid": "YAML bucket provisioning fields are invalid",
   "Tenant name is required": "Tenant name is required",
   "Namespace is required": "Namespace is required",
+  "Image is required": "Image is required",
   "Delete tenant \"{{name}}\"? This cannot be undone.": "Delete tenant \"{{name}}\"? This cannot be undone.",
   "Overview": "Overview",
   "Events": "Events",

--- a/console-web/i18n/locales/zh-CN.json
+++ b/console-web/i18n/locales/zh-CN.json
@@ -146,6 +146,7 @@
   "YAML bucket provisioning fields are invalid": "YAML 中 bucket provisioning 字段不合法",
   "Tenant name is required": "请输入租户名称",
   "Namespace is required": "请输入命名空间",
+  "Image is required": "请输入镜像名称",
   "Delete tenant \"{{name}}\"? This cannot be undone.": "确定删除租户「{{name}}」？此操作不可恢复。",
   "Overview": "概览",
   "Events": "事件",

--- a/deploy/rustfs-operator/README.md
+++ b/deploy/rustfs-operator/README.md
@@ -288,40 +288,34 @@ To upgrade the operator:
 helm upgrade rustfs-operator deploy/rustfs-operator/
 ```
 
-## Console UI (Frontend + Backend in K8s)
+## Console UI
 
-The console has a **backend** (Rust API, `/api/v1/*`) and an optional **frontend** (static web app, `console-web`). To have the browser reach the API correctly when both run in Kubernetes:
+The published `rustfs/operator` image contains both the Console backend (Rust API,
+`/api/v1/*`) and the exported `console-web` static frontend. By default the chart
+deploys one Console service that serves both `/` and `/api/v1` from the same pod,
+so browser requests are same-origin and do not need CORS.
 
 ### Same-origin deployment (recommended)
 
-Serve the frontend and the API under **one HTTPS host** so the browser sends requests to the same origin (no CORS, Secure cookies work):
+Serve the Console service under **one HTTPS host**:
 
-1. Enable the frontend and Ingress in `values.yaml`:
+1. Enable the Console and Ingress in `values.yaml`:
 
    ```yaml
    console:
      enabled: true
-     frontend:
-       enabled: true
-       image:
-         repository: your-registry/console-web
-         tag: latest
      ingress:
        enabled: true
        className: nginx
        hosts:
          - host: console.example.com
-           paths: []   # ignored when frontend.enabled; / and /api are used
    ```
 
-2. Build and push the frontend image from the repo root:
-
-   ```bash
-   docker build -t your-registry/console-web:latest console-web/
-   docker push your-registry/console-web:latest
-   ```
-
-3. Install/upgrade the chart. The Ingress will route **`/api`** to the console backend and **`/`** to the frontend. The frontend is built with `NEXT_PUBLIC_API_BASE_URL=/api/v1` (default), so all API calls are same-origin. If you intentionally test over plain HTTP, set `CONSOLE_COOKIE_SECURE=false` in `console.env`; do not use that setting for production.
+2. Install/upgrade the chart. The Ingress routes `/` and `/api/v1` to the Console
+   service. The embedded frontend is built with `NEXT_PUBLIC_API_BASE_URL=/api/v1`
+   by default. If you intentionally test over plain HTTP, set
+   `CONSOLE_COOKIE_SECURE=false` in `console.env`; do not use that setting for
+   production.
 
 No CORS configuration is needed on the backend for this setup.
 
@@ -348,6 +342,13 @@ console:
 ```
 
 Multiple origins (e.g. dev + prod): comma-separated, e.g. `"https://ui.example.com,http://localhost:3000"`.
+
+### Legacy Split Frontend
+
+`console.frontend.enabled=true` still deploys a separate `console-web` image for
+installations that intentionally keep frontend and backend images separate. In
+that mode the Ingress routes `/api` to the Console backend and `/` to the split
+frontend service.
 
 ### Console login token
 

--- a/deploy/rustfs-operator/crds/tenant-crd.yaml
+++ b/deploy/rustfs-operator/crds/tenant-crd.yaml
@@ -36,10 +36,13 @@ spec:
                       - Retain
                       type: string
                     name:
+                      maxLength: 63
+                      minLength: 3
+                      pattern: ^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$
                       type: string
                       x-kubernetes-validations:
                       - message: bucket name must be a valid RustFS/S3 bucket name
-                        rule: self.size() >= 3 && self.size() <= 63 && self != 'rustfs' && !self.matches('^(\\d+\\.){3}\\d+$') && !self.contains('..') && !self.contains('.-') && !self.contains('-.') && self.matches('^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$')
+                        rule: self != 'rustfs' && !self.matches('^(\\d+\\.){3}\\d+$') && !self.contains('..') && !self.contains('.-') && !self.contains('-.')
                     objectLock:
                       nullable: true
                       type: boolean
@@ -49,10 +52,11 @@ spec:
                   required:
                   - name
                   type: object
+                maxItems: 1024
                 type: array
-                x-kubernetes-validations:
-                - message: bucket names must be unique
-                  rule: self.all(x, self.filter(y, y.name == x.name).size() == 1)
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               createServiceAccountRbac:
                 nullable: true
                 type: boolean
@@ -461,15 +465,13 @@ spec:
                         configMapKeyRef:
                           properties:
                             key:
+                              maxLength: 253
+                              minLength: 1
                               type: string
-                              x-kubernetes-validations:
-                              - message: configMapKeyRef key must be not empty
-                                rule: self != ''
                             name:
+                              maxLength: 253
+                              minLength: 1
                               type: string
-                              x-kubernetes-validations:
-                              - message: configMapKeyRef name must be not empty
-                                rule: self != ''
                           required:
                           - key
                           - name
@@ -478,18 +480,19 @@ spec:
                       - configMapKeyRef
                       type: object
                     name:
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^\S+$
                       type: string
-                      x-kubernetes-validations:
-                      - message: policy name must be not empty and must not contain whitespace
-                        rule: self != '' && !self.matches('.*\\s.*')
                   required:
                   - document
                   - name
                   type: object
+                maxItems: 256
                 type: array
-                x-kubernetes-validations:
-                - message: policy names must be unique
-                  rule: self.all(x, self.filter(y, y.name == x.name).size() == 1)
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               poolLifecycle:
                 description: Explicit lifecycle requests for pool decommissioning.
                 nullable: true
@@ -506,11 +509,16 @@ spec:
                           nullable: true
                           type: string
                         poolName:
+                          maxLength: 63
+                          minLength: 1
                           type: string
                         reason:
+                          maxLength: 1024
                           nullable: true
                           type: string
                         requestId:
+                          maxLength: 128
+                          minLength: 1
                           type: string
                         requestedAt:
                           nullable: true
@@ -520,15 +528,16 @@ spec:
                       - poolName
                       - requestId
                       type: object
+                    maxItems: 32
                     type: array
+                    x-kubernetes-list-map-keys:
+                    - poolName
+                    x-kubernetes-list-type: map
                   pvcRetentionPolicy:
                     enum:
                     - Retain
                     type: string
                 type: object
-                x-kubernetes-validations:
-                - message: decommissionRequests must contain at most one entry per poolName
-                  rule: '!has(self.decommissionRequests) || self.decommissionRequests.all(r, self.decommissionRequests.exists_one(other, other.poolName == r.poolName))'
               pools:
                 items:
                   description: |-
@@ -1039,12 +1048,10 @@ spec:
                           type: object
                       type: object
                     name:
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
-                      x-kubernetes-validations:
-                      - message: pool name must be not empty
-                        rule: self != ''
-                      - message: 'pool name must be a valid RFC 1123 label: lowercase alphanumeric or ''-'', start and end with alphanumeric, max 63 characters'
-                        rule: self.size() <= 63 && self.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
                     nodeSelector:
                       additionalProperties:
                         type: string
@@ -1356,15 +1363,12 @@ spec:
                   - messageExpression: '"pool " + self.name + " with 3 servers must have at least 6 volumes in total"'
                     reason: FieldValueInvalid
                     rule: self.servers != 3 || self.servers * self.persistence.volumesPerServer >= 6
+                maxItems: 32
+                minItems: 1
                 type: array
                 x-kubernetes-list-map-keys:
                 - name
                 x-kubernetes-list-type: map
-                x-kubernetes-validations:
-                - message: pools must be configured
-                  rule: self.size() > 0
-                - message: pool names must be unique
-                  rule: self.all(x, self.filter(y, y.name == x.name).size() == 1)
               priorityClassName:
                 nullable: true
                 type: string
@@ -1541,27 +1545,30 @@ spec:
                       - Retain
                       type: string
                     name:
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^\S+$
                       type: string
-                      x-kubernetes-validations:
-                      - message: user Secret name must be not empty and must not contain whitespace
-                        rule: self != '' && !self.matches('.*\\s.*')
                     policies:
                       description: Canned policies to map directly to this user.
                       items:
+                        maxLength: 253
+                        minLength: 1
+                        pattern: ^\S+$
                         type: string
+                      maxItems: 64
+                      minItems: 1
                       type: array
-                      x-kubernetes-validations:
-                      - message: user policy names must be not empty and must not contain whitespace
-                        rule: self.all(x, x != '' && !x.matches('.*\\s.*'))
-                      - message: user policy names must be unique
-                        rule: self.all(x, self.filter(y, y == x).size() == 1)
+                      x-kubernetes-list-type: set
                   required:
                   - name
                   type: object
+                maxItems: 256
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
                 x-kubernetes-validations:
-                - message: user Secret names must be unique
-                  rule: self.all(x, self.filter(y, y.name == x.name).size() == 1)
                 - message: user policies must contain at least one policy
                   rule: self.all(x, has(x.policies) && x.policies.size() > 0)
             required:

--- a/deploy/rustfs-operator/crds/tenant.yaml
+++ b/deploy/rustfs-operator/crds/tenant.yaml
@@ -36,10 +36,13 @@ spec:
                       - Retain
                       type: string
                     name:
+                      maxLength: 63
+                      minLength: 3
+                      pattern: ^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$
                       type: string
                       x-kubernetes-validations:
                       - message: bucket name must be a valid RustFS/S3 bucket name
-                        rule: self.size() >= 3 && self.size() <= 63 && self != 'rustfs' && !self.matches('^(\\d+\\.){3}\\d+$') && !self.contains('..') && !self.contains('.-') && !self.contains('-.') && self.matches('^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$')
+                        rule: self != 'rustfs' && !self.matches('^(\\d+\\.){3}\\d+$') && !self.contains('..') && !self.contains('.-') && !self.contains('-.')
                     objectLock:
                       nullable: true
                       type: boolean
@@ -49,10 +52,11 @@ spec:
                   required:
                   - name
                   type: object
+                maxItems: 1024
                 type: array
-                x-kubernetes-validations:
-                - message: bucket names must be unique
-                  rule: self.all(x, self.filter(y, y.name == x.name).size() == 1)
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               createServiceAccountRbac:
                 nullable: true
                 type: boolean
@@ -461,15 +465,13 @@ spec:
                         configMapKeyRef:
                           properties:
                             key:
+                              maxLength: 253
+                              minLength: 1
                               type: string
-                              x-kubernetes-validations:
-                              - message: configMapKeyRef key must be not empty
-                                rule: self != ''
                             name:
+                              maxLength: 253
+                              minLength: 1
                               type: string
-                              x-kubernetes-validations:
-                              - message: configMapKeyRef name must be not empty
-                                rule: self != ''
                           required:
                           - key
                           - name
@@ -478,18 +480,19 @@ spec:
                       - configMapKeyRef
                       type: object
                     name:
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^\S+$
                       type: string
-                      x-kubernetes-validations:
-                      - message: policy name must be not empty and must not contain whitespace
-                        rule: self != '' && !self.matches('.*\\s.*')
                   required:
                   - document
                   - name
                   type: object
+                maxItems: 256
                 type: array
-                x-kubernetes-validations:
-                - message: policy names must be unique
-                  rule: self.all(x, self.filter(y, y.name == x.name).size() == 1)
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               poolLifecycle:
                 description: Explicit lifecycle requests for pool decommissioning.
                 nullable: true
@@ -506,11 +509,16 @@ spec:
                           nullable: true
                           type: string
                         poolName:
+                          maxLength: 63
+                          minLength: 1
                           type: string
                         reason:
+                          maxLength: 1024
                           nullable: true
                           type: string
                         requestId:
+                          maxLength: 128
+                          minLength: 1
                           type: string
                         requestedAt:
                           nullable: true
@@ -520,15 +528,16 @@ spec:
                       - poolName
                       - requestId
                       type: object
+                    maxItems: 32
                     type: array
+                    x-kubernetes-list-map-keys:
+                    - poolName
+                    x-kubernetes-list-type: map
                   pvcRetentionPolicy:
                     enum:
                     - Retain
                     type: string
                 type: object
-                x-kubernetes-validations:
-                - message: decommissionRequests must contain at most one entry per poolName
-                  rule: '!has(self.decommissionRequests) || self.decommissionRequests.all(r, self.decommissionRequests.exists_one(other, other.poolName == r.poolName))'
               pools:
                 items:
                   description: |-
@@ -1039,12 +1048,10 @@ spec:
                           type: object
                       type: object
                     name:
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
-                      x-kubernetes-validations:
-                      - message: pool name must be not empty
-                        rule: self != ''
-                      - message: 'pool name must be a valid RFC 1123 label: lowercase alphanumeric or ''-'', start and end with alphanumeric, max 63 characters'
-                        rule: self.size() <= 63 && self.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
                     nodeSelector:
                       additionalProperties:
                         type: string
@@ -1356,15 +1363,12 @@ spec:
                   - messageExpression: '"pool " + self.name + " with 3 servers must have at least 6 volumes in total"'
                     reason: FieldValueInvalid
                     rule: self.servers != 3 || self.servers * self.persistence.volumesPerServer >= 6
+                maxItems: 32
+                minItems: 1
                 type: array
                 x-kubernetes-list-map-keys:
                 - name
                 x-kubernetes-list-type: map
-                x-kubernetes-validations:
-                - message: pools must be configured
-                  rule: self.size() > 0
-                - message: pool names must be unique
-                  rule: self.all(x, self.filter(y, y.name == x.name).size() == 1)
               priorityClassName:
                 nullable: true
                 type: string
@@ -1541,27 +1545,30 @@ spec:
                       - Retain
                       type: string
                     name:
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^\S+$
                       type: string
-                      x-kubernetes-validations:
-                      - message: user Secret name must be not empty and must not contain whitespace
-                        rule: self != '' && !self.matches('.*\\s.*')
                     policies:
                       description: Canned policies to map directly to this user.
                       items:
+                        maxLength: 253
+                        minLength: 1
+                        pattern: ^\S+$
                         type: string
+                      maxItems: 64
+                      minItems: 1
                       type: array
-                      x-kubernetes-validations:
-                      - message: user policy names must be not empty and must not contain whitespace
-                        rule: self.all(x, x != '' && !x.matches('.*\\s.*'))
-                      - message: user policy names must be unique
-                        rule: self.all(x, self.filter(y, y == x).size() == 1)
+                      x-kubernetes-list-type: set
                   required:
                   - name
                   type: object
+                maxItems: 256
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
                 x-kubernetes-validations:
-                - message: user Secret names must be unique
-                  rule: self.all(x, self.filter(y, y.name == x.name).size() == 1)
                 - message: user policies must contain at least one policy
                   rule: self.all(x, has(x.policies) && x.policies.size() > 0)
             required:

--- a/deploy/rustfs-operator/templates/console-ingress.yaml
+++ b/deploy/rustfs-operator/templates/console-ingress.yaml
@@ -31,7 +31,7 @@ spec:
       http:
         paths:
           {{- if $.Values.console.frontend.enabled }}
-          # API first so /api/v1/* goes to backend (same-origin for browser)
+          # Legacy split frontend mode: API first so /api/v1/* goes to backend.
           - path: /api
             pathType: Prefix
             backend:
@@ -39,7 +39,7 @@ spec:
                 name: {{ include "rustfs-operator.fullname" $ }}-console
                 port:
                   number: {{ $.Values.console.service.port }}
-          # Frontend serves UI at /
+          # Legacy split frontend service serves UI at /.
           - path: /
             pathType: Prefix
             backend:
@@ -48,6 +48,7 @@ spec:
                 port:
                   number: {{ $.Values.console.frontend.service.port }}
           {{- else }}
+          # Unified console mode: the Console service serves both UI and API.
           - path: /
             pathType: Prefix
             backend:

--- a/deploy/rustfs-operator/values.yaml
+++ b/deploy/rustfs-operator/values.yaml
@@ -238,7 +238,9 @@ console:
     # Specifies whether RBAC resources should be created
     create: true
 
-  # Frontend (console-web) deployment. When enabled, Ingress serves / from frontend and /api from backend (same host = same-origin, no CORS).
+  # Legacy split frontend deployment. The default operator image already embeds
+  # console-web static files, so the Console service serves both / and /api/v1.
+  # Enable this only when you intentionally deploy a separate frontend image.
   frontend:
     enabled: false
     replicas: 1
@@ -266,7 +268,9 @@ console:
     service:
       port: 80
 
-  # Ingress configuration. When frontend.enabled is true, / is served by frontend and /api by backend (same origin).
+  # Ingress configuration. By default, / and /api/v1 are served by the Console
+  # service from the unified operator image. When frontend.enabled=true, / is
+  # routed to the legacy split frontend service and /api to the Console backend.
   ingress:
     enabled: false
     className: ""

--- a/e2e/Cargo.lock
+++ b/e2e/Cargo.lock
@@ -1054,6 +1054,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2904,7 +2910,12 @@ dependencies = [
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
  "mime",
+ "mime_guess",
+ "percent-encoding",
  "pin-project-lite",
  "tokio",
  "tokio-util",

--- a/e2e/src/framework/kind.rs
+++ b/e2e/src/framework/kind.rs
@@ -23,6 +23,8 @@ use crate::framework::{
 };
 
 const RUSTFS_FORMAT_MARKER_PATHS: [&str; 2] = [".rustfs.sys/format.json", ".minio.sys/format.json"];
+const DOCKER_ROOT_UID: u32 = 0;
+const CLEANUP_HELPER_FALLBACK_IMAGES: [&str; 2] = ["rustfs/rustfs:latest", "busybox:latest"];
 
 #[derive(Debug, Clone)]
 pub struct KindCluster {
@@ -102,7 +104,8 @@ impl KindCluster {
     }
 
     fn remove_host_storage_dir(&self, dir: &Path) -> Result<()> {
-        ensure_existing_dedicated_host_storage_dir_is_safe(dir)?;
+        let metadata = ensure_existing_dedicated_host_storage_dir_is_safe(dir)?;
+        ensure_host_storage_dir_owner_allows_cleanup(dir, metadata.uid())?;
         println!("removing dedicated e2e storage dir {}", dir.display());
 
         match fs::remove_dir_all(dir) {
@@ -112,7 +115,7 @@ impl KindCluster {
                     "direct removal failed for {}: {error}; retrying through Docker helper as root",
                     dir.display()
                 );
-                self.docker_clean_host_storage_command(dir)?.run_checked()?;
+                self.docker_clean_host_storage(dir)?;
                 fs::remove_dir_all(dir).with_context(|| {
                     format!("remove dedicated e2e host storage dir {}", dir.display())
                 })
@@ -120,7 +123,53 @@ impl KindCluster {
         }
     }
 
-    fn docker_clean_host_storage_command(&self, dir: &Path) -> Result<CommandSpec> {
+    fn docker_clean_host_storage(&self, dir: &Path) -> Result<()> {
+        let uid = current_uid()?;
+        let gid = current_gid()?;
+        let mut last_error = None;
+
+        for image in self.cleanup_helper_images() {
+            if !docker_image_exists(&image) {
+                println!("Docker cleanup helper image {image} is not present locally; skipping");
+                continue;
+            }
+            let command = self.docker_clean_host_storage_command(dir, &image, uid, gid)?;
+            match command.run_checked() {
+                Ok(_) => return Ok(()),
+                Err(error) => {
+                    println!("Docker cleanup helper image {image} failed: {error}");
+                    last_error = Some(error);
+                }
+            }
+        }
+
+        Err(last_error.unwrap_or_else(|| {
+            anyhow::anyhow!(
+                "no local Docker cleanup helper image is available; build rustfs/operator:e2e or ensure rustfs/rustfs:latest is present"
+            )
+        }))
+    }
+
+    fn cleanup_helper_images(&self) -> Vec<String> {
+        let mut images = Vec::new();
+        for image in std::iter::once(self.config.operator_image.as_str())
+            .chain(std::iter::once(self.config.rustfs_image.as_str()))
+            .chain(CLEANUP_HELPER_FALLBACK_IMAGES)
+        {
+            if !images.iter().any(|existing| existing == image) {
+                images.push(image.to_string());
+            }
+        }
+        images
+    }
+
+    fn docker_clean_host_storage_command(
+        &self,
+        dir: &Path,
+        image: &str,
+        uid: u32,
+        gid: u32,
+    ) -> Result<CommandSpec> {
         ensure_dedicated_host_storage_dir(dir)?;
 
         Ok(CommandSpec::new("docker").args([
@@ -128,13 +177,17 @@ impl KindCluster {
             "--rm".to_string(),
             "--pull".to_string(),
             "never".to_string(),
+            "--user".to_string(),
+            "0:0".to_string(),
             "--entrypoint".to_string(),
             "/bin/sh".to_string(),
             "-v".to_string(),
             format!("{}:/e2e-storage", dir.display()),
-            self.config.operator_image.clone(),
+            image.to_string(),
             "-c".to_string(),
-            "find /e2e-storage -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +".to_string(),
+            format!(
+                "find /e2e-storage -mindepth 1 -maxdepth 1 -exec rm -rf -- {{}} + && chown {uid}:{gid} /e2e-storage"
+            ),
         ]))
     }
 
@@ -220,7 +273,7 @@ fn ensure_host_storage_dir_is_absent(dir: &Path) -> Result<()> {
     Ok(())
 }
 
-fn ensure_existing_dedicated_host_storage_dir_is_safe(path: &Path) -> Result<()> {
+fn ensure_existing_dedicated_host_storage_dir_is_safe(path: &Path) -> Result<fs::Metadata> {
     ensure_dedicated_host_storage_dir(path)?;
     let metadata = fs::symlink_metadata(path)
         .with_context(|| format!("inspect e2e host storage dir {}", path.display()))?;
@@ -239,12 +292,16 @@ fn ensure_existing_dedicated_host_storage_dir_is_safe(path: &Path) -> Result<()>
         );
     }
 
+    Ok(metadata)
+}
+
+fn ensure_host_storage_dir_owner_allows_cleanup(path: &Path, owner_uid: u32) -> Result<()> {
     let current_uid = current_uid()?;
-    if metadata.uid() != current_uid {
+    if owner_uid != current_uid && owner_uid != DOCKER_ROOT_UID {
         bail!(
-            "refusing Docker-root cleanup for e2e host storage dir {} owned by uid {}; current uid is {}",
+            "refusing Docker-root cleanup for e2e host storage dir {} owned by uid {}; current uid is {}; only current-user or root-owned dedicated e2e storage dirs can be cleaned",
             path.display(),
-            metadata.uid(),
+            owner_uid,
             current_uid
         );
     }
@@ -275,11 +332,30 @@ fn current_uid() -> Result<u32> {
         .context("parse current uid from `id -u`")
 }
 
+fn current_gid() -> Result<u32> {
+    let output = CommandSpec::new("id").arg("-g").run_checked()?;
+    output
+        .stdout
+        .trim()
+        .parse::<u32>()
+        .context("parse current gid from `id -g`")
+}
+
+fn docker_image_exists(image: &str) -> bool {
+    match CommandSpec::new("docker")
+        .args(["image", "inspect", image])
+        .run()
+    {
+        Ok(output) => output.code == Some(0),
+        Err(_) => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
         KindCluster, ensure_dedicated_host_storage_dir, ensure_host_storage_dir_is_absent,
-        ensure_host_storage_dir_is_empty,
+        ensure_host_storage_dir_is_empty, ensure_host_storage_dir_owner_allows_cleanup,
     };
     use crate::framework::config::E2eConfig;
 
@@ -331,16 +407,64 @@ mod tests {
     fn docker_cleanup_command_mounts_only_dedicated_storage_dir() {
         let kind = KindCluster::new(E2eConfig::defaults());
         let command = kind
-            .docker_clean_host_storage_command(std::path::Path::new("/tmp/rustfs-e2e-storage-1"))
+            .docker_clean_host_storage_command(
+                std::path::Path::new("/tmp/rustfs-e2e-storage-1"),
+                "rustfs/rustfs:latest",
+                1000,
+                1000,
+            )
             .expect("dedicated storage dir should be accepted");
 
         assert_eq!(
             command.display(),
-            "docker run --rm --pull never --entrypoint /bin/sh -v /tmp/rustfs-e2e-storage-1:/e2e-storage rustfs/operator:e2e -c find /e2e-storage -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +"
+            "docker run --rm --pull never --user 0:0 --entrypoint /bin/sh -v /tmp/rustfs-e2e-storage-1:/e2e-storage rustfs/rustfs:latest -c find /e2e-storage -mindepth 1 -maxdepth 1 -exec rm -rf -- {} + && chown 1000:1000 /e2e-storage"
         );
         assert!(
-            kind.docker_clean_host_storage_command(std::path::Path::new("/tmp/other"))
-                .is_err()
+            kind.docker_clean_host_storage_command(
+                std::path::Path::new("/tmp/other"),
+                "rustfs/rustfs:latest",
+                1000,
+                1000,
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn host_storage_owner_guard_accepts_current_user_and_docker_root() {
+        let current_uid = super::current_uid().expect("current uid is available");
+
+        ensure_host_storage_dir_owner_allows_cleanup(
+            std::path::Path::new("/tmp/rustfs-e2e-storage-1"),
+            current_uid,
+        )
+        .expect("current user-owned storage should be accepted");
+        ensure_host_storage_dir_owner_allows_cleanup(
+            std::path::Path::new("/tmp/rustfs-e2e-storage-1"),
+            0,
+        )
+        .expect("Docker root-owned storage should be accepted");
+
+        let other_uid = if current_uid == 1 { 2 } else { 1 };
+        let error = ensure_host_storage_dir_owner_allows_cleanup(
+            std::path::Path::new("/tmp/rustfs-e2e-storage-1"),
+            other_uid,
+        )
+        .expect_err("other user-owned storage should be rejected");
+        assert!(error.to_string().contains("owned by uid"));
+    }
+
+    #[test]
+    fn cleanup_helper_images_prefer_configured_images_and_deduplicate_defaults() {
+        let kind = KindCluster::new(E2eConfig::defaults());
+
+        assert_eq!(
+            kind.cleanup_helper_images(),
+            vec![
+                "rustfs/operator:e2e".to_string(),
+                "rustfs/rustfs:latest".to_string(),
+                "busybox:latest".to_string(),
+            ]
         );
     }
 

--- a/src/console/middleware/auth.rs
+++ b/src/console/middleware/auth.rs
@@ -43,6 +43,7 @@ pub async fn auth_middleware(
         || path.starts_with("/api/v1/logout")
         || path.starts_with("/swagger-ui")
         || path.starts_with("/api-docs")
+        || !path.starts_with("/api/v1")
     {
         return Ok(next.run(request).await);
     }
@@ -142,6 +143,22 @@ mod tests {
                 "message": "Missing or invalid session"
             })
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn static_paths_do_not_require_session() -> Result<(), Box<dyn std::error::Error>> {
+        let state = AppState::new("test-secret".to_string());
+        let app = Router::new()
+            .route("/", get(|| async { "ui" }))
+            .with_state(state.clone())
+            .layer(middleware::from_fn_with_state(state, auth_middleware));
+
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty())?)
+            .await?;
+
+        assert_eq!(response.status(), StatusCode::OK);
         Ok(())
     }
 }

--- a/src/console/server.rs
+++ b/src/console/server.rs
@@ -13,13 +13,31 @@
 // limitations under the License.
 
 use crate::console::{openapi::ApiDoc, routes, state::AppState};
-use axum::http::{HeaderValue, Method, StatusCode, header};
+use axum::body::Body;
+use axum::http::{HeaderValue, Method, Request, Response, StatusCode, header};
 use axum::{Router, middleware, response::IntoResponse, routing::get};
 use k8s_openapi::api::core::v1 as corev1;
 use kube::{Api, Client, api::ListParams};
-use tower_http::{compression::CompressionLayer, cors::CorsLayer, trace::TraceLayer};
+use std::{
+    convert::Infallible,
+    future::Future,
+    path::PathBuf,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tower::Service;
+use tower_http::{
+    compression::CompressionLayer,
+    cors::CorsLayer,
+    services::{ServeDir, ServeFile, fs::ServeFileSystemResponseBody},
+    trace::TraceLayer,
+};
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
+
+const CONSOLE_STATIC_DIR_ENV: &str = "CONSOLE_STATIC_DIR";
+const IMAGE_CONSOLE_STATIC_DIR: &str = "/app/console-web";
+const LOCAL_CONSOLE_STATIC_DIR: &str = "console-web/out";
 
 /// Build CORS allowed origins from env.
 /// Env: CORS_ALLOWED_ORIGINS, comma-separated (e.g. "https://console.example.com,http://localhost:3000").
@@ -73,7 +91,8 @@ pub async fn run(port: u16) -> Result<(), Box<dyn std::error::Error>> {
         // REST API v1
         .nest("/api/v1", api_routes())
         // Shared state
-        .with_state(state.clone())
+        .with_state(state.clone());
+    let app = with_static_frontend(app)
         // Middleware runs in reverse order: Trace -> Compression -> Cors -> auth
         .layer(middleware::from_fn_with_state(
             state.clone(),
@@ -121,6 +140,77 @@ fn api_routes() -> Router<AppState> {
         .merge(routes::event_routes())
         .merge(routes::cluster_routes())
         .merge(routes::topology_routes())
+}
+
+fn with_static_frontend(app: Router) -> Router {
+    let Some(static_dir) = static_frontend_dir() else {
+        tracing::warn!(
+            "Console frontend static files not found; serving API only. Set {} to enable static UI serving.",
+            CONSOLE_STATIC_DIR_ENV
+        );
+        return app;
+    };
+
+    tracing::info!("Serving Console frontend from {}", static_dir.display());
+    app.fallback_service(static_frontend_service(static_dir))
+}
+
+fn static_frontend_service(static_dir: PathBuf) -> StaticFrontendService {
+    let index_path = static_dir.join("index.html");
+    let static_service = ServeDir::new(static_dir)
+        .append_index_html_on_directories(true)
+        .fallback(ServeFile::new(index_path));
+
+    StaticFrontendService { static_service }
+}
+
+#[derive(Clone)]
+struct StaticFrontendService {
+    static_service: ServeDir<ServeFile>,
+}
+
+impl Service<Request<Body>> for StaticFrontendService {
+    type Response = Response<ServeFileSystemResponseBody>;
+    type Error = Infallible;
+    type Future =
+        Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        <ServeDir<ServeFile> as Service<Request<Body>>>::poll_ready(&mut self.static_service, cx)
+    }
+
+    fn call(&mut self, request: Request<Body>) -> Self::Future {
+        if is_api_path(request.uri().path()) {
+            return Box::pin(async { Ok(api_not_found_response()) });
+        }
+
+        let mut static_service = self.static_service.clone();
+        Box::pin(async move { static_service.call(request).await })
+    }
+}
+
+fn is_api_path(path: &str) -> bool {
+    path == "/api" || path.starts_with("/api/")
+}
+
+fn api_not_found_response() -> Response<ServeFileSystemResponseBody> {
+    let mut response = Response::new(ServeFileSystemResponseBody::default());
+    *response.status_mut() = StatusCode::NOT_FOUND;
+    response
+}
+
+fn static_frontend_dir() -> Option<PathBuf> {
+    let candidates = match std::env::var(CONSOLE_STATIC_DIR_ENV) {
+        Ok(value) if !value.trim().is_empty() => vec![PathBuf::from(value.trim())],
+        _ => vec![
+            PathBuf::from(IMAGE_CONSOLE_STATIC_DIR),
+            PathBuf::from(LOCAL_CONSOLE_STATIC_DIR),
+        ],
+    };
+
+    candidates
+        .into_iter()
+        .find(|dir| dir.join("index.html").is_file())
 }
 
 /// Liveness probe: always OK if process runs.
@@ -195,4 +285,57 @@ fn read_urandom(bytes: &mut [u8]) -> std::io::Result<()> {
 
     let mut file = std::fs::File::open("/dev/urandom")?;
     file.read_exact(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tower::ServiceExt;
+
+    fn temp_static_dir() -> std::io::Result<PathBuf> {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "rustfs-console-static-{}-{nanos}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir)?;
+        std::fs::write(dir.join("index.html"), "console")?;
+        Ok(dir)
+    }
+
+    #[tokio::test]
+    async fn static_frontend_fallback_does_not_handle_api_paths()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let dir = temp_static_dir()?;
+
+        let response = static_frontend_service(dir.clone())
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/missing")
+                    .body(Body::empty())?,
+            )
+            .await
+            .map_err(|error| match error {})?;
+
+        let _ = std::fs::remove_dir_all(dir);
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn static_frontend_fallback_serves_spa_paths() -> Result<(), Box<dyn std::error::Error>> {
+        let dir = temp_static_dir()?;
+
+        let response = static_frontend_service(dir.clone())
+            .oneshot(Request::builder().uri("/tenants").body(Body::empty())?)
+            .await
+            .map_err(|error| match error {})?;
+
+        let _ = std::fs::remove_dir_all(dir);
+        assert_eq!(response.status(), StatusCode::OK);
+        Ok(())
+    }
 }

--- a/src/sts/admin_ops.rs
+++ b/src/sts/admin_ops.rs
@@ -130,6 +130,13 @@ impl RustfsAdminClient {
         policies
             .into_iter()
             .map(|(name, policy)| {
+                let raw = serde_json::to_string(&policy)
+                    .map_err(|_| RustfsClientError::ParseResponseFailed)?;
+                let policy = extract_canned_policy_document(&raw)
+                    .map_err(|_| RustfsClientError::ParseResponseFailed)?;
+                let policy = serde_json::from_str::<Value>(&policy)
+                    .map_err(|_| RustfsClientError::ParseResponseFailed)?;
+
                 serde_json::to_string(&policy)
                     .map(|document| (name, document))
                     .map_err(|_| RustfsClientError::ParseResponseFailed)

--- a/src/sts/tests.rs
+++ b/src/sts/tests.rs
@@ -28,7 +28,8 @@ use tokio::sync::Mutex;
 
 use super::{
     ADD_USER_PATH, CreateBucketResult, POOLS_DECOMMISSION_PATH, POOLS_LIST_PATH, POOLS_STATUS_PATH,
-    RustfsAdminClient, RustfsClientError, SERVER_INFO_PATH, SET_POLICY_PATH,
+    LIST_CANNED_POLICIES_PATH, RustfsAdminClient, RustfsClientError, SERVER_INFO_PATH,
+    SET_POLICY_PATH,
     helpers::{extract_canned_policy_document, extract_credentials, parse_assume_role_response},
 };
 
@@ -244,6 +245,75 @@ async fn info_canned_policy_uses_expected_path_and_query() {
             .await
             .contains("/s3/aws4_request")
     );
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn list_canned_policies_extracts_policy_document_and_canonicalizes_json() {
+    let capture = Capture::default();
+    let route_capture = capture.clone();
+
+    let router = Router::new()
+            .route(
+                LIST_CANNED_POLICIES_PATH,
+                get(
+                    move |State(c): State<Capture>, req: Request<Body>| async move {
+                        let path = req.uri().path().to_string();
+                        let query = req.uri().query().unwrap_or("").to_string();
+
+                        *c.path.lock().await = path;
+                        *c.query.lock().await = query;
+
+                        (
+                            StatusCode::OK,
+                            serde_json::json!({
+                                "tenant-policy": {
+                                    "policy_name":"tenant-policy",
+                                    "policy":{
+                                        "Statement": [{
+                                            "Resource": "arn:aws:s3:::tenant",
+                                            "Effect": "Allow",
+                                            "Action": "s3:GetObject"
+                                        }],
+                                        "Version":"2012-10-17"
+                                    }
+                                },
+                                "inline-policy": {
+                                    "Version": "2012-10-17",
+                                    "Statement": [{
+                                        "Sid": "inline",
+                                        "Action": "s3:ListBucket",
+                                        "Effect": "Allow",
+                                        "Resource": ["arn:aws:s3:::tenant*"]
+                                    }]
+                                }
+                            })
+                            .to_string(),
+                        )
+                    },
+                ),
+            )
+            .with_state(route_capture.clone());
+
+    let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+        .await
+        .unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
+
+    let client = RustfsAdminClient::new_with_base_url(format!("http://{addr}"), "access", "secret");
+    let policies = client.list_canned_policies().await.unwrap();
+
+    let tenant_policy = serde_json::from_str::<Value>(&policies["tenant-policy"]).unwrap();
+    assert_eq!(tenant_policy["Version"], "2012-10-17");
+    assert_eq!(tenant_policy["Statement"][0]["Action"], "s3:GetObject");
+
+    let inline_policy = serde_json::from_str::<Value>(&policies["inline-policy"]).unwrap();
+    assert_eq!(inline_policy["Version"], "2012-10-17");
+    assert_eq!(inline_policy["Statement"][0]["Sid"], "inline");
+    assert_eq!(&*capture.path.lock().await, LIST_CANNED_POLICIES_PATH);
+    assert!(capture.query.lock().await.is_empty());
 
     server.abort();
 }

--- a/src/sts/tests.rs
+++ b/src/sts/tests.rs
@@ -27,8 +27,8 @@ use std::{collections::BTreeMap, sync::Arc};
 use tokio::sync::Mutex;
 
 use super::{
-    ADD_USER_PATH, CreateBucketResult, POOLS_DECOMMISSION_PATH, POOLS_LIST_PATH, POOLS_STATUS_PATH,
-    LIST_CANNED_POLICIES_PATH, RustfsAdminClient, RustfsClientError, SERVER_INFO_PATH,
+    ADD_USER_PATH, CreateBucketResult, LIST_CANNED_POLICIES_PATH, POOLS_DECOMMISSION_PATH,
+    POOLS_LIST_PATH, POOLS_STATUS_PATH, RustfsAdminClient, RustfsClientError, SERVER_INFO_PATH,
     SET_POLICY_PATH,
     helpers::{extract_canned_policy_document, extract_credentials, parse_assume_role_response},
 };
@@ -255,46 +255,46 @@ async fn list_canned_policies_extracts_policy_document_and_canonicalizes_json() 
     let route_capture = capture.clone();
 
     let router = Router::new()
-            .route(
-                LIST_CANNED_POLICIES_PATH,
-                get(
-                    move |State(c): State<Capture>, req: Request<Body>| async move {
-                        let path = req.uri().path().to_string();
-                        let query = req.uri().query().unwrap_or("").to_string();
+        .route(
+            LIST_CANNED_POLICIES_PATH,
+            get(
+                move |State(c): State<Capture>, req: Request<Body>| async move {
+                    let path = req.uri().path().to_string();
+                    let query = req.uri().query().unwrap_or("").to_string();
 
-                        *c.path.lock().await = path;
-                        *c.query.lock().await = query;
+                    *c.path.lock().await = path;
+                    *c.query.lock().await = query;
 
-                        (
-                            StatusCode::OK,
-                            serde_json::json!({
-                                "tenant-policy": {
-                                    "policy_name":"tenant-policy",
-                                    "policy":{
-                                        "Statement": [{
-                                            "Resource": "arn:aws:s3:::tenant",
-                                            "Effect": "Allow",
-                                            "Action": "s3:GetObject"
-                                        }],
-                                        "Version":"2012-10-17"
-                                    }
-                                },
-                                "inline-policy": {
-                                    "Version": "2012-10-17",
+                    (
+                        StatusCode::OK,
+                        serde_json::json!({
+                            "tenant-policy": {
+                                "policy_name":"tenant-policy",
+                                "policy":{
                                     "Statement": [{
-                                        "Sid": "inline",
-                                        "Action": "s3:ListBucket",
+                                        "Resource": "arn:aws:s3:::tenant",
                                         "Effect": "Allow",
-                                        "Resource": ["arn:aws:s3:::tenant*"]
-                                    }]
+                                        "Action": "s3:GetObject"
+                                    }],
+                                    "Version":"2012-10-17"
                                 }
-                            })
-                            .to_string(),
-                        )
-                    },
-                ),
-            )
-            .with_state(route_capture.clone());
+                            },
+                            "inline-policy": {
+                                "Version": "2012-10-17",
+                                "Statement": [{
+                                    "Sid": "inline",
+                                    "Action": "s3:ListBucket",
+                                    "Effect": "Allow",
+                                    "Resource": ["arn:aws:s3:::tenant*"]
+                                }]
+                            }
+                        })
+                        .to_string(),
+                    )
+                },
+            ),
+        )
+        .with_state(route_capture.clone());
 
     let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
         .await

--- a/src/types/v1alpha1.rs
+++ b/src/types/v1alpha1.rs
@@ -137,12 +137,18 @@ mod policy_binding_tests {
 
 #[cfg(test)]
 mod tenant_provisioning_crd_tests {
-    use super::tenant::Tenant;
+    use super::{
+        pool_lifecycle::MAX_DECOMMISSION_REQUESTS,
+        provisioning::MAX_POLICIES_PER_USER,
+        tenant::{
+            MAX_TENANT_BUCKETS, MAX_TENANT_POLICIES, MAX_TENANT_POOLS, MAX_TENANT_USERS, Tenant,
+        },
+    };
     use kube::CustomResourceExt;
     use serde_json::json;
 
     #[test]
-    fn tenant_crd_includes_provisioning_spec_status_and_uniqueness_rules() {
+    fn tenant_crd_includes_provisioning_spec_status_and_bounded_list_rules() {
         let crd = serde_json::to_value(Tenant::crd()).expect("Tenant CRD serializes");
         let schema = &crd["spec"]["versions"][0]["schema"]["openAPIV3Schema"];
         let spec = &schema["properties"]["spec"];
@@ -152,6 +158,74 @@ mod tenant_provisioning_crd_tests {
         assert_eq!(spec["properties"]["users"]["type"], json!("array"));
         assert_eq!(spec["properties"]["buckets"]["type"], json!("array"));
         assert_eq!(
+            spec["properties"]["pools"]["x-kubernetes-list-type"],
+            json!("map")
+        );
+        assert_eq!(
+            spec["properties"]["pools"]["x-kubernetes-list-map-keys"],
+            json!(["name"])
+        );
+        assert_eq!(
+            spec["properties"]["pools"]["maxItems"],
+            json!(MAX_TENANT_POOLS)
+        );
+        assert_eq!(
+            spec["properties"]["policies"]["x-kubernetes-list-type"],
+            json!("map")
+        );
+        assert_eq!(
+            spec["properties"]["policies"]["x-kubernetes-list-map-keys"],
+            json!(["name"])
+        );
+        assert_eq!(
+            spec["properties"]["policies"]["maxItems"],
+            json!(MAX_TENANT_POLICIES)
+        );
+        assert_eq!(
+            spec["properties"]["users"]["x-kubernetes-list-type"],
+            json!("map")
+        );
+        assert_eq!(
+            spec["properties"]["users"]["x-kubernetes-list-map-keys"],
+            json!(["name"])
+        );
+        assert_eq!(
+            spec["properties"]["users"]["maxItems"],
+            json!(MAX_TENANT_USERS)
+        );
+        assert_eq!(
+            spec["properties"]["users"]["items"]["properties"]["policies"]["x-kubernetes-list-type"],
+            json!("set")
+        );
+        assert_eq!(
+            spec["properties"]["users"]["items"]["properties"]["policies"]["maxItems"],
+            json!(MAX_POLICIES_PER_USER)
+        );
+        assert_eq!(
+            spec["properties"]["buckets"]["x-kubernetes-list-type"],
+            json!("map")
+        );
+        assert_eq!(
+            spec["properties"]["buckets"]["x-kubernetes-list-map-keys"],
+            json!(["name"])
+        );
+        assert_eq!(
+            spec["properties"]["buckets"]["maxItems"],
+            json!(MAX_TENANT_BUCKETS)
+        );
+        assert_eq!(
+            spec["properties"]["poolLifecycle"]["properties"]["decommissionRequests"]["x-kubernetes-list-type"],
+            json!("map")
+        );
+        assert_eq!(
+            spec["properties"]["poolLifecycle"]["properties"]["decommissionRequests"]["x-kubernetes-list-map-keys"],
+            json!(["poolName"])
+        );
+        assert_eq!(
+            spec["properties"]["poolLifecycle"]["properties"]["decommissionRequests"]["maxItems"],
+            json!(MAX_DECOMMISSION_REQUESTS)
+        );
+        assert_eq!(
             status["properties"]["provisioning"]["properties"]["policies"]["type"],
             json!("array")
         );
@@ -160,9 +234,9 @@ mod tenant_provisioning_crd_tests {
             json!(["Pending", "Ready", "Failed", null])
         );
 
-        assert_eq!(
-            spec["properties"]["policies"]["x-kubernetes-validations"][0]["message"],
-            json!("policy names must be unique")
+        assert!(
+            spec["properties"]["policies"]["x-kubernetes-validations"].is_null(),
+            "policy name uniqueness should use x-kubernetes-list-type=map"
         );
         let user_validations = &spec["properties"]["users"]["x-kubernetes-validations"];
         assert!(
@@ -176,11 +250,8 @@ mod tenant_provisioning_crd_tests {
         let user_policy_validations = &spec["properties"]["users"]["items"]["properties"]["policies"]
             ["x-kubernetes-validations"];
         assert!(
-            user_policy_validations
-                .as_array()
-                .expect("user policy validations are present")
-                .iter()
-                .any(|rule| rule["message"] == json!("user policy names must be unique"))
+            user_policy_validations.is_null(),
+            "user policy uniqueness should use x-kubernetes-list-type=set"
         );
         assert_eq!(
             spec["properties"]["buckets"]["items"]["properties"]["name"]["x-kubernetes-validations"]

--- a/src/types/v1alpha1/pool.rs
+++ b/src/types/v1alpha1/pool.rs
@@ -67,10 +67,10 @@ pub struct SchedulingConfig {
     reason(Reason::FieldValueInvalid))
 ]
 pub struct Pool {
-    #[x_kube(validation = Rule::new("self != ''").message("pool name must be not empty"))]
-    #[x_kube(validation = Rule::new("self.size() <= 63 && self.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')").
-        message("pool name must be a valid RFC 1123 label: lowercase alphanumeric or '-', start and end with alphanumeric, max 63 characters"))
-    ]
+    #[schemars(
+        length(min = 1, max = 63),
+        regex(pattern = r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
+    )]
     pub name: String,
 
     #[x_kube(validation = Rule::new("self > 0").message("servers must be greater than 0"))]

--- a/src/types/v1alpha1/pool_lifecycle.rs
+++ b/src/types/v1alpha1/pool_lifecycle.rs
@@ -17,14 +17,21 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use strum::Display;
 
+pub(crate) const MAX_DECOMMISSION_REQUESTS: u32 = 32;
+pub(crate) const MAX_DECOMMISSION_POOL_NAME_LENGTH: u32 = 63;
+pub(crate) const MAX_DECOMMISSION_REQUEST_ID_LENGTH: u32 = 128;
+pub(crate) const MAX_DECOMMISSION_REASON_LENGTH: u32 = 1024;
+
 #[derive(Deserialize, Serialize, Clone, Debug, KubeSchema, Default)]
 #[serde(rename_all = "camelCase")]
-#[x_kube(validation = Rule::new("!has(self.decommissionRequests) || self.decommissionRequests.all(r, self.decommissionRequests.exists_one(other, other.poolName == r.poolName))").
-    message("decommissionRequests must contain at most one entry per poolName"))]
 pub struct PoolLifecycleSpec {
     #[serde(default, skip_serializing_if = "is_default_pvc_retention_policy")]
     pub pvc_retention_policy: PvcRetentionPolicy,
 
+    #[schemars(
+        length(max = MAX_DECOMMISSION_REQUESTS),
+        extend("x-kubernetes-list-type" = "map", "x-kubernetes-list-map-keys" = ["poolName"])
+    )]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub decommission_requests: Vec<DecommissionRequest>,
 }
@@ -41,7 +48,9 @@ pub enum PvcRetentionPolicy {
 #[derive(Deserialize, Serialize, Clone, Debug, KubeSchema, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct DecommissionRequest {
+    #[schemars(length(min = 1, max = MAX_DECOMMISSION_POOL_NAME_LENGTH))]
     pub pool_name: String,
+    #[schemars(length(min = 1, max = MAX_DECOMMISSION_REQUEST_ID_LENGTH))]
     pub request_id: String,
     pub action: DecommissionAction,
 
@@ -51,6 +60,7 @@ pub struct DecommissionRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cancel_requested_at: Option<String>,
 
+    #[schemars(length(max = MAX_DECOMMISSION_REASON_LENGTH))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
 }

--- a/src/types/v1alpha1/provisioning.rs
+++ b/src/types/v1alpha1/provisioning.rs
@@ -17,6 +17,15 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
+pub(crate) const MAX_CONFIG_MAP_REF_NAME_LENGTH: u32 = 253;
+pub(crate) const MAX_CONFIG_MAP_REF_KEY_LENGTH: u32 = 253;
+pub(crate) const MAX_PROVISIONING_POLICY_NAME_LENGTH: u32 = 253;
+pub(crate) const MAX_PROVISIONING_USER_NAME_LENGTH: u32 = 253;
+pub(crate) const MAX_POLICIES_PER_USER: u32 = 64;
+pub(crate) const MAX_USER_POLICY_NAME_LENGTH: u32 = 253;
+pub(crate) const MIN_BUCKET_NAME_LENGTH: u32 = 3;
+pub(crate) const MAX_BUCKET_NAME_LENGTH: u32 = 63;
+
 #[derive(Deserialize, Serialize, Clone, Debug, JsonSchema, ToSchema, Default, PartialEq, Eq)]
 #[serde(rename_all = "PascalCase")]
 pub enum ProvisioningDeletionPolicy {
@@ -31,10 +40,10 @@ pub fn is_retain(policy: &ProvisioningDeletionPolicy) -> bool {
 #[derive(Deserialize, Serialize, Clone, Debug, KubeSchema, ToSchema, Default, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ConfigMapKeyReference {
-    #[x_kube(validation = Rule::new("self != ''").message("configMapKeyRef name must be not empty"))]
+    #[schemars(length(min = 1, max = MAX_CONFIG_MAP_REF_NAME_LENGTH))]
     pub name: String,
 
-    #[x_kube(validation = Rule::new("self != ''").message("configMapKeyRef key must be not empty"))]
+    #[schemars(length(min = 1, max = MAX_CONFIG_MAP_REF_KEY_LENGTH))]
     pub key: String,
 }
 
@@ -47,7 +56,7 @@ pub struct PolicyDocumentSource {
 #[derive(Deserialize, Serialize, Clone, Debug, KubeSchema, ToSchema, Default, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ProvisioningPolicy {
-    #[x_kube(validation = Rule::new("self != '' && !self.matches('.*\\\\s.*')").message("policy name must be not empty and must not contain whitespace"))]
+    #[schemars(length(min = 1, max = MAX_PROVISIONING_POLICY_NAME_LENGTH), regex(pattern = r"^\S+$"))]
     pub name: String,
 
     pub document: PolicyDocumentSource,
@@ -59,12 +68,15 @@ pub struct ProvisioningPolicy {
 #[derive(Deserialize, Serialize, Clone, Debug, KubeSchema, ToSchema, Default, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ProvisioningUser {
-    #[x_kube(validation = Rule::new("self != '' && !self.matches('.*\\\\s.*')").message("user Secret name must be not empty and must not contain whitespace"))]
+    #[schemars(length(min = 1, max = MAX_PROVISIONING_USER_NAME_LENGTH), regex(pattern = r"^\S+$"))]
     pub name: String,
 
     /// Canned policies to map directly to this user.
-    #[x_kube(validation = Rule::new("self.all(x, x != '' && !x.matches('.*\\\\s.*'))").message("user policy names must be not empty and must not contain whitespace"))]
-    #[x_kube(validation = Rule::new("self.all(x, self.filter(y, y == x).size() == 1)").message("user policy names must be unique"))]
+    #[schemars(
+        length(min = 1, max = MAX_POLICIES_PER_USER),
+        inner(length(min = 1, max = MAX_USER_POLICY_NAME_LENGTH), regex(pattern = r"^\S+$")),
+        extend("x-kubernetes-list-type" = "set")
+    )]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub policies: Vec<String>,
 
@@ -75,7 +87,11 @@ pub struct ProvisioningUser {
 #[derive(Deserialize, Serialize, Clone, Debug, KubeSchema, ToSchema, Default, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ProvisioningBucket {
-    #[x_kube(validation = Rule::new("self.size() >= 3 && self.size() <= 63 && self != 'rustfs' && !self.matches('^(\\\\d+\\\\.){3}\\\\d+$') && !self.contains('..') && !self.contains('.-') && !self.contains('-.') && self.matches('^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$')").message("bucket name must be a valid RustFS/S3 bucket name"))]
+    #[schemars(
+        length(min = MIN_BUCKET_NAME_LENGTH, max = MAX_BUCKET_NAME_LENGTH),
+        regex(pattern = r"^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$")
+    )]
+    #[x_kube(validation = Rule::new("self != 'rustfs' && !self.matches('^(\\\\d+\\\\.){3}\\\\d+$') && !self.contains('..') && !self.contains('.-') && !self.contains('-.')").message("bucket name must be a valid RustFS/S3 bucket name"))]
     pub name: String,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/types/v1alpha1/tenant.rs
+++ b/src/types/v1alpha1/tenant.rs
@@ -34,6 +34,11 @@ mod rbac;
 mod services;
 mod workloads;
 
+pub(crate) const MAX_TENANT_POOLS: u32 = 32;
+pub(crate) const MAX_TENANT_POLICIES: u32 = 256;
+pub(crate) const MAX_TENANT_USERS: u32 = 256;
+pub(crate) const MAX_TENANT_BUCKETS: u32 = 1024;
+
 #[derive(CustomResource, Deserialize, Serialize, Clone, Debug, KubeSchema, Default)]
 #[kube(
     group = "rustfs.com",
@@ -53,9 +58,10 @@ pub struct TenantSpec {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scheduler: Option<String>,
 
-    #[schemars(extend("x-kubernetes-list-type" = "map", "x-kubernetes-list-map-keys" = ["name"]))]
-    #[x_kube(validation = Rule::new("self.size() > 0").message("pools must be configured"))]
-    #[x_kube(validation = Rule::new("self.all(x, self.filter(y, y.name == x.name).size() == 1)").message("pool names must be unique"))]
+    #[schemars(
+        length(min = 1, max = MAX_TENANT_POOLS),
+        extend("x-kubernetes-list-type" = "map", "x-kubernetes-list-map-keys" = ["name"])
+    )]
     pub pools: Vec<Pool>,
 
     /// Explicit lifecycle requests for pool decommissioning.
@@ -157,18 +163,27 @@ pub struct TenantSpec {
     pub creds_secret: Option<corev1::LocalObjectReference>,
 
     /// Canned policies that should be applied to the RustFS tenant.
-    #[x_kube(validation = Rule::new("self.all(x, self.filter(y, y.name == x.name).size() == 1)").message("policy names must be unique"))]
+    #[schemars(
+        length(max = MAX_TENANT_POLICIES),
+        extend("x-kubernetes-list-type" = "map", "x-kubernetes-list-map-keys" = ["name"])
+    )]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub policies: Vec<ProvisioningPolicy>,
 
     /// Regular users that should exist in the RustFS tenant.
-    #[x_kube(validation = Rule::new("self.all(x, self.filter(y, y.name == x.name).size() == 1)").message("user Secret names must be unique"))]
+    #[schemars(
+        length(max = MAX_TENANT_USERS),
+        extend("x-kubernetes-list-type" = "map", "x-kubernetes-list-map-keys" = ["name"])
+    )]
     #[x_kube(validation = Rule::new("self.all(x, has(x.policies) && x.policies.size() > 0)").message("user policies must contain at least one policy"))]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub users: Vec<ProvisioningUser>,
 
     /// Buckets that should exist in the RustFS tenant.
-    #[x_kube(validation = Rule::new("self.all(x, self.filter(y, y.name == x.name).size() == 1)").message("bucket names must be unique"))]
+    #[schemars(
+        length(max = MAX_TENANT_BUCKETS),
+        extend("x-kubernetes-list-type" = "map", "x-kubernetes-list-map-keys" = ["name"])
+    )]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub buckets: Vec<ProvisioningBucket>,
 


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [x] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
N/A

## Summary of Changes
- Bound Tenant CRD lists and strings with named constants so CEL validation cost stays within Kubernetes admission limits.
- Replace expensive CEL uniqueness checks with OpenAPI list semantics where possible.
- Allow live e2e cleanup to remove dedicated Docker-root-owned Kind storage directories while preserving path and owner guards.
- Update generated Tenant CRDs and tests for the schema and cleanup behavior.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit` (fmt-check + clippy + test + console-lint + console-fmt-check)
- [x] Added/updated necessary tests
- [ ] Documentation updated (N/A)
- [ ] CHANGELOG.md updated under `[Unreleased]` (N/A: this checkout does not contain CHANGELOG.md)
- [ ] CI/CD passed (N/A: pending upstream CI)

## Impact
- [x] Breaking change (CRD/API compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact: introduces explicit schema upper bounds for Tenant pools, policies, users, buckets, user policies, and pool lifecycle requests.

## Verification
```bash
make pre-commit
git diff --check
kubectl --context kind-rustfs-e2e apply --dry-run=server -f deploy/rustfs-operator/crds/tenant-crd.yaml
make e2e-live-delete
```

## Additional Notes
The schema bounds are named constants in the Rust API types so future product-limit changes have one source of truth before regenerating CRDs.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
