### PR TITLE
docs: add operator user guides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,9 @@ console-web/node_modules/
 CONSOLE-INTEGRATION-SUMMARY.md
 SCRIPTS-UPDATE.md
 AGENTS.md
-docs/
+docs/*
+!docs/operator-user-guide.md
+!docs/operator-user-guide.zh-CN.md
 .codex
 .codex/
 .claude/

--- a/docs/operator-user-guide.md
+++ b/docs/operator-user-guide.md
@@ -1,0 +1,816 @@
+<!--
+Copyright 2025 RustFS Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# RustFS Operator User Guide
+
+This guide is a technical manual for installing, configuring, and operating the RustFS Kubernetes Operator.
+
+Chinese version: [operator-user-guide.zh-CN.md](operator-user-guide.zh-CN.md)
+
+## 1. Overview
+
+RustFS Operator manages RustFS object storage clusters on Kubernetes. Users describe the desired storage cluster with a namespaced `Tenant` custom resource, and the operator reconciles Kubernetes resources needed to run RustFS.
+
+The operator provides:
+
+- `Tenant` CRD (`rustfs.com/v1alpha1`) for declaring RustFS pools, persistence, scheduling, credentials, TLS, logging, encryption, and bootstrap provisioning.
+- Controller reconciliation for Tenant-owned RBAC, Services, StatefulSets, PVC templates, status conditions, and Kubernetes Events.
+- Helm chart under `deploy/rustfs-operator/` for production-style installation.
+- Operator Console API and UI for management workflows.
+- Optional operator STS endpoint for workload identity based temporary RustFS credentials.
+- Optional tenant provisioning for canned policies, regular users, and buckets.
+- Metrics, health probes, and optional Prometheus Operator resources.
+
+Important service separation:
+
+| Component | Purpose | Default port |
+|-----------|---------|--------------|
+| RustFS S3 API inside a Tenant | S3-compatible object storage access | `9000` |
+| RustFS Tenant Console | Web console for one RustFS Tenant | `9001` |
+| Operator Console API/UI | Operator management API and UI | `9090` |
+| Operator STS | Temporary credentials endpoint | `4223` |
+| Operator observability endpoint | `/metrics`, `/healthz`, `/readyz` | `8080` |
+
+## 2. Architecture Model
+
+A `Tenant` is one RustFS cluster. A Tenant can contain one or more pools, but all pools in the same Tenant form one unified RustFS cluster. Do not use pools as hot/warm/cold storage tiers. If you need separate performance, isolation, lifecycle, or administrative boundaries, create separate Tenants.
+
+When a Tenant is applied, the operator creates and owns:
+
+- one ServiceAccount, Role, and RoleBinding when Tenant RBAC is enabled;
+- one headless Service named `{tenant}-hl` for StatefulSet peer DNS;
+- one S3 Service named `{tenant}-io` on port `9000`;
+- one Tenant Console Service named `{tenant}-console` on port `9001`;
+- one StatefulSet per pool;
+- PVC templates named `vol-0`, `vol-1`, and so on;
+- generated RustFS environment variables such as `RUSTFS_VOLUMES`, `RUSTFS_ADDRESS`, `RUSTFS_CONSOLE_ADDRESS`, and `RUSTFS_CONSOLE_ENABLE`.
+
+## 3. Prerequisites
+
+- Kubernetes v1.30 or newer.
+- Helm 3.0 or newer for chart installation.
+- A StorageClass that can satisfy the Tenant PVCs.
+- `kubectl` configured for the target cluster.
+- Access to the configured operator and RustFS images.
+- Optional: Prometheus Operator when enabling `ServiceMonitor` or `PrometheusRule`.
+- Optional: cert-manager when using cert-manager managed Tenant TLS.
+
+## 4. Install the Operator
+
+Install with the included Helm chart:
+
+```bash
+helm install rustfs-operator deploy/rustfs-operator/ \
+  --namespace rustfs-system \
+  --create-namespace
+```
+
+Verify the operator and Console pods:
+
+```bash
+kubectl get pods -n rustfs-system
+kubectl logs -n rustfs-system \
+  -l app.kubernetes.io/name=rustfs-operator,app.kubernetes.io/component=operator \
+  -f
+```
+
+Upgrade an existing installation:
+
+```bash
+helm upgrade rustfs-operator deploy/rustfs-operator/ \
+  --namespace rustfs-system
+```
+
+Uninstall:
+
+```bash
+helm uninstall rustfs-operator --namespace rustfs-system
+```
+
+## 5. Helm Configuration
+
+Use a values file for repeatable installation:
+
+```bash
+helm upgrade --install rustfs-operator deploy/rustfs-operator/ \
+  --namespace rustfs-system \
+  --create-namespace \
+  -f values.yaml
+```
+
+Common chart sections:
+
+| Section | Purpose |
+|---------|---------|
+| `operator` | Operator Deployment replicas, image, resources, probes, metrics, scheduling, leader election, and tenant monitoring. |
+| `sts` | Operator STS endpoint, service port, TokenReview audience, and TLS handling. |
+| `serviceAccount` / `rbac` | Operator ServiceAccount and RBAC creation. |
+| `console` | Operator Console backend/UI Deployment, service, session cookie secret, ingress, resources, and optional split frontend. |
+| `namespace` | Namespace override for chart resources; defaults to the Helm release namespace. |
+| `commonLabels` / `commonAnnotations` | Labels and annotations added to chart-managed resources. |
+
+Example production-oriented values:
+
+```yaml
+operator:
+  replicas: 2
+  image:
+    repository: registry.example.com/rustfs/operator
+    tag: v0.1.0
+  resources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+  tenantMonitor:
+    enabled: true
+    intervalSeconds: 300
+  serviceMonitor:
+    enabled: true
+
+console:
+  enabled: true
+  replicas: 2
+  jwtSecret: "<stable-base64-or-random-secret>"
+  ingress:
+    enabled: true
+    className: nginx
+    hosts:
+      - host: console.example.com
+
+sts:
+  enabled: true
+  audience: sts.rustfs.com
+  tls:
+    enabled: true
+    auto: true
+```
+
+Notes:
+
+- `operator.leaderElect` can be unset. The chart enables leader election automatically when `operator.replicas > 1`.
+- Keep `console.jwtSecret` stable when running multiple Console replicas. If unset, the chart generates or reuses a Secret.
+- Keep `CONSOLE_COOKIE_SECURE` enabled for production HTTPS. Only disable it for local HTTP testing.
+- `sts.tls.auto=true` lets the operator create the `sts-tls` Secret when missing.
+
+## 6. Create a Tenant
+
+A minimal development Tenant:
+
+```yaml
+apiVersion: rustfs.com/v1alpha1
+kind: Tenant
+metadata:
+  name: dev-minimal
+  namespace: default
+spec:
+  image: rustfs/rustfs:latest
+  pools:
+    - name: dev-pool
+      servers: 1
+      persistence:
+        volumesPerServer: 4
+```
+
+Apply and verify:
+
+```bash
+kubectl apply -f tenant.yaml
+kubectl get tenant dev-minimal
+kubectl get pods,pvc,svc -l rustfs.tenant=dev-minimal
+```
+
+Wait for pods:
+
+```bash
+kubectl wait --for=condition=ready pod \
+  -l rustfs.tenant=dev-minimal \
+  --timeout=300s
+```
+
+Access the Tenant S3 API:
+
+```bash
+kubectl port-forward svc/dev-minimal-io 9000:9000
+```
+
+Access the Tenant Console:
+
+```bash
+kubectl port-forward svc/dev-minimal-console 9001:9001
+```
+
+Use examples in `examples/` as starting points:
+
+| Example | Use case |
+|---------|----------|
+| `examples/minimal-dev-tenant.yaml` | Smallest valid development Tenant. |
+| `examples/secret-credentials-tenant.yaml` | Secret-based admin credentials. |
+| `examples/provisioning-tenant.yaml` | Bootstrap policies, users, and buckets. |
+| `examples/production-ha-tenant.yaml` | High-availability production-style layout. |
+| `examples/multi-pool-tenant.yaml` | Multiple pools in one unified Tenant cluster. |
+| `examples/custom-rbac-tenant.yaml` | Custom ServiceAccount and RBAC patterns. |
+
+## 7. Tenant Configuration Reference
+
+### 7.1 Tenant Identity
+
+Tenant names must be DNS-1035 compatible and no longer than 55 characters because the operator derives Service names such as `{tenant}-console`.
+
+Use lowercase names that start with a letter and contain only lowercase letters, digits, and `-`.
+
+### 7.2 Pool Configuration
+
+`spec.pools` is required. Each pool creates one StatefulSet.
+
+Key fields:
+
+| Field | Purpose |
+|-------|---------|
+| `name` | Pool name used in labels, StatefulSet names, and peer DNS. Must be unique in the Tenant. |
+| `servers` | Number of RustFS pods in the pool. Must be greater than `0`. Immutable after creation. |
+| `persistence.volumesPerServer` | Number of PVCs mounted into each server. Must be greater than `0`. Immutable after creation. |
+| `persistence.volumeClaimTemplate` | PVC spec used for each generated volume. Set storage size, access modes, and StorageClass here. |
+| `persistence.path` | Base mount path. Defaults to `/data`; mounted paths become `{path}/rustfs0`, `{path}/rustfs1`, and so on. |
+| `nodeSelector`, `affinity`, `tolerations`, `topologySpreadConstraints` | Pool-level scheduling controls. |
+| `resources` | Container resource requests and limits for the pool. |
+| `priorityClassName` | Pool-level priority class override. |
+
+Validation rules:
+
+- `servers * volumesPerServer >= 4`.
+- For `servers: 3`, total volumes must be at least `6`.
+- Pool names must be unique.
+- Pool peer DNS labels must fit Kubernetes DNS label limits.
+- Existing pool `servers` and `volumesPerServer` cannot be changed in place.
+
+Example:
+
+```yaml
+spec:
+  pools:
+    - name: pool-0
+      servers: 4
+      persistence:
+        volumesPerServer: 4
+        volumeClaimTemplate:
+          accessModes: ["ReadWriteOnce"]
+          resources:
+            requests:
+              storage: 100Gi
+          storageClassName: fast-ssd
+      resources:
+        requests:
+          cpu: "2"
+          memory: 8Gi
+        limits:
+          cpu: "4"
+          memory: 16Gi
+```
+
+### 7.3 Credentials
+
+For production, use `spec.credsSecret`. The Secret must be in the same namespace as the Tenant and contain UTF-8 `accesskey` and `secretkey` keys. Both values must be at least 8 characters.
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rustfs-admin-creds
+  namespace: storage
+type: Opaque
+stringData:
+  accesskey: "replace-with-access-key"
+  secretkey: "replace-with-secret-key"
+---
+apiVersion: rustfs.com/v1alpha1
+kind: Tenant
+metadata:
+  name: rustfs-a
+  namespace: storage
+spec:
+  credsSecret:
+    name: rustfs-admin-creds
+  pools:
+    - name: pool-0
+      servers: 2
+      persistence:
+        volumesPerServer: 2
+```
+
+Credential priority:
+
+1. `spec.credsSecret`.
+2. Explicit `RUSTFS_ACCESS_KEY` and `RUSTFS_SECRET_KEY` in `spec.env`.
+3. RustFS built-in defaults. Use defaults only for development.
+
+### 7.4 Workload Settings
+
+Useful Tenant-level fields:
+
+| Field | Purpose |
+|-------|---------|
+| `image` | RustFS server image. Defaults to the operator's configured fallback. |
+| `imagePullSecret` | Image pull Secret reference. |
+| `imagePullPolicy` | RustFS image pull policy. |
+| `scheduler` | Custom scheduler name. |
+| `env` | Additional RustFS container environment variables. Do not override operator-managed variables. |
+| `serviceAccountName` | Custom ServiceAccount for RustFS pods. |
+| `createServiceAccountRbac` | Whether the operator should create Role/RoleBinding for the Tenant ServiceAccount. |
+| `priorityClassName` | Tenant-level priority class. |
+| `lifecycle` | Kubernetes container lifecycle hooks. |
+| `podManagementPolicy` | StatefulSet pod management policy. |
+| `podDeletionPolicyWhenNodeIsDown` | Node-down pod deletion behavior. |
+| `securityContext` | Pod SecurityContext override for RustFS pods. |
+
+The operator reserves these environment variables and manages them automatically:
+
+- `RUSTFS_VOLUMES`
+- `RUSTFS_ADDRESS`
+- `RUSTFS_CONSOLE_ADDRESS`
+- `RUSTFS_CONSOLE_ENABLE`
+- TLS-related RustFS variables when Tenant TLS is enabled.
+
+`podDeletionPolicyWhenNodeIsDown` accepts:
+
+- `DoNothing`: do not delete pods automatically.
+- `Delete`: request a normal pod delete.
+- `ForceDelete`: force delete the pod with `gracePeriodSeconds=0`.
+- `DeleteStatefulSetPod`: Longhorn-compatible force delete for StatefulSet pods stuck on down nodes.
+- `DeleteDeploymentPod`: Longhorn-compatible force delete for Deployment pods stuck on down nodes.
+- `DeleteBothStatefulSetAndDeploymentPod`: Longhorn-compatible force delete for both StatefulSet and Deployment pods.
+
+Force deletion can have data consistency implications. Use it only when the storage backend and operational procedure are designed for that failure mode.
+
+### 7.5 TLS
+
+Tenant TLS is configured under `spec.tls`.
+
+Important fields:
+
+| Field | Purpose |
+|-------|---------|
+| `mode` | `disabled` or `certManager` for current usable configurations. `external` is reserved and currently blocks reconciliation. |
+| `mountPath` | TLS mount path. Defaults to `/var/run/rustfs/tls`. |
+| `rotationStrategy` | `Rollout` is supported. `HotReload` is accepted by the CRD but currently blocks reconciliation. |
+| `enableInternodeHttps` | Use HTTPS for RustFS peer communication. |
+| `requireSanMatch` | Require generated DNS names to match certificate SANs. Defaults to `true`. |
+| `certManager` | Certificate settings when using cert-manager. `secretName` is required for `mode: certManager`. |
+
+For cert-manager managed certificates:
+
+```yaml
+spec:
+  tls:
+    mode: certManager
+    rotationStrategy: Rollout
+    enableInternodeHttps: true
+    certManager:
+      manageCertificate: true
+      secretName: rustfs-a-server-tls
+      issuerRef:
+        group: cert-manager.io
+        kind: Issuer
+        name: rustfs-issuer
+      includeGeneratedDnsNames: true
+```
+
+When `manageCertificate: true`, `issuerRef` is also required. The operator creates or reconciles the cert-manager `Certificate`, waits for the referenced Secret, validates `tls.crt` and `tls.key`, and uses `ca.crt` unless another CA trust source is configured.
+
+### 7.6 Logging
+
+Tenant logging is configured under `spec.logging`.
+
+Modes:
+
+| Mode | Purpose |
+|------|---------|
+| `stdout` | Default and recommended. Kubernetes collects logs from stdout/stderr. |
+| `emptyDir` | Temporary local log storage for debugging. Logs are lost on pod restart. |
+| `persistent` | PVC-backed logs. Use only with external storage independent of RustFS. |
+
+Do not store RustFS startup logs in RustFS itself. That creates a circular dependency because the storage service is not available during startup.
+
+Example:
+
+```yaml
+spec:
+  logging:
+    mode: stdout
+```
+
+### 7.7 Encryption / KMS
+
+Tenant encryption is configured under `spec.encryption`.
+
+Supported backends:
+
+| Backend | Purpose |
+|---------|---------|
+| `local` | File-based local KMS key directory. The directory must be absolute, and the Tenant must have exactly one RustFS server replica across all pools. |
+| `vault` | HashiCorp Vault endpoint. Requires a Secret containing `vault-token`. |
+
+Local KMS does not use `kmsSecret`; if you set one, it is ignored. Use Vault KMS for multi-server Tenants.
+
+Vault example:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rustfs-kms
+  namespace: storage
+type: Opaque
+stringData:
+  vault-token: "replace-with-vault-token"
+---
+apiVersion: rustfs.com/v1alpha1
+kind: Tenant
+metadata:
+  name: rustfs-a
+  namespace: storage
+spec:
+  pools:
+    - name: pool-0
+      servers: 2
+      persistence:
+        volumesPerServer: 2
+  encryption:
+    enabled: true
+    backend: vault
+    vault:
+      endpoint: https://vault.example.com:8200
+    kmsSecret:
+      name: rustfs-kms
+    defaultKeyId: tenant-default
+```
+
+### 7.8 Bootstrap Provisioning
+
+The operator can create RustFS policies, users, and buckets after the Tenant workload is ready. Configure:
+
+- `spec.credsSecret` for RustFS admin credentials.
+- `spec.policies` for canned policies sourced from ConfigMaps.
+- `spec.users` for regular users. Each user must have at least one direct policy mapping.
+- `spec.buckets` for buckets and optional object lock.
+
+ConfigMaps and user Secrets must live in the Tenant namespace. If managed outside the Operator Console, label them with `rustfs.tenant=<tenant-name>` so updates enqueue the owning Tenant.
+
+For each `spec.users[]` entry, the operator reads a Secret with the same name as the user. The Secret must contain `accesskey` and `secretkey`, or the MinIO-compatible keys `CONSOLE_ACCESS_KEY` and `CONSOLE_SECRET_KEY`. If both key formats are present, their values must match. User access keys must be at least 8 characters and must not contain whitespace, `=`, or `,`; user secret keys must be at least 8 characters.
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-policy
+  namespace: storage
+  labels:
+    rustfs.tenant: rustfs-a
+data:
+  policy.json: |
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": ["s3:ListBucket", "s3:GetObject", "s3:PutObject", "s3:DeleteObject"],
+          "Resource": ["arn:aws:s3:::app-data", "arn:aws:s3:::app-data/*"]
+        }
+      ]
+    }
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app-user
+  namespace: storage
+  labels:
+    rustfs.tenant: rustfs-a
+type: Opaque
+stringData:
+  accesskey: appuser01
+  secretkey: appuser01secret
+---
+apiVersion: rustfs.com/v1alpha1
+kind: Tenant
+metadata:
+  name: rustfs-a
+  namespace: storage
+spec:
+  credsSecret:
+    name: rustfs-admin-creds
+  pools:
+    - name: pool-0
+      servers: 1
+      persistence:
+        volumesPerServer: 4
+  policies:
+    - name: app-readwrite
+      document:
+        configMapKeyRef:
+          name: app-policy
+          key: policy.json
+  users:
+    - name: app-user
+      policies:
+        - app-readwrite
+  buckets:
+    - name: app-data
+      objectLock: true
+```
+
+Deletion behavior is conservative: provisioned resources are retained when removed from the Tenant spec.
+
+### 7.9 Pool Lifecycle
+
+`spec.poolLifecycle` controls explicit pool lifecycle requests. The current PVC retention policy is `Retain`.
+
+Example decommission request:
+
+```yaml
+spec:
+  poolLifecycle:
+    pvcRetentionPolicy: Retain
+    decommissionRequests:
+      - poolName: pool-old
+        requestId: decommission-pool-old-20250623
+        action: Start
+        reason: "capacity migrated to pool-new"
+```
+
+Use pool lifecycle operations carefully. Keep a backup and verify RustFS-level decommission behavior before removing capacity.
+
+## 8. Operator Console
+
+The Helm chart enables the Operator Console by default with `console.enabled=true`.
+
+Recommended same-origin deployment:
+
+```yaml
+console:
+  enabled: true
+  ingress:
+    enabled: true
+    className: nginx
+    hosts:
+      - host: console.example.com
+```
+
+The unified operator image serves both `/` and `/api/v1` from the Console service. No backend CORS configuration is needed for this mode.
+
+Console login uses a Kubernetes ServiceAccount bearer token. For the chart-managed Console ServiceAccount:
+
+```bash
+kubectl -n rustfs-system create token rustfs-operator-console --duration=24h
+```
+
+Paste the token into the login form. The Console stores the validated token in an encrypted session cookie.
+
+For local port-forward testing:
+
+```bash
+kubectl -n rustfs-system port-forward svc/rustfs-operator-console 19090:9090
+```
+
+Open `http://127.0.0.1:19090`.
+
+## 9. Operator STS
+
+The operator STS endpoint lets a Kubernetes workload exchange a projected ServiceAccount token for temporary RustFS credentials, authorized by a `PolicyBinding`.
+
+STS route:
+
+```text
+POST /sts/{tenantNamespace}/{tenantName}
+```
+
+Create a `PolicyBinding` in the target Tenant namespace:
+
+```yaml
+apiVersion: sts.rustfs.com/v1alpha1
+kind: PolicyBinding
+metadata:
+  name: reports-readonly
+  namespace: storage
+spec:
+  application:
+    namespace: reports
+    serviceaccount: reports-api
+  policies:
+    - readonly
+```
+
+The workload ServiceAccount token audience must match `sts.audience`, which defaults to `sts.rustfs.com`.
+
+```yaml
+volumes:
+  - name: rustfs-sts-token
+    projected:
+      sources:
+        - serviceAccountToken:
+            path: token
+            audience: sts.rustfs.com
+            expirationSeconds: 3600
+```
+
+Call STS from the workload:
+
+```bash
+TOKEN="$(cat /var/run/secrets/rustfs-sts/token)"
+
+curl -sS -X POST \
+  --cacert /var/run/secrets/rustfs-sts-ca/ca.crt \
+  "https://rustfs-operator-sts.rustfs-system.svc:4223/sts/storage/rustfs-a" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  --data-urlencode "Version=2011-06-15" \
+  --data-urlencode "Action=AssumeRoleWithWebIdentity" \
+  --data-urlencode "WebIdentityToken=${TOKEN}" \
+  --data-urlencode "DurationSeconds=3600"
+```
+
+Current STS constraints:
+
+- STS only issues credentials for TLS-enabled Tenants.
+- Operator STS uses the explicit Tenant route with both namespace and name.
+- The `PolicyBinding` must reference at least one policy.
+- Tenants requiring client certificates for upstream Tenant calls are rejected by Operator STS.
+
+## 10. Monitoring and Status
+
+Check Tenant status:
+
+```bash
+kubectl get tenant -A
+kubectl describe tenant -n <namespace> <tenant>
+```
+
+The operator reports `status.currentState` values such as:
+
+- `Ready`
+- `Reconciling`
+- `Blocked`
+- `Degraded`
+- `NotReady`
+- `Unknown`
+
+Important conditions include:
+
+- `Ready`
+- `Reconciling`
+- `Degraded`
+- `SpecValid`
+- `CredentialsReady`
+- `KmsReady`
+- `TlsReady`
+- `PoolsReady`
+- `WorkloadsReady`
+- `ProvisioningReady`
+
+Check chart-managed observability:
+
+```bash
+kubectl -n rustfs-system port-forward svc/rustfs-operator-metrics 18080:8080
+curl http://127.0.0.1:18080/healthz
+curl http://127.0.0.1:18080/readyz
+curl http://127.0.0.1:18080/metrics
+```
+
+Enable Prometheus Operator integration:
+
+```yaml
+operator:
+  serviceMonitor:
+    enabled: true
+  prometheusRule:
+    enabled: true
+```
+
+## 11. Operations
+
+### Change RustFS Image
+
+```yaml
+spec:
+  image: rustfs/rustfs:v1.0.0
+```
+
+The operator reconciles StatefulSets and reports rollout status in Tenant conditions and pool status.
+
+### Change Storage Capacity
+
+PVC expansion depends on the StorageClass and Kubernetes environment. Do not change immutable pool shape fields (`servers` and `volumesPerServer`) in place. To add capacity, add a new pool when appropriate and follow RustFS decommission and migration procedures.
+
+### Restart Tenant Pods
+
+Use Kubernetes primitives:
+
+```bash
+kubectl rollout restart statefulset -n <namespace> -l rustfs.tenant=<tenant>
+kubectl rollout status statefulset -n <namespace> -l rustfs.tenant=<tenant>
+```
+
+### Rotate Admin Credentials
+
+Update the referenced Secret and restart Tenant StatefulSets so pods consume the new Secret values:
+
+```bash
+kubectl create secret generic rustfs-admin-creds \
+  -n <namespace> \
+  --from-literal=accesskey=<new-access-key> \
+  --from-literal=secretkey=<new-secret-key> \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl rollout restart statefulset -n <namespace> -l rustfs.tenant=<tenant>
+```
+
+## 12. Troubleshooting
+
+### Tenant is Blocked
+
+```bash
+kubectl describe tenant -n <namespace> <tenant>
+kubectl get events -n <namespace> --sort-by=.lastTimestamp
+kubectl logs -n rustfs-system \
+  -l app.kubernetes.io/name=rustfs-operator,app.kubernetes.io/component=operator
+```
+
+Common blocked reasons:
+
+| Reason | Check |
+|--------|-------|
+| `InvalidTenantName` | Tenant name length and DNS-1035 format. |
+| `InvalidPoolSpec` | Pool count, total volume count, pool name, and immutable fields. |
+| `CredentialSecretNotFound` | Secret exists in the Tenant namespace. |
+| `CredentialSecretMissingKey` | Secret contains `accesskey` and `secretkey`. |
+| `CredentialSecretTooShort` | Both credential values are at least 8 characters. |
+| `KmsSecretNotFound` / `KmsSecretMissingKey` | KMS Secret exists and contains required keys such as `vault-token`. |
+| `CertManagerCrdMissing` / `CertManagerIssuerNotFound` | cert-manager is installed and the issuer exists. |
+| `StatefulSetUpdateValidationFailed` | An immutable StatefulSet or pool-shape field was changed. |
+| `ProvisioningFailed` | Check `status.provisioning`, policy ConfigMaps, user Secrets, and RustFS admin credentials. |
+
+### Pods are not Ready
+
+```bash
+kubectl get pods -n <namespace> -l rustfs.tenant=<tenant>
+kubectl describe pod -n <namespace> -l rustfs.tenant=<tenant>
+kubectl logs -n <namespace> -l rustfs.tenant=<tenant>
+```
+
+Check PVC binding, StorageClass availability, image pull errors, node selectors, tolerations, and resource requests.
+
+### S3 API is not reachable
+
+Verify the Tenant S3 service and endpoints:
+
+```bash
+kubectl get svc,endpoints -n <namespace> <tenant>-io
+kubectl port-forward -n <namespace> svc/<tenant>-io 9000:9000
+```
+
+### Console login fails
+
+For the Operator Console, verify the ServiceAccount token and Console logs:
+
+```bash
+kubectl -n rustfs-system create token rustfs-operator-console --duration=24h
+kubectl logs -n rustfs-system \
+  -l app.kubernetes.io/name=rustfs-operator,app.kubernetes.io/component=console
+```
+
+For the RustFS Tenant Console, use the Tenant admin credentials from `spec.credsSecret` or configured RustFS environment variables.
+
+## 13. Best Practices
+
+- Use `spec.credsSecret` or an external secret manager for production credentials.
+- Enable Kubernetes Secret encryption at rest.
+- Use one StorageClass performance class within a Tenant unless you have a deliberate RustFS layout reason.
+- Do not model hot/warm/cold tiers as pools inside one Tenant.
+- Use separate Tenants for separate clusters, administrative boundaries, or performance isolation.
+- Keep the Operator Console on HTTPS in production.
+- Keep `console.jwtSecret` stable for multi-replica Console deployments.
+- Use `ServiceMonitor` and `PrometheusRule` only when Prometheus Operator is installed.
+- Keep Tenant examples under version control, but never commit raw Secret values.
+- Check `status.conditions` before debugging lower-level StatefulSets.
+
+## 14. Related Documentation
+
+- [Project README](../README.md)
+- [Deployment guide](../deploy/README.md)
+- [Helm chart README](../deploy/rustfs-operator/README.md)
+- [Tenant examples](../examples/README.md)
+- [Console frontend README](../console-web/README.md)

--- a/docs/operator-user-guide.zh-CN.md
+++ b/docs/operator-user-guide.zh-CN.md
@@ -1,0 +1,818 @@
+<!--
+Copyright 2025 RustFS Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# RustFS Operator 使用手册
+
+本文档面向需要在 Kubernetes 上部署、配置和运维 RustFS Operator 的用户，作为 Operator 技术使用手册。
+
+English version: [operator-user-guide.md](operator-user-guide.md)
+
+## 1. 概述
+
+RustFS Operator 用于在 Kubernetes 中管理 RustFS 对象存储集群。用户通过命名空间级别的 `Tenant` 自定义资源描述期望的 RustFS 集群，Operator 负责创建和维护运行 RustFS 所需的 Kubernetes 资源。
+
+Operator 提供以下能力：
+
+- `Tenant` CRD（`rustfs.com/v1alpha1`）：声明 RustFS pool、持久化、调度、凭据、TLS、日志、加密和初始化 provisioning。
+- 控制器 reconciliation：维护 Tenant 相关的 RBAC、Service、StatefulSet、PVC 模板、状态条件和 Kubernetes Event。
+- Helm Chart：位于 `deploy/rustfs-operator/`，用于安装 Operator。
+- Operator Console API 和 UI：用于 Operator 管理场景。
+- 可选 Operator STS：基于 Kubernetes 工作负载身份签发临时 RustFS 凭据。
+- 可选 Tenant provisioning：自动创建 RustFS canned policy、普通用户和 bucket。
+- Metrics、健康检查，以及可选 Prometheus Operator 集成。
+
+注意区分以下服务：
+
+| 组件 | 用途 | 默认端口 |
+|------|------|----------|
+| Tenant 内 RustFS S3 API | S3 兼容对象存储访问 | `9000` |
+| RustFS Tenant Console | 单个 RustFS Tenant 的 Web Console | `9001` |
+| Operator Console API/UI | Operator 管理 API 和 UI | `9090` |
+| Operator STS | 临时凭据签发接口 | `4223` |
+| Operator observability endpoint | `/metrics`、`/healthz`、`/readyz` | `8080` |
+
+## 2. 架构模型
+
+一个 `Tenant` 就是一个 RustFS 集群。一个 Tenant 可以包含一个或多个 pool，但同一个 Tenant 内的所有 pool 会组成一个统一的 RustFS 集群，不是冷热分层或性能分层。
+
+如果你需要独立性能、独立生命周期、独立权限边界或独立管理边界，请创建多个 Tenant，而不是在一个 Tenant 内用多个 pool 模拟多个集群。
+
+创建 Tenant 后，Operator 会创建并维护：
+
+- Tenant RBAC 启用时的 ServiceAccount、Role、RoleBinding；
+- headless Service：`{tenant}-hl`，用于 StatefulSet peer DNS；
+- S3 Service：`{tenant}-io`，端口 `9000`；
+- Tenant Console Service：`{tenant}-console`，端口 `9001`；
+- 每个 pool 一个 StatefulSet；
+- PVC 模板：`vol-0`、`vol-1` 等；
+- 自动生成的 RustFS 环境变量，例如 `RUSTFS_VOLUMES`、`RUSTFS_ADDRESS`、`RUSTFS_CONSOLE_ADDRESS` 和 `RUSTFS_CONSOLE_ENABLE`。
+
+## 3. 前置条件
+
+- Kubernetes v1.30 或更高版本。
+- 使用 Helm 安装时需要 Helm 3.0 或更高版本。
+- 可满足 Tenant PVC 的 StorageClass。
+- 已配置目标集群访问权限的 `kubectl`。
+- 能够拉取配置的 Operator 镜像和 RustFS 镜像。
+- 可选：启用 `ServiceMonitor` 或 `PrometheusRule` 时需要 Prometheus Operator。
+- 可选：使用 cert-manager 管理 Tenant TLS 时需要 cert-manager。
+
+## 4. 安装 Operator
+
+使用仓库内 Helm Chart 安装：
+
+```bash
+helm install rustfs-operator deploy/rustfs-operator/ \
+  --namespace rustfs-system \
+  --create-namespace
+```
+
+验证 Operator 和 Console Pod：
+
+```bash
+kubectl get pods -n rustfs-system
+kubectl logs -n rustfs-system \
+  -l app.kubernetes.io/name=rustfs-operator,app.kubernetes.io/component=operator \
+  -f
+```
+
+升级已有安装：
+
+```bash
+helm upgrade rustfs-operator deploy/rustfs-operator/ \
+  --namespace rustfs-system
+```
+
+卸载：
+
+```bash
+helm uninstall rustfs-operator --namespace rustfs-system
+```
+
+## 5. Helm 配置
+
+建议通过 values 文件管理安装配置：
+
+```bash
+helm upgrade --install rustfs-operator deploy/rustfs-operator/ \
+  --namespace rustfs-system \
+  --create-namespace \
+  -f values.yaml
+```
+
+常用配置分组：
+
+| 配置段 | 用途 |
+|--------|------|
+| `operator` | Operator Deployment 副本数、镜像、资源、探针、metrics、调度、leader election 和 Tenant monitor。 |
+| `sts` | Operator STS 端点、Service 端口、TokenReview audience 和 TLS。 |
+| `serviceAccount` / `rbac` | Operator ServiceAccount 和 RBAC 创建策略。 |
+| `console` | Operator Console 后端/UI Deployment、Service、session cookie 密钥、Ingress、资源和可选独立前端。 |
+| `namespace` | Chart 资源命名空间覆盖；默认使用 Helm release namespace。 |
+| `commonLabels` / `commonAnnotations` | 添加到 Chart 管理资源上的统一 label 和 annotation。 |
+
+生产风格 values 示例：
+
+```yaml
+operator:
+  replicas: 2
+  image:
+    repository: registry.example.com/rustfs/operator
+    tag: v0.1.0
+  resources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+  tenantMonitor:
+    enabled: true
+    intervalSeconds: 300
+  serviceMonitor:
+    enabled: true
+
+console:
+  enabled: true
+  replicas: 2
+  jwtSecret: "<stable-base64-or-random-secret>"
+  ingress:
+    enabled: true
+    className: nginx
+    hosts:
+      - host: console.example.com
+
+sts:
+  enabled: true
+  audience: sts.rustfs.com
+  tls:
+    enabled: true
+    auto: true
+```
+
+配置说明：
+
+- `operator.leaderElect` 可以不配置；当 `operator.replicas > 1` 时 Chart 会自动启用 leader election。
+- 多副本 Console 部署需要保持 `console.jwtSecret` 稳定；不设置时 Chart 会生成或复用已有 Secret。
+- 生产环境应使用 HTTPS 并保持 `CONSOLE_COOKIE_SECURE` 启用。仅本地 HTTP 调试时才关闭。
+- `sts.tls.auto=true` 时，Operator 会在缺失时创建 `sts-tls` Secret。
+
+## 6. 创建 Tenant
+
+最小开发 Tenant 示例：
+
+```yaml
+apiVersion: rustfs.com/v1alpha1
+kind: Tenant
+metadata:
+  name: dev-minimal
+  namespace: default
+spec:
+  image: rustfs/rustfs:latest
+  pools:
+    - name: dev-pool
+      servers: 1
+      persistence:
+        volumesPerServer: 4
+```
+
+应用并检查：
+
+```bash
+kubectl apply -f tenant.yaml
+kubectl get tenant dev-minimal
+kubectl get pods,pvc,svc -l rustfs.tenant=dev-minimal
+```
+
+等待 Pod Ready：
+
+```bash
+kubectl wait --for=condition=ready pod \
+  -l rustfs.tenant=dev-minimal \
+  --timeout=300s
+```
+
+访问 Tenant S3 API：
+
+```bash
+kubectl port-forward svc/dev-minimal-io 9000:9000
+```
+
+访问 Tenant Console：
+
+```bash
+kubectl port-forward svc/dev-minimal-console 9001:9001
+```
+
+推荐从 `examples/` 目录选择示例开始：
+
+| 示例 | 使用场景 |
+|------|----------|
+| `examples/minimal-dev-tenant.yaml` | 最小可用开发 Tenant。 |
+| `examples/secret-credentials-tenant.yaml` | 基于 Secret 的管理员凭据。 |
+| `examples/provisioning-tenant.yaml` | 初始化 policy、user 和 bucket。 |
+| `examples/production-ha-tenant.yaml` | 高可用生产风格配置。 |
+| `examples/multi-pool-tenant.yaml` | 一个统一 Tenant 集群内的多 pool 配置。 |
+| `examples/custom-rbac-tenant.yaml` | 自定义 ServiceAccount 和 RBAC。 |
+
+## 7. Tenant 配置说明
+
+### 7.1 Tenant 命名
+
+Tenant 名称必须兼容 DNS-1035，且长度不超过 55 个字符，因为 Operator 会派生 `{tenant}-console` 等 Service 名称。
+
+建议使用小写名称，以字母开头，仅包含小写字母、数字和 `-`。
+
+### 7.2 Pool 配置
+
+`spec.pools` 是必填字段。每个 pool 会创建一个 StatefulSet。
+
+关键字段：
+
+| 字段 | 用途 |
+|------|------|
+| `name` | Pool 名称，用于 label、StatefulSet 名称和 peer DNS。同一个 Tenant 内必须唯一。 |
+| `servers` | 该 pool 的 RustFS Pod 数量。必须大于 `0`。创建后不可变。 |
+| `persistence.volumesPerServer` | 每个 server 挂载的 PVC 数量。必须大于 `0`。创建后不可变。 |
+| `persistence.volumeClaimTemplate` | 每个数据卷的 PVC spec，可设置容量、access mode 和 StorageClass。 |
+| `persistence.path` | 数据卷挂载基础路径。默认 `/data`，最终路径为 `{path}/rustfs0`、`{path}/rustfs1` 等。 |
+| `nodeSelector`、`affinity`、`tolerations`、`topologySpreadConstraints` | Pool 级调度控制。 |
+| `resources` | Pool 容器资源 request 和 limit。 |
+| `priorityClassName` | Pool 级 PriorityClass 覆盖。 |
+
+校验规则：
+
+- `servers * volumesPerServer >= 4`。
+- 当 `servers: 3` 时，总卷数至少为 `6`。
+- Pool 名称必须唯一。
+- Pool peer DNS label 必须满足 Kubernetes DNS label 长度限制。
+- 已存在 pool 的 `servers` 和 `volumesPerServer` 不能原地修改。
+
+示例：
+
+```yaml
+spec:
+  pools:
+    - name: pool-0
+      servers: 4
+      persistence:
+        volumesPerServer: 4
+        volumeClaimTemplate:
+          accessModes: ["ReadWriteOnce"]
+          resources:
+            requests:
+              storage: 100Gi
+          storageClassName: fast-ssd
+      resources:
+        requests:
+          cpu: "2"
+          memory: 8Gi
+        limits:
+          cpu: "4"
+          memory: 16Gi
+```
+
+### 7.3 凭据配置
+
+生产环境建议使用 `spec.credsSecret`。Secret 必须与 Tenant 在同一 namespace，并包含 UTF-8 编码的 `accesskey` 和 `secretkey` 两个 key，两个值长度都至少为 8 个字符。
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rustfs-admin-creds
+  namespace: storage
+type: Opaque
+stringData:
+  accesskey: "replace-with-access-key"
+  secretkey: "replace-with-secret-key"
+---
+apiVersion: rustfs.com/v1alpha1
+kind: Tenant
+metadata:
+  name: rustfs-a
+  namespace: storage
+spec:
+  credsSecret:
+    name: rustfs-admin-creds
+  pools:
+    - name: pool-0
+      servers: 2
+      persistence:
+        volumesPerServer: 2
+```
+
+凭据优先级：
+
+1. `spec.credsSecret`。
+2. `spec.env` 中显式配置 `RUSTFS_ACCESS_KEY` 和 `RUSTFS_SECRET_KEY`。
+3. RustFS 内置默认值。默认值仅适合开发测试。
+
+### 7.4 工作负载配置
+
+常用 Tenant 级字段：
+
+| 字段 | 用途 |
+|------|------|
+| `image` | RustFS server 镜像。未配置时使用 Operator fallback。 |
+| `imagePullSecret` | 镜像拉取 Secret。 |
+| `imagePullPolicy` | RustFS 镜像拉取策略。 |
+| `scheduler` | 自定义 scheduler 名称。 |
+| `env` | 额外 RustFS 容器环境变量。不要覆盖 Operator 自动管理的变量。 |
+| `serviceAccountName` | RustFS Pod 使用的自定义 ServiceAccount。 |
+| `createServiceAccountRbac` | 是否由 Operator 为 Tenant ServiceAccount 创建 Role/RoleBinding。 |
+| `priorityClassName` | Tenant 级 PriorityClass。 |
+| `lifecycle` | Kubernetes 容器 lifecycle hook。 |
+| `podManagementPolicy` | StatefulSet pod management policy。 |
+| `podDeletionPolicyWhenNodeIsDown` | 节点 NotReady/Unknown 时的 Pod 删除策略。 |
+| `securityContext` | RustFS Pod 的 Pod SecurityContext 覆盖。 |
+
+Operator 会自动管理以下环境变量：
+
+- `RUSTFS_VOLUMES`
+- `RUSTFS_ADDRESS`
+- `RUSTFS_CONSOLE_ADDRESS`
+- `RUSTFS_CONSOLE_ENABLE`
+- 启用 TLS 时的 RustFS TLS 相关变量
+
+`podDeletionPolicyWhenNodeIsDown` 支持以下值：
+
+- `DoNothing`：不自动删除 Pod。
+- `Delete`：发起普通 Pod 删除。
+- `ForceDelete`：使用 `gracePeriodSeconds=0` 强制删除 Pod。
+- `DeleteStatefulSetPod`：Longhorn 兼容模式，强制删除 down node 上卡住的 StatefulSet Pod。
+- `DeleteDeploymentPod`：Longhorn 兼容模式，强制删除 down node 上卡住的 Deployment Pod。
+- `DeleteBothStatefulSetAndDeploymentPod`：Longhorn 兼容模式，同时处理 StatefulSet 和 Deployment Pod。
+
+强制删除可能影响数据一致性。只有当存储后端和运维流程明确支持该故障处理方式时才应启用。
+
+### 7.5 TLS
+
+Tenant TLS 通过 `spec.tls` 配置。
+
+关键字段：
+
+| 字段 | 用途 |
+|------|------|
+| `mode` | 当前可用配置为 `disabled` 或 `certManager`。`external` 是保留模式，目前会阻塞 reconcile。 |
+| `mountPath` | TLS 挂载路径。默认 `/var/run/rustfs/tls`。 |
+| `rotationStrategy` | 当前支持 `Rollout`。`HotReload` 会被 CRD 接受，但目前会阻塞 reconcile。 |
+| `enableInternodeHttps` | RustFS 节点间通信是否使用 HTTPS。 |
+| `requireSanMatch` | 是否要求证书 SAN 匹配生成的 DNS 名称。默认 `true`。 |
+| `certManager` | 使用 cert-manager 时的证书配置。`mode: certManager` 必须设置 `secretName`。 |
+
+cert-manager 证书示例：
+
+```yaml
+spec:
+  tls:
+    mode: certManager
+    rotationStrategy: Rollout
+    enableInternodeHttps: true
+    certManager:
+      manageCertificate: true
+      secretName: rustfs-a-server-tls
+      issuerRef:
+        group: cert-manager.io
+        kind: Issuer
+        name: rustfs-issuer
+      includeGeneratedDnsNames: true
+```
+
+当 `manageCertificate: true` 时，`issuerRef` 也是必填项。Operator 会创建或更新 cert-manager `Certificate`，等待引用的 Secret 就绪，校验 `tls.crt` 和 `tls.key`，并在未配置其它 CA trust source 时使用 `ca.crt`。
+
+### 7.6 日志配置
+
+Tenant 日志通过 `spec.logging` 配置。
+
+模式：
+
+| 模式 | 用途 |
+|------|------|
+| `stdout` | 默认且推荐。日志由 Kubernetes 从 stdout/stderr 采集。 |
+| `emptyDir` | 临时本地日志，适合调试；Pod 重启后丢失。 |
+| `persistent` | 使用 PVC 持久化日志。仅应使用独立于 RustFS 的外部存储。 |
+
+不要把 RustFS 启动日志存储到 RustFS 自己里面。这会产生循环依赖：服务启动前对象存储接口尚不可用。
+
+示例：
+
+```yaml
+spec:
+  logging:
+    mode: stdout
+```
+
+### 7.7 加密 / KMS
+
+Tenant 加密通过 `spec.encryption` 配置。
+
+支持的 backend：
+
+| Backend | 用途 |
+|---------|------|
+| `local` | 文件型本地 KMS key 目录。目录必须是绝对路径，且整个 Tenant 所有 pool 的 server 总数必须为 1。 |
+| `vault` | HashiCorp Vault endpoint，需要包含 `vault-token` 的 Secret。 |
+
+Local KMS 不使用 `kmsSecret`；即使设置也会被忽略。多 server Tenant 应使用 Vault KMS。
+
+Vault 示例：
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rustfs-kms
+  namespace: storage
+type: Opaque
+stringData:
+  vault-token: "replace-with-vault-token"
+---
+apiVersion: rustfs.com/v1alpha1
+kind: Tenant
+metadata:
+  name: rustfs-a
+  namespace: storage
+spec:
+  pools:
+    - name: pool-0
+      servers: 2
+      persistence:
+        volumesPerServer: 2
+  encryption:
+    enabled: true
+    backend: vault
+    vault:
+      endpoint: https://vault.example.com:8200
+    kmsSecret:
+      name: rustfs-kms
+    defaultKeyId: tenant-default
+```
+
+### 7.8 初始化 Provisioning
+
+Operator 可以在 Tenant workload Ready 后自动创建 RustFS policy、user 和 bucket。需要配置：
+
+- `spec.credsSecret`：RustFS 管理员凭据。
+- `spec.policies`：从 ConfigMap 读取 policy document。
+- `spec.users`：普通用户。每个 user 必须至少直接绑定一个 policy。
+- `spec.buckets`：bucket，可选择开启 object lock。
+
+ConfigMap 和 user Secret 必须位于 Tenant namespace。若这些资源不是通过 Operator Console 创建，建议添加 label：`rustfs.tenant=<tenant-name>`，这样资源变化可以触发 owning Tenant reconcile。
+
+每个 `spec.users[]` 条目都会读取一个与 user 名同名的 Secret。Secret 必须包含 `accesskey` 和 `secretkey`，或者 MinIO 兼容 key：`CONSOLE_ACCESS_KEY` 和 `CONSOLE_SECRET_KEY`。如果两种 key 同时存在，值必须一致。user access key 至少 8 个字符，且不能包含空白、`=` 或 `,`；user secret key 至少 8 个字符。
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-policy
+  namespace: storage
+  labels:
+    rustfs.tenant: rustfs-a
+data:
+  policy.json: |
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": ["s3:ListBucket", "s3:GetObject", "s3:PutObject", "s3:DeleteObject"],
+          "Resource": ["arn:aws:s3:::app-data", "arn:aws:s3:::app-data/*"]
+        }
+      ]
+    }
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app-user
+  namespace: storage
+  labels:
+    rustfs.tenant: rustfs-a
+type: Opaque
+stringData:
+  accesskey: appuser01
+  secretkey: appuser01secret
+---
+apiVersion: rustfs.com/v1alpha1
+kind: Tenant
+metadata:
+  name: rustfs-a
+  namespace: storage
+spec:
+  credsSecret:
+    name: rustfs-admin-creds
+  pools:
+    - name: pool-0
+      servers: 1
+      persistence:
+        volumesPerServer: 4
+  policies:
+    - name: app-readwrite
+      document:
+        configMapKeyRef:
+          name: app-policy
+          key: policy.json
+  users:
+    - name: app-user
+      policies:
+        - app-readwrite
+  buckets:
+    - name: app-data
+      objectLock: true
+```
+
+删除行为是保守的：从 Tenant spec 移除已 provisioning 的资源时，实际 RustFS 资源会保留。
+
+### 7.9 Pool 生命周期
+
+`spec.poolLifecycle` 用于显式 pool 生命周期请求。当前 PVC retention policy 为 `Retain`。
+
+Decommission 请求示例：
+
+```yaml
+spec:
+  poolLifecycle:
+    pvcRetentionPolicy: Retain
+    decommissionRequests:
+      - poolName: pool-old
+        requestId: decommission-pool-old-20250623
+        action: Start
+        reason: "capacity migrated to pool-new"
+```
+
+Pool 生命周期操作需要谨慎执行。操作前应确认备份，并验证 RustFS 层面的 decommission 行为。
+
+## 8. Operator Console
+
+Helm Chart 默认启用 Operator Console：`console.enabled=true`。
+
+推荐同源部署：
+
+```yaml
+console:
+  enabled: true
+  ingress:
+    enabled: true
+    className: nginx
+    hosts:
+      - host: console.example.com
+```
+
+统一 Operator 镜像会通过同一个 Console Service 提供 `/` 和 `/api/v1`。该模式不需要后端 CORS 配置。
+
+Console 登录需要 Kubernetes ServiceAccount bearer token。Chart 管理的 Console ServiceAccount 可以这样生成短期 token：
+
+```bash
+kubectl -n rustfs-system create token rustfs-operator-console --duration=24h
+```
+
+将 token 粘贴到 Console 登录页。Console 会把验证后的 token 存入加密 session cookie。
+
+本地 port-forward 调试：
+
+```bash
+kubectl -n rustfs-system port-forward svc/rustfs-operator-console 19090:9090
+```
+
+浏览器打开 `http://127.0.0.1:19090`。
+
+## 9. Operator STS
+
+Operator STS 允许 Kubernetes workload 使用 projected ServiceAccount token 换取临时 RustFS 凭据，权限由 `PolicyBinding` 控制。
+
+STS 路由：
+
+```text
+POST /sts/{tenantNamespace}/{tenantName}
+```
+
+在目标 Tenant namespace 创建 `PolicyBinding`：
+
+```yaml
+apiVersion: sts.rustfs.com/v1alpha1
+kind: PolicyBinding
+metadata:
+  name: reports-readonly
+  namespace: storage
+spec:
+  application:
+    namespace: reports
+    serviceaccount: reports-api
+  policies:
+    - readonly
+```
+
+workload ServiceAccount token 的 audience 必须匹配 `sts.audience`，默认是 `sts.rustfs.com`。
+
+```yaml
+volumes:
+  - name: rustfs-sts-token
+    projected:
+      sources:
+        - serviceAccountToken:
+            path: token
+            audience: sts.rustfs.com
+            expirationSeconds: 3600
+```
+
+workload 内调用 STS：
+
+```bash
+TOKEN="$(cat /var/run/secrets/rustfs-sts/token)"
+
+curl -sS -X POST \
+  --cacert /var/run/secrets/rustfs-sts-ca/ca.crt \
+  "https://rustfs-operator-sts.rustfs-system.svc:4223/sts/storage/rustfs-a" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  --data-urlencode "Version=2011-06-15" \
+  --data-urlencode "Action=AssumeRoleWithWebIdentity" \
+  --data-urlencode "WebIdentityToken=${TOKEN}" \
+  --data-urlencode "DurationSeconds=3600"
+```
+
+当前 STS 约束：
+
+- STS 只为启用 TLS 的 Tenant 签发凭据。
+- Operator STS 使用显式 Tenant 路由，路径中同时包含 namespace 和 Tenant name。
+- `PolicyBinding` 至少需要引用一个 policy。
+- 如果 Tenant 要求 Operator STS 调用 Tenant 时使用 client certificate，目前会被 Operator STS 拒绝。
+
+## 10. 监控和状态
+
+查看 Tenant 状态：
+
+```bash
+kubectl get tenant -A
+kubectl describe tenant -n <namespace> <tenant>
+```
+
+`status.currentState` 常见值：
+
+- `Ready`
+- `Reconciling`
+- `Blocked`
+- `Degraded`
+- `NotReady`
+- `Unknown`
+
+重要 condition：
+
+- `Ready`
+- `Reconciling`
+- `Degraded`
+- `SpecValid`
+- `CredentialsReady`
+- `KmsReady`
+- `TlsReady`
+- `PoolsReady`
+- `WorkloadsReady`
+- `ProvisioningReady`
+
+查看 Chart 管理的 observability endpoint：
+
+```bash
+kubectl -n rustfs-system port-forward svc/rustfs-operator-metrics 18080:8080
+curl http://127.0.0.1:18080/healthz
+curl http://127.0.0.1:18080/readyz
+curl http://127.0.0.1:18080/metrics
+```
+
+启用 Prometheus Operator 集成：
+
+```yaml
+operator:
+  serviceMonitor:
+    enabled: true
+  prometheusRule:
+    enabled: true
+```
+
+## 11. 运维操作
+
+### 修改 RustFS 镜像
+
+```yaml
+spec:
+  image: rustfs/rustfs:v1.0.0
+```
+
+Operator 会 reconcile StatefulSet，并通过 Tenant condition 和 pool status 报告 rollout 状态。
+
+### 修改存储容量
+
+PVC 扩容取决于 StorageClass 和 Kubernetes 环境。不要原地修改不可变的 pool 形态字段（`servers` 和 `volumesPerServer`）。需要扩容时，可按需新增 pool，并结合 RustFS decommission 和迁移流程操作。
+
+### 重启 Tenant Pod
+
+使用 Kubernetes 原生命令：
+
+```bash
+kubectl rollout restart statefulset -n <namespace> -l rustfs.tenant=<tenant>
+kubectl rollout status statefulset -n <namespace> -l rustfs.tenant=<tenant>
+```
+
+### 轮换管理员凭据
+
+更新引用的 Secret，然后重启 Tenant StatefulSet，让 Pod 读取新 Secret：
+
+```bash
+kubectl create secret generic rustfs-admin-creds \
+  -n <namespace> \
+  --from-literal=accesskey=<new-access-key> \
+  --from-literal=secretkey=<new-secret-key> \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl rollout restart statefulset -n <namespace> -l rustfs.tenant=<tenant>
+```
+
+## 12. 故障排查
+
+### Tenant 处于 Blocked
+
+```bash
+kubectl describe tenant -n <namespace> <tenant>
+kubectl get events -n <namespace> --sort-by=.lastTimestamp
+kubectl logs -n rustfs-system \
+  -l app.kubernetes.io/name=rustfs-operator,app.kubernetes.io/component=operator
+```
+
+常见 blocked reason：
+
+| Reason | 检查项 |
+|--------|--------|
+| `InvalidTenantName` | Tenant 名称长度和 DNS-1035 格式。 |
+| `InvalidPoolSpec` | Pool 数量、总卷数、pool 名称和不可变字段。 |
+| `CredentialSecretNotFound` | Secret 是否存在于 Tenant namespace。 |
+| `CredentialSecretMissingKey` | Secret 是否包含 `accesskey` 和 `secretkey`。 |
+| `CredentialSecretTooShort` | 两个凭据值是否都至少 8 个字符。 |
+| `KmsSecretNotFound` / `KmsSecretMissingKey` | KMS Secret 是否存在，并包含 `vault-token` 等必要 key。 |
+| `CertManagerCrdMissing` / `CertManagerIssuerNotFound` | cert-manager 是否安装，issuer 是否存在。 |
+| `StatefulSetUpdateValidationFailed` | 是否修改了不可变 StatefulSet 字段或 pool 形态字段。 |
+| `ProvisioningFailed` | 检查 `status.provisioning`、policy ConfigMap、user Secret 和 RustFS 管理员凭据。 |
+
+### Pod 没有 Ready
+
+```bash
+kubectl get pods -n <namespace> -l rustfs.tenant=<tenant>
+kubectl describe pod -n <namespace> -l rustfs.tenant=<tenant>
+kubectl logs -n <namespace> -l rustfs.tenant=<tenant>
+```
+
+重点检查 PVC 绑定、StorageClass、镜像拉取、node selector、toleration 和资源 request。
+
+### S3 API 不可访问
+
+检查 Tenant S3 Service 和 endpoints：
+
+```bash
+kubectl get svc,endpoints -n <namespace> <tenant>-io
+kubectl port-forward -n <namespace> svc/<tenant>-io 9000:9000
+```
+
+### Console 登录失败
+
+Operator Console 登录失败时，检查 ServiceAccount token 和 Console 日志：
+
+```bash
+kubectl -n rustfs-system create token rustfs-operator-console --duration=24h
+kubectl logs -n rustfs-system \
+  -l app.kubernetes.io/name=rustfs-operator,app.kubernetes.io/component=console
+```
+
+RustFS Tenant Console 登录失败时，应使用 `spec.credsSecret` 或 RustFS 环境变量中配置的 Tenant 管理员凭据。
+
+## 13. 最佳实践
+
+- 生产环境使用 `spec.credsSecret` 或外部 Secret 管理系统。
+- 开启 Kubernetes Secret at-rest encryption。
+- 同一个 Tenant 内尽量使用同一性能等级的 StorageClass，除非你明确理解 RustFS 布局影响。
+- 不要把一个 Tenant 内的多个 pool 当作冷热分层。
+- 独立集群、独立管理边界或独立性能隔离应使用多个 Tenant。
+- 生产环境 Operator Console 使用 HTTPS。
+- 多副本 Console 部署保持 `console.jwtSecret` 稳定。
+- 仅在安装 Prometheus Operator 后启用 `ServiceMonitor` 和 `PrometheusRule`。
+- Tenant YAML 可以进入版本控制，但不要提交明文 Secret 值。
+- 优先查看 `status.conditions`，再进一步排查 StatefulSet 和 Pod。
+
+## 14. 相关文档
+
+- [项目 README](../README.md)
+- [部署入口文档](../deploy/README.md)
+- [Helm Chart README](../deploy/rustfs-operator/README.md)
+- [Tenant 示例](../examples/README.md)
+- [Console 前端 README](../console-web/README.md)


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [x] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
N/A

## Summary of Changes
- Add English and Chinese RustFS Operator user guides under `docs/`.
- Document installation, Helm values, Tenant configuration, Console, STS, monitoring, operations, and troubleshooting.
- Clarify current TLS, KMS, provisioning, credential, and operational constraints with copyable examples.
- Allow the new guide files through `.gitignore` while keeping other generated docs outputs ignored.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit` (fmt-check + clippy + test + console-lint + console-fmt-check)
- [ ] Added/updated necessary tests
- [x] Documentation updated (if needed)
- [ ] CHANGELOG.md updated under `[Unreleased]` (if user-visible change)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (CRD/API compatibility)
- [x] Requires doc/config/deployment update
- [ ] Other impact:

## Verification
```bash
git diff --check
make pre-commit
```

## Additional Notes
N/A

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
