### PR TITLE
fix(sts): fail closed on policy binding errors

### DIFF
--- a/deploy/rustfs-operator/README.md
+++ b/deploy/rustfs-operator/README.md
@@ -272,7 +272,7 @@ curl -sS -X POST \
   --data-urlencode "DurationSeconds=3600"
 ```
 
-Operator STS derives the issued session policy from the matched `PolicyBinding` policies. Caller-supplied `Policy` request parameters are rejected until the operator can prove they only narrow the `PolicyBinding` permissions.
+Operator STS derives the issued session policy from the matched `PolicyBinding` policies. Every referenced policy must exist and resolve to a valid RustFS policy document. Caller-supplied `Policy` request parameters are rejected until the operator can prove they only narrow the `PolicyBinding` permissions.
 
 ## Creating Tenant Resources
 

--- a/docs/operator-user-guide.md
+++ b/docs/operator-user-guide.md
@@ -651,6 +651,7 @@ Current STS constraints:
 - STS only issues credentials for TLS-enabled Tenants.
 - Operator STS uses the explicit Tenant route with both namespace and name.
 - The `PolicyBinding` must reference at least one policy.
+- Every policy referenced by the matched `PolicyBinding` must resolve to a valid RustFS policy document.
 - Caller-supplied `Policy` request parameters are rejected; issued credentials use the matched `PolicyBinding` policies.
 - Tenants requiring client certificates for upstream Tenant calls are rejected by Operator STS.
 

--- a/docs/operator-user-guide.zh-CN.md
+++ b/docs/operator-user-guide.zh-CN.md
@@ -653,6 +653,7 @@ curl -sS -X POST \
 - STS 只为启用 TLS 的 Tenant 签发凭据。
 - Operator STS 使用显式 Tenant 路由，路径中同时包含 namespace 和 Tenant name。
 - `PolicyBinding` 至少需要引用一个 policy。
+- 匹配到的 `PolicyBinding` 引用的每个 policy 都必须能解析为有效 RustFS policy 文档。
 - 调用方传入的 `Policy` 请求参数会被拒绝；签发凭据只使用匹配的 `PolicyBinding` policies。
 - 如果 Tenant 要求 Operator STS 调用 Tenant 时使用 client certificate，目前会被 Operator STS 拒绝。
 

--- a/src/sts/server.rs
+++ b/src/sts/server.rs
@@ -439,9 +439,9 @@ async fn resolve_binding_policies<R: StsRuntime + Send + Sync>(
                     tracing::warn!(
                         policy = %policy_name,
                         error = %error,
-                        "Failed fetching PolicyBinding policy; skipping policy"
+                        "Failed fetching PolicyBinding policy"
                     );
-                    continue;
+                    return Err(StsError::InternalError);
                 }
             };
 
@@ -451,9 +451,9 @@ async fn resolve_binding_policies<R: StsRuntime + Send + Sync>(
                     tracing::warn!(
                         policy = %policy_name,
                         error = %error.code(),
-                        "Invalid PolicyBinding policy document; skipping policy"
+                        "Invalid PolicyBinding policy document"
                     );
-                    continue;
+                    return Err(error);
                 }
             }
         }
@@ -936,6 +936,120 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn sts_handler_rejects_invalid_binding_policy_without_assume_role() {
+        let runtime = MockStsRuntime {
+            identity: Mutex::new(Some(Ok(token_review::ServiceAccountIdentity {
+                namespace: "tenant-a".to_string(),
+                service_account: "workload-sa".to_string(),
+            }))),
+            policy_bindings: Mutex::new(Some(Ok(vec![PolicyBinding {
+                metadata: Default::default(),
+                spec: PolicyBindingSpec {
+                    application: PolicyBindingApplication {
+                        namespace: "tenant-a".to_string(),
+                        serviceaccount: "workload-sa".to_string(),
+                    },
+                    policies: vec![
+                        "policy-binding-good".to_string(),
+                        "policy-binding-invalid".to_string(),
+                    ],
+                },
+                status: None,
+            }]))),
+            tenant: Mutex::new(Some(Ok(crate::types::v1alpha1::tenant::Tenant {
+                metadata: Default::default(),
+                spec: Default::default(),
+                status: None,
+            }))),
+            create_client: Mutex::new(Some(Ok(RustfsAdminClient::new_with_base_url(
+                "http://127.0.0.1:1",
+                "access-key",
+                "secret-key",
+            )))),
+            fetch_policy_results: Mutex::new(VecDeque::from([
+                Ok("{\"Version\": \"2012-10-17\", \"Statement\": [{\"Sid\":\"binding-read\",\"Effect\":\"Allow\",\"Action\":\"s3:GetObject\",\"Resource\":\"arn:aws:s3:::bucket-a/*\"}]}".to_string()),
+                Ok("{\"Version\":\"2012-10-17\",\"Statement\":[]}".to_string()),
+            ])),
+            assume_role_result: Mutex::new(Some(Err(RustfsClientError::RequestFailed))),
+            assume_role_policies: Mutex::new(Vec::new()),
+        };
+
+        let form = AssumeRoleWithWebIdentityForm {
+            version: Some(STS_API_VERSION.to_string()),
+            action: Some(STS_WEB_IDENTITY_ACTION.to_string()),
+            web_identity_token: Some("sa-token".to_string()),
+            duration_seconds: Some("3600".to_string()),
+            policy: None,
+        };
+        let parsed = parse_sts_form("tenant-a".to_string(), "tenant-a".to_string(), form).unwrap();
+
+        let response = process_assume_role_request(&runtime, parsed).await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let text = String::from_utf8(body.to_vec()).unwrap();
+
+        assert!(text.contains("<Code>MalformedPolicyDocument</Code>"));
+        assert!(runtime.assume_role_policies.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn sts_handler_rejects_binding_policy_fetch_failure_without_assume_role() {
+        let runtime = MockStsRuntime {
+            identity: Mutex::new(Some(Ok(token_review::ServiceAccountIdentity {
+                namespace: "tenant-a".to_string(),
+                service_account: "workload-sa".to_string(),
+            }))),
+            policy_bindings: Mutex::new(Some(Ok(vec![PolicyBinding {
+                metadata: Default::default(),
+                spec: PolicyBindingSpec {
+                    application: PolicyBindingApplication {
+                        namespace: "tenant-a".to_string(),
+                        serviceaccount: "workload-sa".to_string(),
+                    },
+                    policies: vec![
+                        "policy-binding-good".to_string(),
+                        "policy-binding-unavailable".to_string(),
+                    ],
+                },
+                status: None,
+            }]))),
+            tenant: Mutex::new(Some(Ok(crate::types::v1alpha1::tenant::Tenant {
+                metadata: Default::default(),
+                spec: Default::default(),
+                status: None,
+            }))),
+            create_client: Mutex::new(Some(Ok(RustfsAdminClient::new_with_base_url(
+                "http://127.0.0.1:1",
+                "access-key",
+                "secret-key",
+            )))),
+            fetch_policy_results: Mutex::new(VecDeque::from([
+                Ok("{\"Version\": \"2012-10-17\", \"Statement\": [{\"Sid\":\"binding-read\",\"Effect\":\"Allow\",\"Action\":\"s3:GetObject\",\"Resource\":\"arn:aws:s3:::bucket-a/*\"}]}".to_string()),
+                Err(RustfsClientError::RequestFailed),
+            ])),
+            assume_role_result: Mutex::new(Some(Err(RustfsClientError::RequestFailed))),
+            assume_role_policies: Mutex::new(Vec::new()),
+        };
+
+        let form = AssumeRoleWithWebIdentityForm {
+            version: Some(STS_API_VERSION.to_string()),
+            action: Some(STS_WEB_IDENTITY_ACTION.to_string()),
+            web_identity_token: Some("sa-token".to_string()),
+            duration_seconds: Some("3600".to_string()),
+            policy: None,
+        };
+        let parsed = parse_sts_form("tenant-a".to_string(), "tenant-a".to_string(), form).unwrap();
+
+        let response = process_assume_role_request(&runtime, parsed).await;
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let text = String::from_utf8(body.to_vec()).unwrap();
+
+        assert!(text.contains("<Code>InternalError</Code>"));
+        assert!(runtime.assume_role_policies.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
     async fn sts_handler_rejects_matching_binding_without_valid_policies() {
         let runtime = MockStsRuntime {
             identity: Mutex::new(Some(Ok(token_review::ServiceAccountIdentity {
@@ -1037,7 +1151,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resolve_binding_policies_skips_invalid_binding_policies() {
+    async fn resolve_binding_policies_rejects_invalid_binding_policy_document() {
         let runtime = MockStsRuntime {
             identity: Mutex::new(None),
             policy_bindings: Mutex::new(None),
@@ -1069,16 +1183,50 @@ mod tests {
             status: None,
         }];
 
-        let policies = super::resolve_binding_policies(&runtime, &client, &bindings)
+        let error = super::resolve_binding_policies(&runtime, &client, &bindings)
             .await
-            .expect("valid referenced policies should allow the STS request");
+            .expect_err("invalid referenced policies must reject the STS request");
 
-        assert_eq!(policies.len(), 1);
-        assert!(policies[0].contains("\"Sid\":\"good\""));
+        assert!(matches!(error, StsError::MalformedPolicyDocument));
     }
 
     #[tokio::test]
-    async fn resolve_binding_policies_rejects_when_no_valid_binding_policy_exists() {
+    async fn resolve_binding_policies_rejects_fetch_failure_after_valid_policy() {
+        let runtime = MockStsRuntime {
+            identity: Mutex::new(None),
+            policy_bindings: Mutex::new(None),
+            tenant: Mutex::new(None),
+            create_client: Mutex::new(None),
+            fetch_policy_results: Mutex::new(VecDeque::from([
+                Ok("{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"good\",\"Effect\":\"Allow\"}]}".to_string()),
+                Err(RustfsClientError::RequestFailed),
+            ])),
+            assume_role_result: Mutex::new(None),
+            assume_role_policies: Mutex::new(Vec::new()),
+        };
+
+        let client = RustfsAdminClient::new_with_base_url("http://127.0.0.1:1", "access", "secret");
+        let bindings = vec![PolicyBinding {
+            metadata: Default::default(),
+            spec: PolicyBindingSpec {
+                application: PolicyBindingApplication {
+                    namespace: "tenant-a".to_string(),
+                    serviceaccount: "sa".to_string(),
+                },
+                policies: vec!["policy-good".to_string(), "policy-fail".to_string()],
+            },
+            status: None,
+        }];
+
+        let error = super::resolve_binding_policies(&runtime, &client, &bindings)
+            .await
+            .expect_err("failed referenced policies must reject the STS request");
+
+        assert!(matches!(error, StsError::InternalError));
+    }
+
+    #[tokio::test]
+    async fn resolve_binding_policies_rejects_fetch_failure_without_valid_policy() {
         let runtime = MockStsRuntime {
             identity: Mutex::new(None),
             policy_bindings: Mutex::new(None),
@@ -1106,9 +1254,9 @@ mod tests {
 
         let error = super::resolve_binding_policies(&runtime, &client, &bindings)
             .await
-            .expect_err("no valid binding policy must reject the STS request");
+            .expect_err("failed referenced policies must reject the STS request");
 
-        assert!(matches!(error, StsError::AccessDenied));
+        assert!(matches!(error, StsError::InternalError));
     }
 
     #[tokio::test]
@@ -1141,6 +1289,54 @@ mod tests {
             .expect_err("empty binding policy list must reject the STS request");
 
         assert!(matches!(error, StsError::AccessDenied));
+    }
+
+    #[tokio::test]
+    async fn resolve_binding_policies_rejects_failure_in_any_matched_binding() {
+        let runtime = MockStsRuntime {
+            identity: Mutex::new(None),
+            policy_bindings: Mutex::new(None),
+            tenant: Mutex::new(None),
+            create_client: Mutex::new(None),
+            fetch_policy_results: Mutex::new(VecDeque::from([
+                Ok("{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"good\",\"Effect\":\"Allow\"}]}".to_string()),
+                Err(RustfsClientError::RequestFailed),
+            ])),
+            assume_role_result: Mutex::new(None),
+            assume_role_policies: Mutex::new(Vec::new()),
+        };
+
+        let client = RustfsAdminClient::new_with_base_url("http://127.0.0.1:1", "access", "secret");
+        let bindings = vec![
+            PolicyBinding {
+                metadata: Default::default(),
+                spec: PolicyBindingSpec {
+                    application: PolicyBindingApplication {
+                        namespace: "tenant-a".to_string(),
+                        serviceaccount: "sa".to_string(),
+                    },
+                    policies: vec!["policy-good".to_string()],
+                },
+                status: None,
+            },
+            PolicyBinding {
+                metadata: Default::default(),
+                spec: PolicyBindingSpec {
+                    application: PolicyBindingApplication {
+                        namespace: "tenant-a".to_string(),
+                        serviceaccount: "sa".to_string(),
+                    },
+                    policies: vec!["policy-fail".to_string()],
+                },
+                status: None,
+            },
+        ];
+
+        let error = super::resolve_binding_policies(&runtime, &client, &bindings)
+            .await
+            .expect_err("any failed binding policy must reject the STS request");
+
+        assert!(matches!(error, StsError::InternalError));
     }
 
     struct MockStsRuntime {


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [x] Documentation
- [ ] Performance Improvement
- [x] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
Fixes rustfs/backlog#1077

## Summary of Changes
- Fail closed when any policy referenced by a matched `PolicyBinding` cannot be fetched from RustFS.
- Fail closed when any referenced `PolicyBinding` policy document cannot be normalized for STS session-policy merging.
- Keep empty `PolicyBinding` policy lists denied, while preserving specific `InternalError` and `MalformedPolicyDocument` responses for fetch and parse failures.
- Add resolver and handler regressions proving partial policy resolution never reaches RustFS `AssumeRole`.
- Document that every referenced `PolicyBinding` policy must exist and resolve to a valid RustFS policy document.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit` (fmt-check + clippy + test + console-lint + console-fmt-check)
- [x] Added/updated necessary tests
- [x] Documentation updated (if needed)
- [ ] CHANGELOG.md updated under `[Unreleased]` (N/A: repository has no `CHANGELOG.md`)
- [ ] CI/CD passed (if applicable) (pending PR CI)

## Impact
- [ ] Breaking change (CRD/API compatibility)
- [x] Requires doc/config/deployment update
- [x] Other impact: STS now fails closed when referenced `PolicyBinding` policies are missing, unavailable, or malformed instead of issuing credentials from a partial policy set.

## Verification
```bash
cargo test -p operator --lib sts::server::tests:: -- --nocapture
make pre-commit
```

## Additional Notes
Live e2e tests remain ignored by default and were not run outside `make pre-commit`.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
