### PR TITLE
feat: allow RustFS to validate tenant storage layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RustFS Kubernetes Operator
 
-A Kubernetes operator for [RustFS](https://rustfs.com/) object storage, written in Rust with [kube-rs](https://github.com/kube-rs/kube). It reconciles a **`Tenant` custom resource** (`rustfs.com/v1alpha1`), validates referenced credential and KMS Secrets, and applies RBAC, Services, and StatefulSets so RustFS runs as an erasure-coded cluster inside your cluster.
+A Kubernetes operator for [RustFS](https://rustfs.com/) object storage, written in Rust with [kube-rs](https://github.com/kube-rs/kube). It reconciles a **`Tenant` custom resource** (`rustfs.com/v1alpha1`), validates referenced credential and KMS Secrets, and applies RBAC, Services, and StatefulSets so RustFS runs inside your cluster, from single-node single-disk development tenants to erasure-coded distributed clusters.
 
 **Status:** v0.1.0 pre-release — under active development.
 

--- a/console-web/app/(dashboard)/tenants/new/page.tsx
+++ b/console-web/app/(dashboard)/tenants/new/page.tsx
@@ -31,8 +31,8 @@ const DEFAULT_RUSTFS_IMAGE = "rustfs/rustfs:latest"
 
 const defaultPool: CreatePoolRequest = {
   name: "pool-0",
-  servers: 2,
-  volumes_per_server: 2,
+  servers: 1,
+  volumes_per_server: 1,
   storage_size: "10Gi",
   storage_class: "",
 }
@@ -48,9 +48,9 @@ spec:
     name: rustfs-creds
   pools:
     - name: pool-0
-      servers: 2
+      servers: 1
       persistence:
-        volumesPerServer: 2
+        volumesPerServer: 1
         volumeClaimTemplate:
           accessModes:
             - ReadWriteOnce
@@ -474,9 +474,7 @@ export default function TenantCreatePage() {
               <CardHeader className="flex flex-row items-center justify-between">
                 <div>
                   <CardTitle className="text-base">{t("Pools")}</CardTitle>
-                  <CardDescription>
-                    {t("At least one pool with 4+ volumes (e.g. 2 servers × 2 volumes).")}
-                  </CardDescription>
+                  <CardDescription>{t("RustFS validates storage layout when the tenant starts.")}</CardDescription>
                 </div>
                 <Button type="button" variant="outline" size="sm" onClick={addPool}>
                   {t("Add Pool")}

--- a/console-web/i18n/locales/en-US.json
+++ b/console-web/i18n/locales/en-US.json
@@ -120,7 +120,7 @@
   "Optional": "Optional",
   "Image": "Image",
   "Credentials Secret": "Credentials Secret",
-  "At least one pool with 4+ volumes (e.g. 2 servers × 2 volumes).": "At least one pool with 4+ volumes (e.g. 2 servers × 2 volumes).",
+  "RustFS validates storage layout when the tenant starts.": "RustFS validates storage layout when the tenant starts.",
   "Add Pool": "Add Pool",
   "Pool": "Pool",
   "Remove": "Remove",

--- a/console-web/i18n/locales/zh-CN.json
+++ b/console-web/i18n/locales/zh-CN.json
@@ -120,7 +120,7 @@
   "Optional": "可选",
   "Image": "镜像",
   "Credentials Secret": "凭证 Secret",
-  "At least one pool with 4+ volumes (e.g. 2 servers × 2 volumes).": "至少一个池且总卷数不少于 4（例如 2 服务器 × 2 卷）。",
+  "RustFS validates storage layout when the tenant starts.": "RustFS 会在 Tenant 启动时校验存储布局。",
   "Add Pool": "添加存储池",
   "Pool": "存储池",
   "Remove": "移除",

--- a/deploy/rustfs-operator/crds/tenant-crd.yaml
+++ b/deploy/rustfs-operator/crds/tenant-crd.yaml
@@ -1356,13 +1356,6 @@ spec:
                   - persistence
                   - servers
                   type: object
-                  x-kubernetes-validations:
-                  - messageExpression: '"pool " + self.name + " must have at least 4 total volumes (servers × volumesPerServer)"'
-                    reason: FieldValueInvalid
-                    rule: self.servers * self.persistence.volumesPerServer >= 4
-                  - messageExpression: '"pool " + self.name + " with 3 servers must have at least 6 volumes in total"'
-                    reason: FieldValueInvalid
-                    rule: self.servers != 3 || self.servers * self.persistence.volumesPerServer >= 6
                 maxItems: 32
                 minItems: 1
                 type: array

--- a/deploy/rustfs-operator/crds/tenant.yaml
+++ b/deploy/rustfs-operator/crds/tenant.yaml
@@ -1356,13 +1356,6 @@ spec:
                   - persistence
                   - servers
                   type: object
-                  x-kubernetes-validations:
-                  - messageExpression: '"pool " + self.name + " must have at least 4 total volumes (servers × volumesPerServer)"'
-                    reason: FieldValueInvalid
-                    rule: self.servers * self.persistence.volumesPerServer >= 4
-                  - messageExpression: '"pool " + self.name + " with 3 servers must have at least 6 volumes in total"'
-                    reason: FieldValueInvalid
-                    rule: self.servers != 3 || self.servers * self.persistence.volumesPerServer >= 6
                 maxItems: 32
                 minItems: 1
                 type: array

--- a/docs/operator-user-guide.md
+++ b/docs/operator-user-guide.md
@@ -184,7 +184,7 @@ spec:
     - name: dev-pool
       servers: 1
       persistence:
-        volumesPerServer: 4
+        volumesPerServer: 1
 ```
 
 Apply and verify:
@@ -251,13 +251,14 @@ Key fields:
 | `resources` | Container resource requests and limits for the pool. |
 | `priorityClassName` | Pool-level priority class override. |
 
-Validation rules:
+Operator admission checks:
 
-- `servers * volumesPerServer >= 4`.
-- For `servers: 3`, total volumes must be at least `6`.
+- `servers` and `persistence.volumesPerServer` must be greater than `0`.
 - Pool names must be unique.
 - Pool peer DNS labels must fit Kubernetes DNS label limits.
 - Existing pool `servers` and `volumesPerServer` cannot be changed in place.
+
+The operator does not validate whether a RustFS storage layout, erasure set size, or storage class parity is supported. RustFS performs those checks when the Tenant workload starts.
 
 Example:
 
@@ -345,6 +346,8 @@ The operator reserves these environment variables and manages them automatically
 - `RUSTFS_CONSOLE_ADDRESS`
 - `RUSTFS_CONSOLE_ENABLE`
 - TLS-related RustFS variables when Tenant TLS is enabled.
+
+For a single-pool single-node single-disk Tenant, `RUSTFS_VOLUMES` is rendered as the local data path, for example `/data/rustfs0`. Multi-pool tenants and other layouts render peer DNS URLs through the Tenant headless Service and are validated by RustFS at runtime.
 
 `podDeletionPolicyWhenNodeIsDown` accepts:
 

--- a/docs/operator-user-guide.zh-CN.md
+++ b/docs/operator-user-guide.zh-CN.md
@@ -186,7 +186,7 @@ spec:
     - name: dev-pool
       servers: 1
       persistence:
-        volumesPerServer: 4
+        volumesPerServer: 1
 ```
 
 应用并检查：
@@ -253,13 +253,14 @@ Tenant 名称必须兼容 DNS-1035，且长度不超过 55 个字符，因为 Op
 | `resources` | Pool 容器资源 request 和 limit。 |
 | `priorityClassName` | Pool 级 PriorityClass 覆盖。 |
 
-校验规则：
+Operator admission 检查：
 
-- `servers * volumesPerServer >= 4`。
-- 当 `servers: 3` 时，总卷数至少为 `6`。
+- `servers` 和 `persistence.volumesPerServer` 必须大于 `0`。
 - Pool 名称必须唯一。
 - Pool peer DNS label 必须满足 Kubernetes DNS label 长度限制。
 - 已存在 pool 的 `servers` 和 `volumesPerServer` 不能原地修改。
+
+Operator 不校验 RustFS 存储布局、erasure set 大小或 storage class parity 是否被支持。这些检查由 Tenant workload 启动后的 RustFS 自行完成。
 
 示例：
 
@@ -347,6 +348,8 @@ Operator 会自动管理以下环境变量：
 - `RUSTFS_CONSOLE_ADDRESS`
 - `RUSTFS_CONSOLE_ENABLE`
 - 启用 TLS 时的 RustFS TLS 相关变量
+
+对于单 pool 的单节点单盘 Tenant，`RUSTFS_VOLUMES` 会渲染为本地数据路径，例如 `/data/rustfs0`。多 pool Tenant 和其他布局仍会通过 Tenant headless Service 渲染 peer DNS URL，并由 RustFS 在运行时校验。
 
 `podDeletionPolicyWhenNodeIsDown` 支持以下值：
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,7 @@ This directory contains example Tenant configurations for the RustFS Kubernetes 
 
 | Example | Use Case | Complexity | Storage | Best For |
 |---------|----------|------------|---------|----------|
-| [minimal-dev-tenant.yaml](./minimal-dev-tenant.yaml) | Development/Learning | ⭐ Simple | 40Gi | **Start here** if new |
+| [minimal-dev-tenant.yaml](./minimal-dev-tenant.yaml) | Development/Learning | ⭐ Simple | 10Gi | **Start here** if new |
 | [simple-tenant.yaml](./simple-tenant.yaml) | Documentation Reference | ⭐⭐ Moderate | Configurable | Learning all options |
 | [secret-credentials-tenant.yaml](./secret-credentials-tenant.yaml) | Secret-based Credentials | ⭐ Simple | Configurable | **Production credential security** |
 | [provisioning-tenant.yaml](./provisioning-tenant.yaml) | Policy/User/Bucket Provisioning | ⭐⭐ Moderate | 40Gi | Tenant bootstrap automation |
@@ -46,8 +46,8 @@ This directory contains example Tenant configurations for the RustFS Kubernetes 
 **Smallest valid configuration** for learning, testing, and local development.
 
 **Configuration:**
-- 1 server × 4 volumes = 4 total volumes (minimum valid)
-- 40Gi total storage (4 × 10Gi default)
+- 1 server × 1 volume = 1 total volume (single-node single-disk)
+- 10Gi total storage (1 × 10Gi default)
 - Debug logging enabled
 
 **Use case:** Local development, learning the operator, quick testing.
@@ -64,7 +64,7 @@ kubectl apply -f examples/minimal-dev-tenant.yaml
 Single-pool tenant with **comprehensive comments** explaining all available options.
 
 **Features demonstrated:**
-- Basic pool configuration with validation
+- Basic pool configuration and admission checks
 - Persistence settings with volume claim templates
 - Custom labels and annotations for PVCs
 - Environment variable configuration
@@ -369,7 +369,6 @@ spec:
       servers: <number>              # Must be > 0
       persistence:
         volumesPerServer: <number>   # Must be > 0
-        # Validation: servers * volumesPerServer >= 4
 
   # Optional fields
   env: [...]
@@ -378,31 +377,22 @@ spec:
   # ... see Tenant CRD for all fields
 ```
 
-## Validation Rules
+## Admission Checks
 
 ### Pool Requirements
 
-- **Minimum total volumes**: `servers * volumesPerServer >= 4` (RustFS erasure coding requirement)
-- **Three-server pools**: `servers * volumesPerServer >= 6` (stricter than the general minimum)
 - **Server count**: Must be > 0
 - **Volumes per server**: Must be > 0
 - **Pool name**: Must not be empty
 
-These rules are enforced by the Tenant CRD (CEL) and the operator console API.
+The operator intentionally does not validate RustFS storage topology, erasure set sizing, or parity compatibility. Those checks are left to RustFS when the Tenant starts.
 
-### Valid Examples
+### Layout Examples
 
-✅ `servers: 4, volumesPerServer: 1` → 4 total volumes
-✅ `servers: 2, volumesPerServer: 2` → 4 total volumes
-✅ `servers: 3, volumesPerServer: 2` → 6 total volumes (minimum for 3 servers)
-✅ `servers: 4, volumesPerServer: 4` → 16 total volumes
-
-### Invalid Examples
-
-❌ `servers: 2, volumesPerServer: 1` → 2 total volumes (< 4)
-❌ `servers: 1, volumesPerServer: 1` → 1 total volume (< 4)
-❌ `servers: 3, volumesPerServer: 1` → 3 total volumes (< 6 for 3 servers)
-❌ `servers: 0, volumesPerServer: 4` → Server count must be > 0
+- `servers: 1, volumesPerServer: 1` → single-node single-disk style
+- `servers: 2, volumesPerServer: 1` → passed through to RustFS
+- `servers: 3, volumesPerServer: 1` → passed through to RustFS
+- `servers: 4, volumesPerServer: 4` → distributed style
 
 ## Common Configurations
 
@@ -414,7 +404,7 @@ spec:
     - name: dev
       servers: 1
       persistence:
-        volumesPerServer: 4  # 1 * 4 = 4 (minimum valid)
+        volumesPerServer: 1  # single-node single-disk
 ```
 
 ### Production (High Availability)
@@ -511,9 +501,9 @@ kubectl logs -n rustfs-system -l app=rustfs-operator
 ### Validation Errors
 
 Common issues:
-- Pool validation: Ensure `servers * volumesPerServer >= 4`
 - Empty pool name
 - Zero servers or volumes
+- RustFS rejecting an unsupported storage layout after the Tenant starts
 
 ### Pods Not Starting
 

--- a/examples/minimal-dev-tenant.yaml
+++ b/examples/minimal-dev-tenant.yaml
@@ -5,11 +5,11 @@
 #
 # Resources created:
 # - 1 StatefulSet with 1 replica
-# - 4 PVCs (1 server × 4 volumes)
+# - 1 PVC (1 server × 1 volume)
 # - 3 Services (IO at 9000, Console at 9001, Headless)
 # - RBAC resources (Role, ServiceAccount, RoleBinding)
 #
-# Total storage: 40Gi (4 volumes × 10Gi default)
+# Total storage: 10Gi (1 volume × 10Gi default)
 
 apiVersion: rustfs.com/v1alpha1
 kind: Tenant
@@ -22,14 +22,14 @@ spec:
   # Container image (optional - uses operator default if not specified)
   image: rustfs/rustfs:latest
 
-  # Minimal pool configuration
-  # servers * volumesPerServer must be >= 4 (RustFS erasure coding requirement)
-  # This uses: 1 server × 4 volumes = 4 total volumes (minimum valid)
+  # Minimal pool configuration.
+  # A single-node single-disk Tenant is expressed as 1 server × 1 volume.
+  # Other storage layouts are passed through to RustFS for validation at startup.
   pools:
     - name: dev-pool
       servers: 1  # Single server for development
       persistence:
-        volumesPerServer: 4  # Minimum 4 volumes required
+        volumesPerServer: 1  # Single PVC; RustFS uses no erasure parity
 
         # Optional: Reduce storage size for development
         # volumeClaimTemplate:
@@ -61,7 +61,7 @@ spec:
 #   kubectl wait --for=condition=ready pod -l rustfs.tenant=dev-minimal --timeout=300s
 
 # 4. Access S3 API (port 9000):
-#   kubectl port-forward svc/rustfs 9000:9000
+#   kubectl port-forward svc/dev-minimal-io 9000:9000
 #   # Test: aws --endpoint-url http://localhost:9000 s3 ls
 
 # 5. Access Console UI (port 9001):
@@ -74,10 +74,10 @@ spec:
 #     -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="RUSTFS_VOLUMES")].value}'
 #
 # Output will be:
-#   http://dev-minimal-dev-pool-0.dev-minimal-hl.default.svc.cluster.local:9000/data/rustfs{0...3}
+#   /data/rustfs0
 #
-# This tells RustFS to use 4 volumes at paths:
-#   /data/rustfs0, /data/rustfs1, /data/rustfs2, /data/rustfs3
+# This tells RustFS to use one local volume at:
+#   /data/rustfs0
 
 # 7. Test with MinIO client:
 #   mc alias set devlocal http://localhost:9000 rustfsadmin rustfsadmin

--- a/examples/simple-tenant.yaml
+++ b/examples/simple-tenant.yaml
@@ -12,15 +12,14 @@ spec:
   podManagementPolicy: Parallel
 
   # Pool configuration - at least one pool is required
-  # Each pool must have: servers * volumesPerServer >= 4
+  # RustFS validates whether the requested storage layout is supported at startup.
   pools:
     - name: primary
       servers: 2
 
       # Persistence configuration for storage (REQUIRED)
-      # Note: servers * volumesPerServer must be >= 4 for RustFS distributed storage
       persistence:
-        # Number of volumes per server (REQUIRED, must satisfy servers * volumesPerServer >= 4)
+        # Number of volumes per server (REQUIRED)
         volumesPerServer: 2
 
         # Optional: Path where volumes will be mounted in the container (defaults to /data)
@@ -99,9 +98,10 @@ spec:
       # Optional: Priority class - overrides tenant-level priority
       # priorityClassName: high-priority
 
-  # Multi-Node Communication (Automatic)
+  # Volume Configuration (Automatic)
   # The operator automatically generates the RUSTFS_VOLUMES environment variable
-  # for multi-node, multi-disk distributed storage communication.
+  # for the selected layout. Single-pool single-node single-disk tenants use a
+  # local path, while multi-pool and distributed layouts use peer DNS.
   #
   # For this configuration, the generated RUSTFS_VOLUMES will be:
   # http://example-tenant-primary-{0...1}.example-tenant-hl.rustfs-system.svc.cluster.local:9000/data/rustfs{0...1}

--- a/examples/spot-instance-tenant.yaml
+++ b/examples/spot-instance-tenant.yaml
@@ -294,7 +294,7 @@ spec:
 # Best Practices:
 
 # 1. Maintain minimum on-demand capacity:
-#    - At least servers × volumesPerServer >= 4 on on-demand
+#    - Keep enough on-demand RustFS capacity for the layout you choose
 #    - Ensures cluster survives even if all spot instances interrupted
 
 # 2. Use topology spread for spot pools:

--- a/examples/tenant-4nodes.yaml
+++ b/examples/tenant-4nodes.yaml
@@ -1,5 +1,5 @@
 # RustFS Tenant - 4-node distributed deployment (Kind multi-node + local storage)
-# Architecture: 4 servers x 2 volumes = 8 drives (servers * volumesPerServer >= 4)
+# Architecture: 4 servers x 2 volumes = 8 drives
 # Requires: kind-rustfs-cluster (3 workers), StorageClass local-storage, 12 PVs
 apiVersion: rustfs.com/v1alpha1
 kind: Tenant

--- a/src/console/handlers/pools.rs
+++ b/src/console/handlers/pools.rs
@@ -24,10 +24,7 @@ use crate::console::{
 };
 use crate::types::v1alpha1::{
     persistence::PersistenceConfig,
-    pool::{
-        Pool, SchedulingConfig, validate_pool_collection, validate_pool_name,
-        validate_pool_total_volumes,
-    },
+    pool::{Pool, SchedulingConfig, validate_pool_collection, validate_pool_name},
     pool_lifecycle::{
         DecommissionAction, DecommissionRequest, PoolLifecycleSpec, PvcRetentionPolicy,
     },
@@ -65,12 +62,6 @@ fn is_valid_k8s_quantity(s: &str) -> bool {
         }
     }
     true
-}
-
-/// Validate pool volume count (same rules as CRD CEL on [`Pool`] and [`validate_pool_total_volumes`]).
-fn validate_pool_volumes(servers: i32, volumes_per_server: i32) -> Result<i32> {
-    validate_pool_total_volumes(servers, volumes_per_server)
-        .map_err(|message| Error::BadRequest { message })
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -578,7 +569,7 @@ pub async fn add_pool(
             ),
         });
     }
