### PR TITLE
fix(console): use console service account in login hint

### DIFF
--- a/console-web/app/(auth)/auth/login/page.tsx
+++ b/console-web/app/(auth)/auth/login/page.tsx
@@ -101,8 +101,7 @@ export default function LoginPage() {
               <div className="flex flex-col gap-2 border border-border bg-muted p-3">
                 <p className="text-xs text-muted-foreground">{t("Run the following command to generate a token:")}</p>
                 <pre className="overflow-x-auto bg-background p-2 font-mono text-xs text-foreground">
-                  {`kubectl create token rustfs-operator \\
-  -n rustfs-system \\
+                  {`kubectl -n rustfs-system create token rustfs-operator-console \\
   --duration=24h`}
                 </pre>
                 <p className="text-xs text-muted-foreground">{t("Paste the token above to sign in.")}</p>

--- a/deploy/rustfs-operator/README.md
+++ b/deploy/rustfs-operator/README.md
@@ -362,7 +362,8 @@ kubectl -n rustfs-system create token rustfs-operator-console --duration=24h
 ```
 
 Paste the printed token into the Console login form. Use the namespace and
-ServiceAccount name from your Helm release if they differ from the defaults.
+ServiceAccount name from your Helm release if they differ from the defaults;
+the Helm install notes print the exact command for the deployed release.
 
 ## Verifying the Installation
 

--- a/deploy/rustfs-operator/templates/NOTES.txt
+++ b/deploy/rustfs-operator/templates/NOTES.txt
@@ -32,4 +32,20 @@ To view Tenant resources:
 
   kubectl get tenants --all-namespaces
 
+{{ if .Values.console.enabled }}
+To log in to the Operator Console, create a short-lived token for the chart-managed Console ServiceAccount:
+
+  kubectl -n {{ include "rustfs-operator.namespace" . }} create token {{ include "rustfs-operator.consoleServiceAccountName" . }} --duration=24h
+
+{{ if .Values.console.frontend.enabled }}
+To open the legacy split Console frontend locally:
+
+  kubectl -n {{ include "rustfs-operator.namespace" . }} port-forward svc/{{ include "rustfs-operator.fullname" . }}-console-frontend 18080:{{ .Values.console.frontend.service.port }}
+{{ else }}
+To open the Operator Console locally:
+
+  kubectl -n {{ include "rustfs-operator.namespace" . }} port-forward svc/{{ include "rustfs-operator.fullname" . }}-console 19090:{{ .Values.console.service.port }}
+{{ end }}
+
+{{ end }}
 For more information, visit: {{ .Chart.Home }}

--- a/docs/operator-user-guide.md
+++ b/docs/operator-user-guide.md
@@ -666,6 +666,8 @@ kubectl -n rustfs-system create token rustfs-operator-console --duration=24h
 ```
 
 Paste the token into the login form. The Console stores the validated token in an encrypted session cookie.
+If your Helm release uses a custom namespace or `console.serviceAccount.name`,
+use the command printed in the Helm install notes.
 
 For local port-forward testing:
 

--- a/docs/operator-user-guide.zh-CN.md
+++ b/docs/operator-user-guide.zh-CN.md
@@ -668,6 +668,7 @@ kubectl -n rustfs-system create token rustfs-operator-console --duration=24h
 ```
 
 将 token 粘贴到 Console 登录页。Console 会把验证后的 token 存入加密 session cookie。
+如果 Helm release 使用了自定义 namespace 或 `console.serviceAccount.name`，请以 Helm 安装提示中输出的命令为准。
 
 本地 port-forward 调试：
 


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [x] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
Fixes #160

## Summary of Changes
- Update the Console login help command to create a token for the chart-managed Console ServiceAccount instead of the operator controller ServiceAccount.
- Add Helm install notes that print the exact token command using the release namespace and `consoleServiceAccountName` helper.
- Clarify the chart README and operator user guides to follow Helm install notes when namespace or Console ServiceAccount names are customized.

Root cause: the Console login form documented `rustfs-operator`, but Console login expects a Kubernetes bearer token with the Console RBAC permissions granted to `rustfs-operator-console` by default.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit` (fmt-check + clippy + test + console-lint + console-fmt-check)
- [ ] Added/updated necessary tests
- [x] Documentation updated (if needed)
- [ ] CHANGELOG.md updated under `[Unreleased]` (if user-visible change)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (CRD/API compatibility)
- [x] Requires doc/config/deployment update
- [ ] Other impact:

## Verification
```bash
make pre-commit
```

## Additional Notes
No runtime RBAC or authentication behavior changes are included; this only aligns user-facing token guidance with the existing Console ServiceAccount boundary.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
