### PR TITLE
fix(sts): reject caller-supplied session policies

### DIFF
--- a/deploy/rustfs-operator/README.md
+++ b/deploy/rustfs-operator/README.md
@@ -272,6 +272,8 @@ curl -sS -X POST \
   --data-urlencode "DurationSeconds=3600"
 ```
 
+Operator STS derives the issued session policy from the matched `PolicyBinding` policies. Caller-supplied `Policy` request parameters are rejected until the operator can prove they only narrow the `PolicyBinding` permissions.
+
 ## Creating Tenant Resources
 
 After installing the operator, you can create Tenant resources. See the project root `examples/` directory for sample manifests:

--- a/docs/operator-user-guide.md
+++ b/docs/operator-user-guide.md
@@ -651,6 +651,7 @@ Current STS constraints:
 - STS only issues credentials for TLS-enabled Tenants.
 - Operator STS uses the explicit Tenant route with both namespace and name.
 - The `PolicyBinding` must reference at least one policy.
+- Caller-supplied `Policy` request parameters are rejected; issued credentials use the matched `PolicyBinding` policies.
 - Tenants requiring client certificates for upstream Tenant calls are rejected by Operator STS.
 
 ## 10. Monitoring and Status

--- a/docs/operator-user-guide.zh-CN.md
+++ b/docs/operator-user-guide.zh-CN.md
@@ -653,6 +653,7 @@ curl -sS -X POST \
 - STS 只为启用 TLS 的 Tenant 签发凭据。
 - Operator STS 使用显式 Tenant 路由，路径中同时包含 namespace 和 Tenant name。
 - `PolicyBinding` 至少需要引用一个 policy。
+- 调用方传入的 `Policy` 请求参数会被拒绝；签发凭据只使用匹配的 `PolicyBinding` policies。
 - 如果 Tenant 要求 Operator STS 调用 Tenant 时使用 client certificate，目前会被 Operator STS 拒绝。
 
 ## 10. 监控和状态

--- a/src/sts/error.rs
+++ b/src/sts/error.rs
@@ -25,6 +25,7 @@ pub enum StsError {
     InvalidParameterValue { parameter: &'static str },
     InvalidIdentityToken,
     AccessDenied,
+    UnsupportedRequestPolicy,
     TenantTlsClientCertificateUnsupported,
     InternalError,
     NotImplemented,
@@ -39,7 +40,7 @@ impl StsError {
             Self::MissingParameter { .. } => "MissingParameter",
             Self::InvalidParameterValue { .. } => "InvalidParameterValue",
             Self::InvalidIdentityToken => "InvalidIdentityToken",
-            Self::AccessDenied => "AccessDenied",
+            Self::AccessDenied | Self::UnsupportedRequestPolicy => "AccessDenied",
             Self::TenantTlsClientCertificateUnsupported => "TenantTlsClientCertificateUnsupported",
             Self::InternalError => "InternalError",
             Self::NotImplemented => "NotImplemented",
@@ -59,7 +60,11 @@ impl StsError {
             }
             Self::InvalidIdentityToken => "The provided web identity token is invalid.".to_string(),
             Self::AccessDenied => {
-                "No matching policy binding was found for this identity.".to_string()
+                "The request is not authorized by a matching PolicyBinding.".to_string()
+            }
+            Self::UnsupportedRequestPolicy => {
+                "Caller-supplied Policy request parameters are not supported by Operator STS."
+                    .to_string()
             }
             Self::TenantTlsClientCertificateUnsupported => {
                 "Operator STS does not support Tenants that require TLS client certificates."

--- a/src/sts/server.rs
+++ b/src/sts/server.rs
@@ -302,7 +302,7 @@ async fn process_assume_role_request(
                 error = %error.code(),
                 "Failed to build merged STS session policy"
             );
-            return xml_response(StatusCode::BAD_REQUEST, error.as_xml());
+            return xml_response(sts_error_status(&error), error.as_xml());
         }
     };
 
@@ -580,7 +580,7 @@ fn xml_response(status_code: StatusCode, body: String) -> Response {
 
 fn sts_error_status(error: &StsError) -> StatusCode {
     match error {
-        StsError::AccessDenied => StatusCode::FORBIDDEN,
+        StsError::AccessDenied | StsError::UnsupportedRequestPolicy => StatusCode::FORBIDDEN,
         StsError::InvalidParameterValue { .. }
         | StsError::TenantTlsClientCertificateUnsupported
         | StsError::MissingParameter { .. }
@@ -695,6 +695,7 @@ mod tests {
                 session_token: "token".to_string(),
                 expiration: "2024-01-01T00:00:00Z".to_string(),
             }))),
+            assume_role_policies: Mutex::new(Vec::new()),
         };
 
         let form = AssumeRoleWithWebIdentityForm {
@@ -745,6 +746,7 @@ mod tests {
                 session_token: "token".to_string(),
                 expiration: "2024-01-01T00:00:00Z".to_string(),
             }))),
+            assume_role_policies: Mutex::new(Vec::new()),
         };
 
         let form = AssumeRoleWithWebIdentityForm {
@@ -761,7 +763,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn sts_handler_merges_binding_policy_and_requests_and_succeeds() {
+    async fn sts_handler_uses_binding_policy_without_request_policy_and_succeeds() {
         let runtime = MockStsRuntime {
             identity: Mutex::new(Some(Ok(token_review::ServiceAccountIdentity {
                 namespace: "tenant-a".to_string(),
@@ -797,6 +799,7 @@ mod tests {
                 session_token: "session".to_string(),
                 expiration: "2024-01-01T00:00:00Z".to_string(),
             }))),
+            assume_role_policies: Mutex::new(Vec::new()),
         };
 
         let form = AssumeRoleWithWebIdentityForm {
@@ -804,7 +807,7 @@ mod tests {
             action: Some(STS_WEB_IDENTITY_ACTION.to_string()),
             web_identity_token: Some("sa-token".to_string()),
             duration_seconds: Some("3600".to_string()),
-            policy: Some("{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"req\",\"Effect\":\"Allow\"}] }".to_string()),
+            policy: None,
         };
         let parsed = parse_sts_form("tenant-a".to_string(), "tenant-a".to_string(), form).unwrap();
 
@@ -815,6 +818,121 @@ mod tests {
 
         assert!(text.contains("<AssumeRoleWithWebIdentityResponse"));
         assert!(text.contains("<AccessKeyId>ak</AccessKeyId>"));
+
+        let assume_role_policies = runtime.assume_role_policies.lock().unwrap();
+        assert_eq!(assume_role_policies.len(), 1);
+        let policy = assume_role_policies[0]
+            .as_ref()
+            .expect("binding session policy should be passed to RustFS AssumeRole");
+        assert!(policy.contains("\"Sid\":\"b1\""));
+    }
+
+    #[tokio::test]
+    async fn sts_handler_rejects_caller_supplied_request_policy() {
+        let runtime = MockStsRuntime {
+            identity: Mutex::new(Some(Ok(token_review::ServiceAccountIdentity {
+                namespace: "tenant-a".to_string(),
+                service_account: "workload-sa".to_string(),
+            }))),
+            policy_bindings: Mutex::new(Some(Ok(vec![PolicyBinding {
+                metadata: Default::default(),
+                spec: PolicyBindingSpec {
+                    application: PolicyBindingApplication {
+                        namespace: "tenant-a".to_string(),
+                        serviceaccount: "workload-sa".to_string(),
+                    },
+                    policies: vec!["policy-binding".to_string()],
+                },
+                status: None,
+            }]))),
+            tenant: Mutex::new(Some(Ok(crate::types::v1alpha1::tenant::Tenant {
+                metadata: Default::default(),
+                spec: Default::default(),
+                status: None,
+            }))),
+            create_client: Mutex::new(Some(Ok(RustfsAdminClient::new_with_base_url(
+                "http://127.0.0.1:1",
+                "access-key",
+                "secret-key",
+            )))),
+            fetch_policy_results: Mutex::new(VecDeque::from([
+                Ok("{\"Version\": \"2012-10-17\", \"Statement\": [{\"Sid\":\"binding-read\",\"Effect\":\"Allow\",\"Action\":\"s3:GetObject\",\"Resource\":\"arn:aws:s3:::bucket-a/*\"}]}".to_string()),
+            ])),
+            assume_role_result: Mutex::new(Some(Err(RustfsClientError::RequestFailed))),
+            assume_role_policies: Mutex::new(Vec::new()),
+        };
+
+        let form = AssumeRoleWithWebIdentityForm {
+            version: Some(STS_API_VERSION.to_string()),
+            action: Some(STS_WEB_IDENTITY_ACTION.to_string()),
+            web_identity_token: Some("sa-token".to_string()),
+            duration_seconds: Some("3600".to_string()),
+            policy: Some("{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"request-admin\",\"Effect\":\"Allow\",\"Action\":\"s3:*\",\"Resource\":\"*\"}] }".to_string()),
+        };
+        let parsed = parse_sts_form("tenant-a".to_string(), "tenant-a".to_string(), form).unwrap();
+
+        let response = process_assume_role_request(&runtime, parsed).await;
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let text = String::from_utf8(body.to_vec()).unwrap();
+
+        assert!(text.contains("<Code>AccessDenied</Code>"));
+        assert!(text.contains("Policy request parameters are not supported"));
+        assert!(runtime.assume_role_policies.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn sts_handler_rejects_malformed_caller_policy_without_assume_role() {
+        let runtime = MockStsRuntime {
+            identity: Mutex::new(Some(Ok(token_review::ServiceAccountIdentity {
+                namespace: "tenant-a".to_string(),
+                service_account: "workload-sa".to_string(),
+            }))),
+            policy_bindings: Mutex::new(Some(Ok(vec![PolicyBinding {
+                metadata: Default::default(),
+                spec: PolicyBindingSpec {
+                    application: PolicyBindingApplication {
+                        namespace: "tenant-a".to_string(),
+                        serviceaccount: "workload-sa".to_string(),
+                    },
+                    policies: vec!["policy-binding".to_string()],
+                },
+                status: None,
+            }]))),
+            tenant: Mutex::new(Some(Ok(crate::types::v1alpha1::tenant::Tenant {
+                metadata: Default::default(),
+                spec: Default::default(),
+                status: None,
+            }))),
+            create_client: Mutex::new(Some(Ok(RustfsAdminClient::new_with_base_url(
+                "http://127.0.0.1:1",
+                "access-key",
+                "secret-key",
+            )))),
+            fetch_policy_results: Mutex::new(VecDeque::from([
+                Ok("{\"Version\": \"2012-10-17\", \"Statement\": [{\"Sid\":\"binding-read\",\"Effect\":\"Allow\",\"Action\":\"s3:GetObject\",\"Resource\":\"arn:aws:s3:::bucket-a/*\"}]}".to_string()),
+            ])),
+            assume_role_result: Mutex::new(Some(Err(RustfsClientError::RequestFailed))),
+            assume_role_policies: Mutex::new(Vec::new()),
+        };
+
+        let form = AssumeRoleWithWebIdentityForm {
+            version: Some(STS_API_VERSION.to_string()),
+            action: Some(STS_WEB_IDENTITY_ACTION.to_string()),
+            web_identity_token: Some("sa-token".to_string()),
+            duration_seconds: Some("3600".to_string()),
+            policy: Some("{".to_string()),
+        };
+        let parsed = parse_sts_form("tenant-a".to_string(), "tenant-a".to_string(), form).unwrap();
+
+        let response = process_assume_role_request(&runtime, parsed).await;
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let text = String::from_utf8(body.to_vec()).unwrap();
+
+        assert!(text.contains("<Code>AccessDenied</Code>"));
+        assert!(text.contains("Policy request parameters are not supported"));
+        assert!(runtime.assume_role_policies.lock().unwrap().is_empty());
     }
 
     #[tokio::test]
@@ -847,6 +965,7 @@ mod tests {
             )))),
             fetch_policy_results: Mutex::new(VecDeque::new()),
             assume_role_result: Mutex::new(None),
+            assume_role_policies: Mutex::new(Vec::new()),
         };
 
         let form = AssumeRoleWithWebIdentityForm {
@@ -888,6 +1007,7 @@ mod tests {
             create_client: Mutex::new(Some(Err(StsError::TenantTlsClientCertificateUnsupported))),
             fetch_policy_results: Mutex::new(VecDeque::new()),
             assume_role_result: Mutex::new(None),
+            assume_role_policies: Mutex::new(Vec::new()),
         };
 
         let form = AssumeRoleWithWebIdentityForm {
@@ -929,6 +1049,7 @@ mod tests {
                 Err(RustfsClientError::RequestFailed),
             ])),
             assume_role_result: Mutex::new(None),
+            assume_role_policies: Mutex::new(Vec::new()),
         };
 
         let client = RustfsAdminClient::new_with_base_url("http://127.0.0.1:1", "access", "secret");
@@ -967,6 +1088,7 @@ mod tests {
                 RustfsClientError::RequestFailed,
             )])),
             assume_role_result: Mutex::new(None),
+            assume_role_policies: Mutex::new(Vec::new()),
         };
 
         let client = RustfsAdminClient::new_with_base_url("http://127.0.0.1:1", "access", "secret");
@@ -998,6 +1120,7 @@ mod tests {
             create_client: Mutex::new(None),
             fetch_policy_results: Mutex::new(VecDeque::new()),
             assume_role_result: Mutex::new(None),
+            assume_role_policies: Mutex::new(Vec::new()),
         };
 
         let client = RustfsAdminClient::new_with_base_url("http://127.0.0.1:1", "access", "secret");
@@ -1028,6 +1151,7 @@ mod tests {
         fetch_policy_results: Mutex<VecDeque<Result<String, RustfsClientError>>>,
         assume_role_result:
             Mutex<Option<Result<crate::sts::types::StsAssumeRoleCredentials, RustfsClientError>>>,
+        assume_role_policies: Mutex<Vec<Option<String>>>,
     }
 
     #[async_trait]
@@ -1093,9 +1217,13 @@ mod tests {
         async fn assume_role(
             &self,
             _rustfs_client: &RustfsAdminClient,
-            _policy: Option<&str>,
+            policy: Option<&str>,
             _duration_seconds: u64,
         ) -> Result<crate::sts::types::StsAssumeRoleCredentials, RustfsClientError> {
+            self.assume_role_policies
+                .lock()
+                .unwrap()
+                .push(policy.map(ToString::to_string));
             self.assume_role_result
                 .lock()
                 .unwrap()

--- a/src/sts/session_policy.rs
+++ b/src/sts/session_policy.rs
@@ -36,19 +36,17 @@ pub fn normalize_policy_for_merge(raw: &str) -> Result<String, StsError> {
     serde_json::to_string(&Value::Object(merged)).map_err(|_| StsError::MalformedPolicyDocument)
 }
 
-/// Merge request policy + binding policies to an inline session policy.
+/// Build the inline session policy from PolicyBinding policies.
 pub fn merge_session_policies(
     request_policy: Option<&str>,
     binding_policies: &[String],
 ) -> Result<Option<String>, StsError> {
+    if request_policy.is_some() {
+        return Err(StsError::UnsupportedRequestPolicy);
+    }
+
     let mut statements = Vec::<Value>::new();
     let mut version: Option<String> = None;
-
-    if let Some(raw_request_policy) = request_policy {
-        let policy = parse_policy(raw_request_policy)?;
-        version.get_or_insert(policy.version);
-        statements.extend(policy.statements);
-    }
 
     for raw_policy in binding_policies {
         let policy = parse_policy(raw_policy)?;
@@ -62,21 +60,11 @@ pub fn merge_session_policies(
         return Ok(None);
     }
 
-    let mut merged = Map::new();
-    merged.insert(
-        "Version".to_string(),
-        Value::String(version.unwrap_or_else(|| DEFAULT_POLICY_VERSION.to_string())),
-    );
-    merged.insert("Statement".to_string(), Value::Array(statements));
-
-    let compacted = serde_json::to_string(&Value::Object(merged))
-        .map_err(|_| StsError::MalformedPolicyDocument)?;
-
-    if compacted.len() > MAX_SESSION_POLICY_SIZE {
-        return Err(StsError::PackedPolicyTooLarge);
-    }
-
-    Ok(Some(compacted))
+    compact_policy(
+        version.unwrap_or_else(|| DEFAULT_POLICY_VERSION.to_string()),
+        statements,
+    )
+    .map(Some)
 }
 
 fn parse_policy(raw: &str) -> Result<ParsedPolicy, StsError> {
@@ -118,22 +106,43 @@ fn parse_policy(raw: &str) -> Result<ParsedPolicy, StsError> {
     })
 }
 
+fn compact_policy(version: String, statements: Vec<Value>) -> Result<String, StsError> {
+    let mut merged = Map::new();
+    merged.insert("Version".to_string(), Value::String(version));
+    merged.insert("Statement".to_string(), Value::Array(statements));
+
+    let compacted = serde_json::to_string(&Value::Object(merged))
+        .map_err(|_| StsError::MalformedPolicyDocument)?;
+
+    if compacted.len() > MAX_SESSION_POLICY_SIZE {
+        return Err(StsError::PackedPolicyTooLarge);
+    }
+
+    Ok(compacted)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn policy(statements: &[&str]) -> String {
+    fn policy(statements: &[String]) -> String {
         let statement_lines = statements
             .iter()
-            .map(|value| format!("{{\"Sid\":\"{value}\",\"Effect\":\"Allow\"}}"))
+            .map(String::as_str)
             .collect::<Vec<_>>()
             .join(",");
 
         format!("{{\"Version\":\"2012-10-17\",\"Statement\":[{statement_lines}]}}")
     }
 
+    fn allow_statement(sid: &str, action: &str, resource: &str) -> String {
+        format!(
+            "{{\"Sid\":\"{sid}\",\"Effect\":\"Allow\",\"Action\":\"{action}\",\"Resource\":\"{resource}\"}}"
+        )
+    }
+
     #[test]
-    fn parse_and_compact_policy_rejects_empty_policy() {
+    fn normalize_policy_for_merge_rejects_empty_policy() {
         assert!(matches!(
             normalize_policy_for_merge(""),
             Err(StsError::MalformedPolicyDocument)
@@ -141,7 +150,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_and_compact_policy_rejects_malformed_json() {
+    fn normalize_policy_for_merge_rejects_malformed_json() {
         assert!(matches!(
             normalize_policy_for_merge("{\"Version\": \"2012-10-17\""),
             Err(StsError::MalformedPolicyDocument)
@@ -149,7 +158,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_and_compact_policy_rejects_missing_statements() {
+    fn normalize_policy_for_merge_rejects_missing_statements() {
         let without_statements = "{\"Version\":\"2012-10-17\"}";
         assert!(matches!(
             normalize_policy_for_merge(without_statements),
@@ -158,12 +167,13 @@ mod tests {
     }
 
     #[test]
-    fn merge_request_and_binding_policies_keeps_compact_shape() {
-        let request_policy = policy(&["RequestPolicy"]);
-        let binding_policy = policy(&["BindingPolicy"]);
+    fn merge_binding_policies_without_request_keeps_compact_shape() {
+        let binding_policy = policy(&[
+            allow_statement("BindingRead", "s3:GetObject", "arn:aws:s3:::bucket-a/*"),
+            allow_statement("BindingList", "s3:ListBucket", "arn:aws:s3:::bucket-a"),
+        ]);
 
-        let merged = merge_session_policies(Some(&request_policy), &[binding_policy])
-            .expect("merge should succeed");
+        let merged = merge_session_policies(None, &[binding_policy]).expect("merge should succeed");
         let merged = merged.expect("merged policy should exist");
 
         let value = serde_json::from_str::<Value>(&merged).expect("merged policy is json");
@@ -176,22 +186,52 @@ mod tests {
     }
 
     #[test]
+    fn merge_rejects_caller_supplied_request_policy() {
+        let request_policy = policy(&[allow_statement(
+            "RequestRead",
+            "s3:GetObject",
+            "arn:aws:s3:::bucket-a/*",
+        )]);
+        let binding_policy = policy(&[allow_statement(
+            "BindingRead",
+            "s3:GetObject",
+            "arn:aws:s3:::bucket-a/*",
+        )]);
+
+        let error = merge_session_policies(Some(&request_policy), &[binding_policy])
+            .expect_err("caller policy must not be accepted until subset evaluation exists");
+
+        assert!(matches!(error, StsError::UnsupportedRequestPolicy));
+    }
+
+    #[test]
     fn merge_session_policy_returns_none_for_empty_inputs() {
         let merged = merge_session_policies(None, &[]).expect("merge should succeed");
         assert!(merged.is_none());
     }
 
     #[test]
-    fn merge_rejects_oversized_inline_policy() {
-        let long_statement = policy(&["A"; 4000]);
+    fn merge_rejects_request_policy_without_binding_upper_bound() {
+        let request_policy = policy(&[allow_statement("RequestAll", "s3:*", "*")]);
 
-        let err = merge_session_policies(Some(&long_statement), &[])
+        let error = merge_session_policies(Some(&request_policy), &[])
+            .expect_err("request policy without a binding upper bound must be rejected");
+
+        assert!(matches!(error, StsError::UnsupportedRequestPolicy));
+    }
+
+    #[test]
+    fn merge_rejects_oversized_inline_policy() {
+        let long_sid = "A".repeat(4000);
+        let long_statement = policy(&[allow_statement(&long_sid, "s3:GetObject", "*")]);
+
+        let err = merge_session_policies(None, &[long_statement])
             .expect_err("policy should be too large");
         assert!(matches!(err, StsError::PackedPolicyTooLarge));
     }
 
     #[test]
-    fn merge_skips_no_statement_policy_as_malformed() {
+    fn normalize_policy_for_merge_rejects_empty_statement_array() {
         let no_statements = "{\"Version\":\"2012-10-17\",\"Statement\":[]}";
         assert!(matches!(
             normalize_policy_for_merge(no_statements),


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [x] Documentation
- [ ] Performance Improvement
- [x] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
Fixes rustfs/backlog#1071

## Summary of Changes
- Reject caller-supplied STS `Policy` request parameters before calling RustFS `AssumeRole`.
- Build the inline session policy only from policies authorized by the matched `PolicyBinding`.
- Add regression coverage proving request policies do not reach `assume_role`, while the normal PolicyBinding-only flow still passes the binding session policy.
- Document the current Operator STS constraint in the user guide and Helm README.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit` (fmt-check + clippy + test + console-lint + console-fmt-check)
- [x] Added/updated necessary tests
- [x] Documentation updated (if needed)
- [x] CHANGELOG.md updated under `[Unreleased]` (if user-visible change; N/A, this repository has no CHANGELOG.md)
- [ ] CI/CD passed (if applicable; pending GitHub Actions)

## Impact
- [ ] Breaking change (CRD/API compatibility)
- [x] Requires doc/config/deployment update
- [x] Other impact: Operator STS callers must omit the `Policy` request parameter; unsupported caller policies now fail with `AccessDenied`.

## Verification
```bash
cargo test -p operator --lib sts::session_policy::tests:: -- --nocapture
cargo test -p operator --lib sts::server::tests::sts_handler -- --nocapture
make test
make pre-commit
```

## Additional Notes
This is the conservative P0 fix: PolicyBinding remains the sole authorization source for the issued session policy. Full request-policy subset evaluation can be added later once the operator has a complete IAM policy semantics layer.