-    let total_volumes = validate_pool_volumes(req.servers, req.volumes_per_server)?;
+    let total_volumes = req.servers.saturating_mul(req.volumes_per_server);
 
     // Build Pool spec
     let new_pool = Pool {
@@ -669,9 +660,7 @@ pub async fn add_pool(
 
         remove_decommission_request(&mut tenant, pool_name);
         tenant.spec.pools.push(new_pool.clone());
-        if let Err(message) =
-            validate_pool_collection(&tenant.name_any(), &tenant.spec.pools, &tenant.spec.env)
-        {
+        if let Err(message) = validate_pool_collection(&tenant.name_any(), &tenant.spec.pools) {
             return Err(Error::BadRequest { message });
         }
 

--- a/src/types/v1alpha1.rs
+++ b/src/types/v1alpha1.rs
@@ -25,7 +25,7 @@ pub mod tenant;
 pub mod tls;
 
 // Re-export commonly used types
-pub use pool::{SchedulingConfig, validate_pool_total_volumes};
+pub use pool::SchedulingConfig;
 
 #[cfg(test)]
 mod policy_binding_tests {

--- a/src/types/v1alpha1/persistence.rs
+++ b/src/types/v1alpha1/persistence.rs
@@ -40,7 +40,7 @@ pub struct PersistenceConfig {
 impl Default for PersistenceConfig {
     fn default() -> Self {
         Self {
-            volumes_per_server: 4, // Default to 4 volumes to satisfy validation (must be > 0)
+            volumes_per_server: 4, // Must be > 0 when serialized into a Tenant spec.
             volume_claim_template: None,
             path: None,
             labels: None,

--- a/src/types/v1alpha1/pool.rs
+++ b/src/types/v1alpha1/pool.rs
@@ -19,12 +19,6 @@ use std::collections::HashSet;
 
 use crate::types::v1alpha1::persistence::PersistenceConfig;
 
-const RUSTFS_ERASURE_SET_SIZES: &[usize] = &[2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
-const RUSTFS_ERASURE_SET_DRIVE_COUNT_ENV: &str = "RUSTFS_ERASURE_SET_DRIVE_COUNT";
-const RUSTFS_STORAGE_CLASS_STANDARD_ENV: &str = "RUSTFS_STORAGE_CLASS_STANDARD";
-const RUSTFS_STORAGE_CLASS_RRS_ENV: &str = "RUSTFS_STORAGE_CLASS_RRS";
-const DEFAULT_RRS_PARITY: usize = 1;
-
 /// Kubernetes scheduling and placement configuration for pools.
 /// Groups related scheduling fields for better code organization.
 /// Uses #[serde(flatten)] to maintain flat YAML structure.
@@ -58,14 +52,6 @@ pub struct SchedulingConfig {
 
 #[derive(Deserialize, Serialize, Clone, Debug, KubeSchema)]
 #[serde(rename_all = "camelCase")]
-#[x_kube(validation = Rule::new("self.servers * self.persistence.volumesPerServer >= 4").
-    message(Message::Expression(r#""pool " + self.name + " must have at least 4 total volumes (servers × volumesPerServer)""#.into())).
-    reason(Reason::FieldValueInvalid))
-]
-#[x_kube(validation = Rule::new("self.servers != 3 || self.servers * self.persistence.volumesPerServer >= 6").
-    message(Message::Expression(r#""pool " + self.name + " with 3 servers must have at least 6 volumes in total""#.into())).
-    reason(Reason::FieldValueInvalid))
-]
 pub struct Pool {
     #[schemars(
         length(min = 1, max = 63),
@@ -85,26 +71,10 @@ pub struct Pool {
     pub scheduling: SchedulingConfig,
 }
 
-/// Validates total volume count (`servers * volumesPerServer`) for RustFS erasure coding.
-/// Same rules as CRD CEL on [`Pool`] and the operator console API (`validate_pool_volumes`).
-pub fn validate_pool_total_volumes(servers: i32, volumes_per_server: i32) -> Result<i32, String> {
-    let total = servers * volumes_per_server;
-    if servers <= 0 || volumes_per_server <= 0 {
-        return Err("servers and volumes_per_server must be positive".to_string());
+impl Pool {
+    pub fn is_single_node_single_disk(&self) -> bool {
+        self.servers == 1 && self.persistence.volumes_per_server == 1
     }
-    if servers == 2 && total < 4 {
-        return Err("Pool with 2 servers must have at least 4 volumes in total".to_string());
-    }
-    if servers == 3 && total < 6 {
-        return Err("Pool with 3 servers must have at least 6 volumes in total".to_string());
-    }
-    if total < 4 {
-        return Err(format!(
-            "Pool must have at least 4 total volumes (got {} servers × {} volumes = {})",
-            servers, volumes_per_server, total
-        ));
-    }
-    Ok(total)
 }
 
 /// Validate a pool name used in labels and RustFS peer DNS names.
@@ -142,11 +112,7 @@ pub fn validate_pool_name(name: &str) -> Result<(), String> {
     Ok(())
 }
 
-pub fn validate_pool_collection(
-    tenant_name: &str,
-    pools: &[Pool],
-    env: &[corev1::EnvVar],
-) -> Result<(), String> {
+pub fn validate_pool_collection(tenant_name: &str, pools: &[Pool]) -> Result<(), String> {
     if pools.is_empty() {
         return Err("pools must be configured".to_string());
     }
@@ -157,12 +123,10 @@ pub fn validate_pool_collection(
         if !names.insert(pool.name.as_str()) {
             return Err(format!("pool names must be unique: '{}'", pool.name));
         }
-        validate_pool_total_volumes(pool.servers, pool.persistence.volumes_per_server)
-            .map_err(|message| format!("pool '{}': {}", pool.name, message))?;
         validate_rustfs_peer_dns_label(tenant_name, pool)?;
     }
 
-    validate_pool_erasure_compatibility(pools, env)
+    Ok(())
 }
 
 pub fn validate_pool_shape_immutable(existing: &[Pool], desired: &[Pool]) -> Result<(), String> {
@@ -214,273 +178,11 @@ fn ordinal_digits(value: i32) -> usize {
     value.to_string().len()
 }
 
-fn validate_pool_erasure_compatibility(
-    pools: &[Pool],
-    env: &[corev1::EnvVar],
-) -> Result<(), String> {
-    let set_drive_count = rustfs_erasure_set_drive_count_from_env(env)?;
-    let pool_layouts = pools
-        .iter()
-        .map(|pool| {
-            rustfs_drives_per_set(
-                pool.servers,
-                pool.persistence.volumes_per_server,
-                set_drive_count,
-            )
-            .map(|drives_per_set| (pool, drives_per_set))
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-
-    let Some((first_pool, first_drives_per_set)) = pool_layouts.first() else {
-        return Ok(());
-    };
-
-    let standard_parity = rustfs_standard_parity_from_env(env, *first_drives_per_set)?;
-    let rrs_parity = rustfs_rrs_parity_from_env(env, *first_drives_per_set)?;
-
-    if standard_parity > 0 && rrs_parity > 0 && standard_parity < rrs_parity {
-        return Err(format!(
-            "{RUSTFS_STORAGE_CLASS_STANDARD_ENV} parity {} must be greater than or equal to {RUSTFS_STORAGE_CLASS_RRS_ENV} parity {}",
-            standard_parity, rrs_parity
-        ));
-    }
-
-    validate_parity_for_pool(
-        first_pool,
-        *first_drives_per_set,
-        standard_parity,
-        "STANDARD",
-    )?;
-    validate_parity_for_pool(first_pool, *first_drives_per_set, rrs_parity, "RRS")?;
-
-    for (pool, drives_per_set) in pool_layouts.iter().skip(1) {
-        validate_parity_for_pool(pool, *drives_per_set, standard_parity, "STANDARD")?;
-        validate_parity_for_pool(pool, *drives_per_set, rrs_parity, "RRS")?;
-    }
-
-    Ok(())
-}
-
-fn validate_parity_for_pool(
-    pool: &Pool,
-    drives_per_set: usize,
-    parity: usize,
-    storage_class: &str,
-) -> Result<(), String> {
-    if drives_per_set == 0 {
-        return Err(format!(
-            "pool '{}' has invalid drivesPerSet {}, must be greater than zero",
-            pool.name, drives_per_set
-        ));
-    }
-
-    let max_parity = drives_per_set / 2;
-    if parity > max_parity {
-        return Err(format!(
-            "pool '{}' has RustFS drivesPerSet {}, but {} parity {} exceeds the maximum {}",
-            pool.name, drives_per_set, storage_class, parity, max_parity
-        ));
-    }
-    Ok(())
-}
-
-fn rustfs_erasure_set_drive_count_from_env(
-    env: &[corev1::EnvVar],
-) -> Result<Option<usize>, String> {
-    let Some(value) = literal_env_value(env, RUSTFS_ERASURE_SET_DRIVE_COUNT_ENV)? else {
-        return Ok(None);
-    };
-
-    let set_drive_count = value.parse::<usize>().map_err(|_| {
-        format!(
-            "{RUSTFS_ERASURE_SET_DRIVE_COUNT_ENV} must be a non-negative integer, got '{}'",
-            value
-        )
-    })?;
-
-    Ok((set_drive_count > 0).then_some(set_drive_count))
-}
-
-fn rustfs_standard_parity_from_env(
-    env: &[corev1::EnvVar],
-    set_drive_count: usize,
-) -> Result<usize, String> {
-    let parity = literal_env_value(env, RUSTFS_STORAGE_CLASS_STANDARD_ENV)?
-        .map(parse_storage_class_parity)
-        .transpose()?;
-
-    Ok(parity.unwrap_or_else(|| rustfs_default_parity_count(set_drive_count)))
-}
-
-fn rustfs_rrs_parity_from_env(
-    env: &[corev1::EnvVar],
-    set_drive_count: usize,
-) -> Result<usize, String> {
-    let parity = literal_env_value(env, RUSTFS_STORAGE_CLASS_RRS_ENV)?
-        .map(parse_storage_class_parity)
-        .transpose()?;
-
-    Ok(parity.unwrap_or(if set_drive_count == 1 {
-        0
-    } else {
-        DEFAULT_RRS_PARITY
-    }))
-}
-
-fn literal_env_value<'a>(env: &'a [corev1::EnvVar], name: &str) -> Result<Option<&'a str>, String> {
-    let Some(var) = env.iter().rev().find(|var| var.name == name) else {
-        return Ok(None);
-    };
-
-    if var.value_from.is_some() {
-        return Err(format!(
-            "{name} is configured with value_from, which is not supported during admission validation"
-        ));
-    }
-
-    Ok(var.value.as_deref())
-}
-
-fn parse_storage_class_parity(value: &str) -> Result<usize, String> {
-    let Some((scheme, parity)) = value.split_once(':') else {
-        return Err(format!(
-            "invalid storage class '{}': expected 'EC:<parity>'",
-            value
-        ));
-    };
-    if scheme != "EC" {
-        return Err(format!(
-            "invalid storage class '{}': only EC scheme is supported",
-            value
-        ));
-    }
-    parity.parse::<usize>().map_err(|_| {
-        format!(
-            "invalid storage class '{}': parity must be a non-negative integer",
-            value
-        )
-    })
-}
-
-pub fn rustfs_drives_per_set(
-    servers: i32,
-    volumes_per_server: i32,
-    set_drive_count: Option<usize>,
-) -> Result<usize, String> {
-    let total_volumes = validate_pool_total_volumes(servers, volumes_per_server)? as usize;
-    let volume_pattern_size = volumes_per_server as usize;
-
-    // Matches the current RustFS ellipsis layout calculation for the operator's
-    // generated host{0...n}/rustfs{0...m} pattern.
-    let set_counts = RUSTFS_ERASURE_SET_SIZES
-        .iter()
-        .copied()
-        .filter(|set_size| total_volumes.is_multiple_of(*set_size))
-        .filter(|set_size| pattern_is_symmetric(volume_pattern_size, *set_size))
-        .collect::<Vec<_>>();
-
-    if set_counts.is_empty() {
-        return Err(format!(
-            "pool layout with {} servers × {} volumesPerServer = {} total volumes is not divisible by any RustFS supported erasure set size with symmetric volume distribution",
-            servers, volumes_per_server, total_volumes
-        ));
-    }
-
-    if let Some(set_drive_count) = set_drive_count {
-        if !set_counts.contains(&set_drive_count) {
-            return Err(format!(
-                "{RUSTFS_ERASURE_SET_DRIVE_COUNT_ENV}={} is not valid for pool layout {} servers × {} volumesPerServer; acceptable values are {:?}",
-                set_drive_count, servers, volumes_per_server, set_counts
-            ));
-        }
-        return Ok(set_drive_count);
-    }
-
-    Ok(common_set_drive_count(total_volumes, &set_counts))
-}
-
-fn pattern_is_symmetric(pattern_size: usize, set_size: usize) -> bool {
-    if pattern_size > set_size {
-        pattern_size.is_multiple_of(set_size)
-    } else {
-        set_size.is_multiple_of(pattern_size)
-    }
-}
-
-fn common_set_drive_count(divisible_size: usize, set_counts: &[usize]) -> usize {
-    if divisible_size < set_counts[set_counts.len() - 1] {
-        return divisible_size;
-    }
-
-    let mut prev_d = divisible_size / set_counts[0];
-    let mut set_size = 0;
-    for &count in set_counts {
-        if divisible_size.is_multiple_of(count) {
-            let d = divisible_size / count;
-            if d <= prev_d {
-                prev_d = d;
-                set_size = count;
-            }
-        }
-    }
-    set_size
-}
-
-fn rustfs_default_parity_count(drives_per_set: usize) -> usize {
-    match drives_per_set {
-        1 => 0,
-        2 | 3 => 1,
-        4 | 5 => 2,
-        6 | 7 => 3,
-        _ => 4,
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{
-        parse_storage_class_parity, rustfs_drives_per_set, validate_pool_collection,
-        validate_pool_name, validate_pool_total_volumes,
-    };
+    use super::{validate_pool_collection, validate_pool_name};
     use crate::types::v1alpha1::persistence::PersistenceConfig;
     use crate::types::v1alpha1::pool::Pool;
-    use k8s_openapi::api::core::v1 as corev1;
-
-    #[test]
-    fn rejects_non_positive_inputs() {
-        assert!(validate_pool_total_volumes(0, 4).is_err());
-        assert!(validate_pool_total_volumes(4, 0).is_err());
-    }
-
-    #[test]
-    fn rejects_total_under_four_when_not_caught_by_special_cases() {
-        assert!(validate_pool_total_volumes(1, 3).is_err());
-        assert!(validate_pool_total_volumes(1, 2).is_err());
-    }
-
-    #[test]
-    fn four_servers_one_volume_each_is_ok() {
-        assert_eq!(validate_pool_total_volumes(4, 1).unwrap(), 4);
-    }
-
-    #[test]
-    fn two_servers_need_at_least_four_total() {
-        assert!(validate_pool_total_volumes(2, 1).is_err());
-        assert_eq!(validate_pool_total_volumes(2, 2).unwrap(), 4);
-    }
-
-    #[test]
-    fn three_servers_need_at_least_six_total() {
-        assert!(validate_pool_total_volumes(3, 1).is_err());
-        assert_eq!(validate_pool_total_volumes(3, 2).unwrap(), 6);
-    }
-
-    #[test]
-    fn accepts_common_valid_configs() {
-        assert_eq!(validate_pool_total_volumes(1, 4).unwrap(), 4);
-        assert_eq!(validate_pool_total_volumes(4, 1).unwrap(), 4);
-        assert_eq!(validate_pool_total_volumes(2, 2).unwrap(), 4);
-    }
 
     #[test]
     fn validates_pool_name_as_rfc1123_label() {
@@ -492,96 +194,24 @@ mod tests {
     }
 
     #[test]
-    fn derives_rustfs_drives_per_set_for_operator_pool_pattern() {
-        assert_eq!(rustfs_drives_per_set(4, 4, None).unwrap(), 16);
-        assert_eq!(rustfs_drives_per_set(8, 4, None).unwrap(), 16);
-        assert_eq!(rustfs_drives_per_set(2, 2, None).unwrap(), 4);
-        assert_eq!(rustfs_drives_per_set(3, 2, None).unwrap(), 6);
-    }
-
-    #[test]
-    fn rejects_pool_layout_rustfs_cannot_split_into_sets() {
-        assert!(rustfs_drives_per_set(17, 1, None).is_err());
-    }
-
-    #[test]
-    fn rejects_incompatible_pool_parity() {
-        let pools = vec![test_pool("pool-0", 4, 4), test_pool("pool-1", 2, 2)];
-
-        let err = validate_pool_collection("tenant", &pools, &[]).unwrap_err();
-
-        assert!(err.contains("STANDARD parity 4 exceeds the maximum 2"));
-    }
-
-    #[test]
-    fn rejects_parity_exceeding_half_for_small_drive_set() {
-        let pools = vec![test_pool("pool-0", 2, 4)];
-        let env = vec![
-            corev1::EnvVar {
-                name: "RUSTFS_ERASURE_SET_DRIVE_COUNT".to_string(),
-                value: Some("2".to_string()),
-                ..Default::default()
-            },
-            corev1::EnvVar {
-                name: "RUSTFS_STORAGE_CLASS_STANDARD".to_string(),
-                value: Some("EC:2".to_string()),
-                ..Default::default()
-            },
+    fn allows_rustfs_to_validate_storage_layouts() {
+        let pools = vec![
+            test_pool("pool-0", 1, 2),
+            test_pool("pool-1", 2, 1),
+            test_pool("pool-2", 3, 1),
+            test_pool("pool-3", 17, 1),
         ];
 
-        let err = validate_pool_collection("tenant", &pools, &env).unwrap_err();
-        assert!(err.contains("STANDARD parity 2 exceeds the maximum 1"));
+        assert!(validate_pool_collection("tenant", &pools).is_ok());
     }
 
     #[test]
-    fn honors_literal_erasure_env_for_pool_compatibility() {
-        let pools = vec![test_pool("pool-0", 4, 4), test_pool("pool-1", 2, 2)];
-        let env = vec![corev1::EnvVar {
-            name: "RUSTFS_ERASURE_SET_DRIVE_COUNT".to_string(),
-            value: Some("4".to_string()),
-            ..Default::default()
-        }];
+    fn rejects_duplicate_pool_names() {
+        let pools = vec![test_pool("pool-0", 1, 1), test_pool("pool-0", 1, 2)];
 
-        assert!(validate_pool_collection("tenant", &pools, &env).is_ok());
-    }
+        let err = validate_pool_collection("tenant", &pools).unwrap_err();
 
-    #[test]
-    fn rejects_erasure_layout_validation_with_value_from_env_vars() {
-        let pools = vec![test_pool("pool-0", 4, 4)];
-        let env = vec![corev1::EnvVar {
-            name: "RUSTFS_STORAGE_CLASS_STANDARD".to_string(),
-            value_from: Some(corev1::EnvVarSource {
-                secret_key_ref: Some(corev1::SecretKeySelector {
-                    name: "legacy-rustfs-config".to_string(),
-                    key: "standard-parity".to_string(),
-                    optional: Some(false),
-                }),
-                ..Default::default()
-            }),
-            ..Default::default()
-        }];
-
-        let err = validate_pool_collection("tenant", &pools, &env).unwrap_err();
-        assert!(err.contains("not supported during admission validation"));
-    }
-
-    #[test]
-    fn honors_literal_standard_storage_class_env_for_pool_compatibility() {
-        let pools = vec![test_pool("pool-0", 4, 4), test_pool("pool-1", 2, 2)];
-        let env = vec![corev1::EnvVar {
-            name: "RUSTFS_STORAGE_CLASS_STANDARD".to_string(),
-            value: Some("EC:2".to_string()),
-            ..Default::default()
-        }];
-
-        assert!(validate_pool_collection("tenant", &pools, &env).is_ok());
-    }
-
-    #[test]
-    fn validates_storage_class_parity_format() {
-        assert_eq!(parse_storage_class_parity("EC:2").unwrap(), 2);
-        assert!(parse_storage_class_parity("INVALID:2").is_err());
-        assert!(parse_storage_class_parity("EC:not-a-number").is_err());
+        assert!(err.contains("pool names must be unique"));
     }
 
     #[test]
@@ -592,8 +222,8 @@ mod tests {
             4,
         )];
 
-        let err = validate_pool_collection("tenant-name-that-is-already-quite-long", &pools, &[])
-            .unwrap_err();
+        let err =
+            validate_pool_collection("tenant-name-that-is-already-quite-long", &pools).unwrap_err();
 
         assert!(err.contains("RustFS peer DNS label too long"));
     }

--- a/src/types/v1alpha1/tenant.rs
+++ b/src/types/v1alpha1/tenant.rs
@@ -217,12 +217,12 @@ impl Tenant {
     }
 
     pub fn validate_pools(&self) -> Result<(), types::error::Error> {
-        validate_pool_collection(&self.name(), &self.spec.pools, &self.spec.env).map_err(
-            |message| types::error::Error::InvalidPoolSpec {
+        validate_pool_collection(&self.name(), &self.spec.pools).map_err(|message| {
+            types::error::Error::InvalidPoolSpec {
                 name: self.name(),
                 message,
-            },
-        )
+            }
+        })
     }
 
     /// a new owner reference for tenant

--- a/src/types/v1alpha1/tenant/workloads.rs
+++ b/src/types/v1alpha1/tenant/workloads.rs
@@ -56,20 +56,24 @@ impl Tenant {
         let tenant_name = self.name();
         let headless_service = self.headless_service_name();
         let base_path = pool.persistence.path.as_deref().unwrap_or("/data");
+        let base_path = base_path.trim_end_matches('/');
+
+        if self.spec.pools.len() == 1 && pool.is_single_node_single_disk() {
+            return format!("{base_path}/rustfs0");
+        }
 
         format!(
             "{scheme}://{tenant_name}-{}-{{0...{}}}.{headless_service}.{namespace}.svc.cluster.local:9000{}/rustfs{{0...{}}}",
             pool.name,
             pool.servers - 1,
-            base_path.trim_end_matches('/'),
+            base_path,
             pool.persistence.volumes_per_server - 1
         )
     }
 
     /// Constructs the RUSTFS_VOLUMES environment variable value
-    /// Format: http://{tenant}-{pool}-{0...servers-1}.{service}.{namespace}.svc.cluster.local:9000{path}/rustfs{0...volumes-1}
-    /// All pools are combined into a space-separated string for a unified cluster
-    /// Follows RustFS convention: /data/rustfs0, /data/rustfs1, etc.
+    /// Distributed and multi-pool tenants use peer DNS entries, while a single-pool
+    /// single-node single-disk tenant uses its local data path.
     fn rustfs_volumes_env_value(&self, scheme: &str) -> Result<String, types::error::Error> {
         let namespace = self.namespace()?;
         let volume_specs = self
@@ -370,7 +374,7 @@ impl Tenant {
         // Generate environment variables: operator-managed + user-provided
         let mut env_vars = Vec::new();
 
-        // Add RUSTFS_VOLUMES environment variable for multi-node communication
+        // Add RUSTFS_VOLUMES environment variable for the inferred storage layout.
         let rustfs_volumes = self.rustfs_volumes_env_value(tls_plan.internode_scheme)?;
         env_vars.push(corev1::EnvVar {
             name: "RUSTFS_VOLUMES".to_owned(),
@@ -1094,6 +1098,64 @@ mod tests {
             container.termination_message_policy.as_deref(),
             Some("FallbackToLogsOnError")
         );
+    }
+
+    #[test]
+    fn single_node_single_disk_statefulset_uses_local_rustfs_volume() {
+        let mut tenant = crate::tests::create_test_tenant(None, None);
+        tenant.spec.pools[0].servers = 1;
+        tenant.spec.pools[0].persistence.volumes_per_server = 1;
+        let pool = &tenant.spec.pools[0];
+
+        let statefulset = tenant
+            .new_statefulset(pool)
+            .expect("Should create StatefulSet for single-node single-disk");
+
+        let pod_spec = statefulset.spec.unwrap().template.spec.unwrap();
+        let container = &pod_spec.containers[0];
+        assert_eq!(
+            env_value(container, "RUSTFS_VOLUMES"),
+            Some("/data/rustfs0")
+        );
+        assert_eq!(
+            container
+                .volume_mounts
+                .as_ref()
+                .expect("data mount should be present")
+                .iter()
+                .filter(|mount| mount.mount_path == "/data/rustfs0")
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn mixed_pool_single_node_single_disk_uses_peer_dns_volume() {
+        let mut tenant = crate::tests::create_test_tenant(None, None);
+        tenant.spec.pools[0].servers = 1;
+        tenant.spec.pools[0].persistence.volumes_per_server = 1;
+        let mut second_pool = tenant.spec.pools[0].clone();
+        second_pool.name = "pool-1".to_string();
+        second_pool.servers = 2;
+        second_pool.persistence.volumes_per_server = 1;
+        tenant.spec.pools.push(second_pool);
+        let pool = &tenant.spec.pools[1];
+
+        let statefulset = tenant
+            .new_statefulset(pool)
+            .expect("Should create StatefulSet for mixed pools");
+
+        let pod_spec = statefulset.spec.unwrap().template.spec.unwrap();
+        let container = &pod_spec.containers[0];
+        let rustfs_volumes =
+            env_value(container, "RUSTFS_VOLUMES").expect("RUSTFS_VOLUMES should be configured");
+        assert!(!rustfs_volumes.starts_with("/data/rustfs0"));
+        assert!(rustfs_volumes.contains(
+            "http://test-tenant-pool-0-{0...0}.test-tenant-hl.default.svc.cluster.local:9000/data/rustfs{0...0}"
+        ));
+        assert!(rustfs_volumes.contains(
+            "http://test-tenant-pool-1-{0...1}.test-tenant-hl.default.svc.cluster.local:9000/data/rustfs{0...0}"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Type of Change
- [x] New Feature
- [ ] Bug Fix
- [x] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
Fixes #144

## Summary of Changes
- Remove operator-side RustFS storage layout validation from the Tenant CRD and Console API paths.
- Keep only Kubernetes/operator constructability checks such as positive server and volume counts, unique pool names, peer DNS label length, and immutable existing pool shape.
- Render `RUSTFS_VOLUMES` as a local path only for a single-pool single-node single-disk Tenant; multi-pool tenants use peer DNS entries so RustFS receives an accurate global topology.
- Update Console defaults, examples, and user guides to show `1x1` development tenants and clarify that RustFS validates storage layout at startup.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit` (fmt-check + clippy + test + console-lint + console-fmt-check)
- [x] Added/updated necessary tests
- [x] Documentation updated (if needed)
- [ ] CHANGELOG.md updated under `[Unreleased]` (N/A: this repository has no `CHANGELOG.md`)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (CRD/API compatibility)
- [x] Requires doc/config/deployment update
- [x] Other impact: RustFS now owns storage layout, erasure set, and parity compatibility validation.

## Verification
```bash
cargo test types::v1alpha1::tenant::workloads::tests::single_node_single_disk_statefulset_uses_local_rustfs_volume
cargo test types::v1alpha1::tenant::workloads::tests::mixed_pool_single_node_single_disk_uses_peer_dns_volume
make pre-commit
git diff --check
```

## Additional Notes
This does not add a separate standalone mode. The operator only infers the local `RUSTFS_VOLUMES=/data/rustfs0` form for the single-pool `1x1` case; other accepted layouts are passed through to RustFS with peer DNS topology.
