### PR TITLE
fix: redact STS credential field aliases

### DIFF
--- a/src/sts/tests.rs
+++ b/src/sts/tests.rs
@@ -155,15 +155,21 @@ fn unexpected_status_includes_upstream_json_error_summary() {
 fn unexpected_status_redacts_sensitive_upstream_error_summary() {
     let err = RustfsClientError::unexpected_status_with_body(
         StatusCode::BAD_REQUEST,
-        r#"{"code":"InvalidRequest","message":"secretkey: SK_TEST clientSecret: oidc-secret <AccessKey>AKIA_XML</AccessKey>"}"#,
+        r#"{"code":"InvalidRequest","message":"secretkey: SK_TEST clientSecret: oidc-secret SecretAccessKey: SK_STS AccessKeyId: AKIA_STS <SecretAccessKey>SK_XML</SecretAccessKey> <AccessKeyId>AKIA_XML</AccessKeyId>"}"#,
     );
 
     let message = err.to_string();
     assert!(message.contains("secretkey: <redacted>"));
     assert!(message.contains("clientSecret: <redacted>"));
-    assert!(message.contains("<AccessKey><redacted></AccessKey>"));
+    assert!(message.contains("SecretAccessKey: <redacted>"));
+    assert!(message.contains("AccessKeyId: <redacted>"));
+    assert!(message.contains("<SecretAccessKey><redacted></SecretAccessKey>"));
+    assert!(message.contains("<AccessKeyId><redacted></AccessKeyId>"));
     assert!(!message.contains("SK_TEST"));
     assert!(!message.contains("oidc-secret"));
+    assert!(!message.contains("SK_STS"));
+    assert!(!message.contains("AKIA_STS"));
+    assert!(!message.contains("SK_XML"));
     assert!(!message.contains("AKIA_XML"));
 }
 

--- a/src/utils/sanitize.rs
+++ b/src/utils/sanitize.rs
@@ -12,15 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const SENSITIVE_KEYS: [&str; 16] = [
+const SENSITIVE_KEYS: [&str; 22] = [
     "token",
     "password",
     "accesskey",
     "access_key",
     "access-key",
+    "accesskeyid",
+    "access_key_id",
+    "access-key-id",
     "secretkey",
     "secret_key",
     "secret-key",
+    "secretaccesskey",
+    "secret_access_key",
+    "secret-access-key",
     "clientsecret",
     "client_secret",
     "client-secret",
@@ -42,7 +48,9 @@ fn is_sensitive_key(key: &str) -> bool {
         "token"
             | "password"
             | "accesskey"
+            | "accesskeyid"
             | "secretkey"
+            | "secretaccesskey"
             | "clientsecret"
             | "sessiontoken"
             | "credential"
@@ -279,6 +287,26 @@ mod tests {
         assert!(sanitized.contains("<SecretKey><redacted></SecretKey>"));
         assert!(!sanitized.contains("oidc-secret"));
         assert!(!sanitized.contains("AKIA_JSON"));
+        assert!(!sanitized.contains("SK_XML"));
+    }
+
+    #[test]
+    fn redacts_sts_credential_field_names() {
+        let message = r#"AccessKeyId: AKIA_TEXT SecretAccessKey: SK_TEXT {"access_key_id":"AKIA_JSON","secret-access-key":"SK_JSON"} <AccessKeyId>AKIA_XML</AccessKeyId> <SecretAccessKey>SK_XML</SecretAccessKey>"#;
+
+        let sanitized = redact_sensitive_pairs(message);
+
+        assert!(sanitized.contains("AccessKeyId: <redacted>"));
+        assert!(sanitized.contains("SecretAccessKey: <redacted>"));
+        assert!(sanitized.contains(r#""access_key_id":"<redacted>""#));
+        assert!(sanitized.contains(r#""secret-access-key":"<redacted>""#));
+        assert!(sanitized.contains("<AccessKeyId><redacted></AccessKeyId>"));
+        assert!(sanitized.contains("<SecretAccessKey><redacted></SecretAccessKey>"));
+        assert!(!sanitized.contains("AKIA_TEXT"));
+        assert!(!sanitized.contains("SK_TEXT"));
+        assert!(!sanitized.contains("AKIA_JSON"));
+        assert!(!sanitized.contains("SK_JSON"));
+        assert!(!sanitized.contains("AKIA_XML"));
         assert!(!sanitized.contains("SK_XML"));
     }
 


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [x] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
Follow-up to PR review feedback on #180: https://github.com/rustfs/operator/pull/180#discussion_r3564360361

## Summary of Changes
- Add STS credential field aliases (`AccessKeyId`, `SecretAccessKey`) to upstream error redaction.
- Cover both key/value summaries and XML tag redaction before RustFS upstream response bodies are surfaced in operator errors.
- Extend sanitizer and RustFS client error summary tests for the STS credential field names.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit` (fmt-check + clippy + test + console-lint + console-fmt-check)
- [x] Added/updated necessary tests
- [x] Documentation updated (if needed; N/A)
- [x] CHANGELOG.md updated under `[Unreleased]` (if user-visible change; N/A)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (CRD/API compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact: prevents STS credential values from appearing in upstream error details.

## Verification
```bash
cargo test redacts_sts_credential_field_names
cargo test unexpected_status_redacts_sensitive_upstream_error_summary
git diff --check
make pre-commit
```

## Additional Notes
This keeps the existing redaction approach intact and only extends the sensitive-key aliases used by the existing match paths.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
