### PR TITLE
Fix stale tenant progressing status in console topology

### DIFF
--- a/src/console/models/tenant.rs
+++ b/src/console/models/tenant.rs
@@ -25,6 +25,8 @@ use kube::ResourceExt;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
+const LEGACY_PROGRESSING_CONDITION: &str = "Progressing";
+
 /// Single tenant row in a list view
 #[derive(Debug, Serialize, ToSchema)]
 pub struct TenantListItem {
@@ -267,21 +269,42 @@ pub fn tenant_status_summary(tenant: &Tenant) -> TenantStatusSummary {
     } else {
         legacy_ready_for_state(&current_state)
     };
-    let mut reconciling = if has_conditions {
-        condition_is_true(status, ConditionType::Reconciling.as_str())
-            || condition_is_true(status, "Progressing")
-    } else {
-        legacy_reconciling_for_state(&current_state)
-    };
     let degraded = if has_conditions {
         condition_is_true(status, ConditionType::Degraded.as_str())
     } else {
         legacy_degraded_for_state(&current_state)
     };
+    let legacy_progressing_condition = if has_conditions && !ready && !degraded {
+        status.and_then(|status| {
+            status
+                .condition_by_type(LEGACY_PROGRESSING_CONDITION)
+                .filter(|condition| condition.status == ConditionStatus::True.as_str())
+        })
+    } else {
+        None
+    };
+    let legacy_progressing = legacy_progressing_condition.is_some();
+
+    if legacy_progressing && matches!(current_state.as_str(), "Unknown" | "NotReady") {
+        current_state = CurrentState::Reconciling.as_str().to_string();
+    }
+
+    let mut reconciling = if has_conditions {
+        condition_is_true(status, ConditionType::Reconciling.as_str()) || legacy_progressing
+    } else {
+        legacy_reconciling_for_state(&current_state)
+    };
 
     let primary = status.and_then(primary_condition);
     let mut primary_reason = primary.map(|condition| condition.reason.clone());
     let mut primary_message = primary.map(|condition| condition.message.clone());
+
+    if primary_reason.is_none()
+        && let Some(condition) = legacy_progressing_condition
+    {
+        primary_reason = Some(condition.reason.clone());
+        primary_message = Some(condition.message.clone());
+    }
 
     if stale {
         current_state = CurrentState::Reconciling.as_str().to_string();
@@ -533,6 +556,10 @@ mod tests {
         assert!(summary.ready);
         assert!(!summary.reconciling);
         assert!(!summary.degraded);
+        assert!(summary.primary_reason.is_none());
+        assert!(summary.next_actions.is_empty());
+        assert!(summary.primary_reason.is_none());
+        assert!(summary.next_actions.is_empty());
     }
 
     #[test]
@@ -551,6 +578,52 @@ mod tests {
         assert_eq!(summary.current_state, "Reconciling");
         assert!(!summary.ready);
         assert!(summary.reconciling);
+        assert_eq!(summary.primary_reason.as_deref(), Some("RolloutInProgress"));
+        assert_eq!(summary.next_actions, vec!["waitForRollout"]);
+    }
+
+    #[test]
+    fn tenant_summary_ignores_legacy_progressing_after_ready_success() {
+        let mut tenant = crate::tests::create_test_tenant(None, None);
+        tenant.metadata.generation = Some(3);
+        tenant.status = Some(Status {
+            current_state: "Ready".to_string(),
+            observed_generation: Some(3),
+            conditions: vec![
+                condition("Ready", "True", "ReconcileSucceeded"),
+                condition("Reconciling", "False", "ReconcileSucceeded"),
+                condition("Degraded", "False", "ReconcileSucceeded"),
+                condition("Progressing", "True", "RolloutInProgress"),
+            ],
+            ..Default::default()
+        });
+
+        let summary = tenant_status_summary(&tenant);
+
+        assert_eq!(summary.current_state, "Ready");
+        assert!(summary.ready);
+        assert!(!summary.reconciling);
+        assert!(!summary.degraded);
+    }
+
+    #[test]
+    fn tenant_summary_uses_legacy_progressing_without_ready_success() {
+        let mut tenant = crate::tests::create_test_tenant(None, None);
+        tenant.metadata.generation = Some(3);
+        tenant.status = Some(Status {
+            current_state: "Ready".to_string(),
+            observed_generation: Some(3),
+            conditions: vec![condition("Progressing", "True", "RolloutInProgress")],
+            ..Default::default()
+        });
+
+        let summary = tenant_status_summary(&tenant);
+
+        assert_eq!(summary.current_state, "Reconciling");
+        assert!(!summary.ready);
+        assert!(summary.reconciling);
+        assert_eq!(summary.primary_reason.as_deref(), Some("RolloutInProgress"));
+        assert_eq!(summary.next_actions, vec!["waitForRollout"]);
     }
 
     #[test]

--- a/src/status.rs
+++ b/src/status.rs
@@ -21,6 +21,8 @@ use crate::types::v1alpha1::status::{
 use crate::types::v1alpha1::tenant::Tenant;
 use kube::runtime::events::EventType;
 
+const LEGACY_PROGRESSING_CONDITION: &str = "Progressing";
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum StatusImpact {
     UserBlocked,
@@ -510,6 +512,8 @@ impl StatusBuilder {
     }
 
     pub fn build(mut self) -> Status {
+        self.next
+            .remove_condition_by_type(LEGACY_PROGRESSING_CONDITION);
         self.next.observed_generation = self.generation;
         self.next.current_state = summarize_current_state(&self.next);
         self.next.sort_conditions();
@@ -910,6 +914,41 @@ mod tests {
                 .condition(ConditionType::Reconciling)
                 .map(|condition| condition.reason.as_str()),
             Some("ReconcileStarted")
+        );
+    }
+
+    #[test]
+    fn status_builder_prunes_legacy_progressing_condition() {
+        let mut tenant = crate::tests::create_test_tenant(None, None);
+        tenant.metadata.generation = Some(1);
+        tenant.status = Some(Status {
+            current_state: "Ready".to_string(),
+            observed_generation: Some(1),
+            conditions: vec![
+                condition("Ready", "True", "ReconcileSucceeded"),
+                condition("Reconciling", "False", "ReconcileSucceeded"),
+                condition("Degraded", "False", "ReconcileSucceeded"),
+                condition("Progressing", "True", "RolloutInProgress"),
+            ],
+            ..Default::default()
+        });
+
+        let mut builder = StatusBuilder::from_tenant(&tenant);
+        builder.finish_success();
+        let status = builder.build();
+
+        assert_eq!(status.current_state, "Ready");
+        assert!(
+            status
+                .conditions
+                .iter()
+                .all(|condition| condition.type_ != "Progressing")
+        );
+        assert_eq!(
+            status
+                .condition(ConditionType::Reconciling)
+                .map(|condition| condition.status.as_str()),
+            Some("False")
         );
     }
 

--- a/src/types/v1alpha1/status.rs
+++ b/src/types/v1alpha1/status.rs
@@ -245,7 +245,7 @@ pub struct ConditionInput {
 #[derive(Deserialize, Serialize, Clone, Debug, JsonSchema, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct Condition {
-    /// Type of condition (Ready, Progressing, Degraded)
+    /// Type of condition (Ready, Reconciling, Degraded)
     #[serde(rename = "type")]
     pub type_: String,
 
@@ -344,6 +344,10 @@ impl Status {
                 (None, None) => left.type_.cmp(&right.type_),
             }
         });
+    }
+
+    pub fn remove_condition_by_type(&mut self, type_: &str) {
+        self.conditions.retain(|condition| condition.type_ != type_);
     }
 
     pub fn condition_is_true(&self, type_: ConditionType) -> bool {


### PR DESCRIPTION
<!--
Pull Request Template for RustFS Operator
-->

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
N/A

## Summary of Changes
- Ignore stale legacy `Progressing=True` tenant conditions when the tenant is already `Ready=True` in the Console topology summary.
- Preserve legacy compatibility for tenants that only expose `Progressing=True` and are not ready yet, including primary reason and next action mapping.
- Prune legacy `Progressing` conditions from future operator status writes so refreshed statuses converge to `Ready`/`Reconciling`/`Degraded` only.
- Add regression coverage for ready tenants with stale legacy progressing state and for legacy progressing-only tenants.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [ ] Passed `make pre-commit` (fmt-check + clippy + test + console-lint + console-fmt-check)
- [x] Added/updated necessary tests
- [x] Documentation updated (if needed)
- [x] CHANGELOG.md updated under `[Unreleased]` (if user-visible change)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (CRD/API compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact: fixes Console topology health classification for tenants carrying stale legacy status.

## Verification
```bash
cargo fmt --all --check
cargo clippy --all-features -- -D warnings
cargo test --all
make e2e-check
cd console-web && CI=true pnpm install --offline --frozen-lockfile
cd console-web && ./node_modules/.bin/eslint .
cd console-web && ./node_modules/.bin/next build
cd console-web && ./node_modules/.bin/prettier --check "**/*.{ts,tsx,js,jsx,json,css,md}"
```

## Additional Notes
`CI=true make pre-commit` was attempted. The Rust and e2e stages passed, then the command failed before running frontend scripts because the local Codex runtime pnpm dependency sync timed out while fetching registry tarballs. After restoring dependencies from the local pnpm cache, the equivalent frontend lint, build, and format checks above passed directly.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
