### PR TITLE
fix(rbac): migrate unlabeled tenant resources

### DIFF
--- a/src/reconcile/phases.rs
+++ b/src/reconcile/phases.rs
@@ -275,13 +275,23 @@ fn operator_resource_owned_by_tenant_or_predecessor(
                     .iter()
                     .any(|owner| owner.controller == Some(true) && !owner_matches_tenant(owner)))
     });
+    let current_owner_matches = tenant.meta().uid.as_ref().is_some_and(|tenant_uid| {
+        metadata.owner_references.as_ref().is_some_and(|owners| {
+            owners.iter().any(|owner| {
+                owner_matches_tenant(owner) && owner.uid.as_str() == tenant_uid.as_str()
+            })
+        })
+    });
     let legacy_manager_matches = metadata.managed_fields.as_ref().is_some_and(|fields| {
         fields
             .iter()
             .any(|field| field.manager.as_deref() == Some("rustfs-operator"))
     });
 
-    labels_match && legacy_manager_matches && owner_scope_matches
+    // Early Operator releases created Tenant resources before common labels were added. An exact
+    // current Tenant owner UID plus the legacy SSA manager is sufficient provenance for those
+    // resources, while stale unlabeled resources remain untouched.
+    legacy_manager_matches && owner_scope_matches && (labels_match || current_owner_matches)
 }
 
 fn security_patch_metadata(
@@ -1465,13 +1475,25 @@ mod tests {
             &tenant
         ));
 
-        let missing_labels = ObjectMeta {
+        let unlabeled_current_owned = ObjectMeta {
             owner_references: Some(vec![tenant.new_owner_ref()]),
             managed_fields: Some(operator_managed_fields()),
             ..Default::default()
         };
+        assert!(operator_resource_owned_by_tenant_or_predecessor(
+            &unlabeled_current_owned,
+            &tenant
+        ));
+
+        let mut stale_unlabeled_owner = tenant.new_owner_ref();
+        stale_unlabeled_owner.uid = "previous-tenant-uid".to_string();
+        let unlabeled_stale_owned = ObjectMeta {
+            owner_references: Some(vec![stale_unlabeled_owner]),
+            managed_fields: Some(operator_managed_fields()),
+            ..Default::default()
+        };
         assert!(!operator_resource_owned_by_tenant_or_predecessor(
-            &missing_labels,
+            &unlabeled_stale_owned,
             &tenant
         ));
 


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [x] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
Follow-up to rustfs/backlog#1080 and rustfs/operator#195.

## Summary of Changes
- Recognize unlabeled Tenant resources created by early Operator releases when the legacy SSA manager and the exact current Tenant controller owner UID both match.
- Keep stale unlabeled predecessor resources and resources with a foreign controller outside the cleanup boundary.
- Extend the ownership regression test to cover both the accepted current-UID case and the rejected stale-UID case.

The original security migration required common labels before removing legacy workload RBAC or hardening default ServiceAccount tokens. Releases before common labels were introduced created these resources without labels, so a direct upgrade could leave the broad legacy Role and RoleBinding in place. The exact owner UID fallback closes that migration gap without weakening protection for same-name user-managed resources.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit` (fmt-check + clippy + test + console-lint + console-fmt-check)
- [x] Added/updated necessary tests
- [x] Documentation updated (N/A: no user-facing contract changes)
- [x] CHANGELOG.md updated under `[Unreleased]` (N/A: this repository does not contain CHANGELOG.md)
- [x] CI/CD passed

## Impact
- [ ] Breaking change (CRD/API compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact: Direct upgrades from early Operator releases now remove legacy workload RBAC and harden operator-managed Tenant identities.

## Verification
```bash
cargo test reconcile::phases::tests::operator_ownership_recognizes_recreated_and_orphaned_tenants -- --exact
make pre-commit
```

## Additional Notes
- The fallback still requires the `rustfs-operator` managed-fields entry, the exact current Tenant UID, and no foreign controller owner.
- Unlabeled resources owned by a previous Tenant UID remain untouched.
- A live Kubernetes upgrade from the pre-label release was not run locally.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
