### PR TITLE
fix(monitoring): parse wrapped tenant server info

### DIFF
--- a/src/sts/admin_ops.rs
+++ b/src/sts/admin_ops.rs
@@ -22,7 +22,7 @@ use super::helpers::{body_mentions_not_found, build_query_pairs, extract_canned_
 use super::{
     ADD_CANNED_POLICY_PATH, ADD_USER_PATH, ADMIN_SIGNING_SERVICE, INFO_CANNED_POLICY_PATH,
     JSON_CONTENT_TYPE, LIST_CANNED_POLICIES_PATH, RustfsAdminClient, RustfsClientError,
-    RustfsServerInfo, SERVER_INFO_PATH, SET_POLICY_PATH, USER_INFO_PATH,
+    RustfsServerInfo, RustfsServerInfoResponse, SERVER_INFO_PATH, SET_POLICY_PATH, USER_INFO_PATH,
 };
 use reqwest::StatusCode;
 use serde_json::Value;
@@ -148,7 +148,8 @@ impl RustfsAdminClient {
         let body = self
             .send_admin_request("GET", SERVER_INFO_PATH, "", "", None)
             .await?;
-        serde_json::from_str::<RustfsServerInfo>(&body)
+        serde_json::from_str::<RustfsServerInfoResponse>(&body)
+            .map(|response| response.info)
             .map_err(|_| RustfsClientError::ParseResponseFailed)
     }
 

--- a/src/sts/rustfs_client.rs
+++ b/src/sts/rustfs_client.rs
@@ -138,6 +138,11 @@ pub struct RustfsServerInfo {
     pub pools: Option<BTreeMap<String, BTreeMap<String, RustfsErasureSetInfo>>>,
 }
 
+#[derive(Debug, Clone, serde::Deserialize, PartialEq)]
+pub(super) struct RustfsServerInfoResponse {
+    pub info: RustfsServerInfo,
+}
+
 #[derive(Debug, Clone, Default, serde::Deserialize, PartialEq)]
 pub struct RustfsServerUsage {
     #[serde(default)]

--- a/src/sts/tests.rs
+++ b/src/sts/tests.rs
@@ -563,7 +563,7 @@ async fn add_canned_policy_reports_upstream_policy_parse_error() {
 }
 
 #[tokio::test]
-async fn server_info_uses_expected_path_and_parses_health_fields() {
+async fn server_info_uses_expected_path_and_parses_wrapped_health_fields() {
     let capture = Capture::default();
     let route_capture = capture.clone();
 
@@ -586,25 +586,32 @@ async fn server_info_uses_expected_path_and_parses_health_fields() {
                     (
                         StatusCode::OK,
                         serde_json::json!({
-                            "usage": {"size": 42},
-                            "backend": {
-                                "onlineDisks": 3,
-                                "offlineDisks": 1,
-                                "standardSCParity": 2,
-                                "totalSets": [1],
-                                "totalDrivesPerSet": [4]
-                            },
-                            "pools": {
-                                "0": {
+                            "info": {
+                                "usage": {"size": 42},
+                                "backend": {
+                                    "onlineDisks": 3,
+                                    "offlineDisks": 1,
+                                    "standardSCParity": 2,
+                                    "totalSets": [1],
+                                    "totalDrivesPerSet": [4]
+                                },
+                                "pools": {
                                     "0": {
-                                        "rawUsage": 100,
-                                        "rawCapacity": 400,
-                                        "usage": 50,
-                                        "objectsCount": 2,
-                                        "healDisks": 1
+                                        "0": {
+                                            "rawUsage": 100,
+                                            "rawCapacity": 400,
+                                            "usage": 50,
+                                            "objectsCount": 2,
+                                            "healDisks": 1
+                                        }
                                     }
                                 }
-                            }
+                            },
+                            "admin_discovery": {
+                                "runtimeCapabilities": "/rustfs/admin/v4/runtime/capabilities",
+                                "clusterSnapshot": "/rustfs/admin/v4/cluster/snapshot",
+                                "extensionsCatalog": "/rustfs/admin/v4/extensions/catalog"
+                            },
                         })
                         .to_string(),
                     )


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
Fixes #199

## Summary of Changes
- Deserialize the RustFS server-info response envelope before reading Tenant storage data.
- Require the top-level `info` field instead of silently accepting an empty server-info snapshot.
- Update the server-info regression test to use the response shape returned by RustFS `1.0.0-beta.10`.

The Operator previously parsed the entire `/rustfs/admin/v3/info` response as the inner server-info object. Since the modeled fields have Serde defaults, the response envelope was accepted as an empty value and the poll was reported as successful with every derived Tenant metric set to zero.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit` (fmt-check + clippy + test + console-lint + console-fmt-check)
- [x] Added/updated necessary tests
- [x] Documentation updated (N/A; no documentation change is required)
- [ ] CHANGELOG.md updated under `[Unreleased]` (not updated)
- [ ] CI/CD passed (pending)

## Impact
- [ ] Breaking change (CRD/API compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact: Restores non-zero Operator-derived Tenant storage health and capacity metrics.

## Verification
```bash
make pre-commit
```

## Additional Notes
No configuration or CRD changes are required.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
