### PR TITLE
fix(sts): limit web identity sessions to 12 hours

### DIFF
--- a/src/sts/types.rs
+++ b/src/sts/types.rs
@@ -20,7 +20,7 @@ pub const STS_API_VERSION: &str = "2011-06-15";
 pub const STS_WEB_IDENTITY_ACTION: &str = "AssumeRoleWithWebIdentity";
 pub const STS_DEFAULT_DURATION_SECONDS: u64 = 3600;
 pub const STS_MIN_DURATION_SECONDS: u64 = 900;
-pub const STS_MAX_DURATION_SECONDS: u64 = 31_536_000;
+pub const STS_MAX_DURATION_SECONDS: u64 = 43_200;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StsParsedRequest {
@@ -330,7 +330,7 @@ mod tests {
                 STS_API_VERSION,
                 STS_WEB_IDENTITY_ACTION,
                 "token",
-                Some("31536001"),
+                Some("43201"),
                 None,
             ),
         );
@@ -364,7 +364,7 @@ mod tests {
                 STS_API_VERSION,
                 STS_WEB_IDENTITY_ACTION,
                 "token",
-                Some("31536000"),
+                Some("43200"),
                 None,
             ),
         )
@@ -372,6 +372,28 @@ mod tests {
 
         assert_eq!(minimum.duration_seconds, STS_MIN_DURATION_SECONDS);
         assert_eq!(maximum.duration_seconds, STS_MAX_DURATION_SECONDS);
+    }
+
+    #[test]
+    fn parse_rejects_legacy_one_year_duration() {
+        let request = parse_sts_form(
+            "tenant-a".to_string(),
+            "rustfs-a".to_string(),
+            form(
+                STS_API_VERSION,
+                STS_WEB_IDENTITY_ACTION,
+                "token",
+                Some("31536000"),
+                None,
+            ),
+        );
+
+        assert!(matches!(
+            request,
+            Err(StsError::InvalidParameterValue {
+                parameter: "DurationSeconds"
+            })
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [x] Test/CI
- [ ] Refactor
- [ ] Other: N/A

## Related Issues
Closes rustfs/backlog#1090.

## Summary of Changes
- Align Operator STS `DurationSeconds` validation with the AWS `AssumeRoleWithWebIdentity` maximum of 43,200 seconds.
- Reject values above 12 hours before TokenReview or any RustFS backend call.
- Add boundary coverage for 43,200, 43,201, and the legacy one-year value.

RustFS currently clamps oversized durations to 12 hours, so this change is protocol alignment and defense in depth: the Operator now returns the AWS-compatible `InvalidParameterValue` response instead of accepting an invalid request and relying on the downstream safeguard.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit` (fmt-check + clippy + test + console-lint + console-fmt-check)
- [x] Added/updated necessary tests
- [x] Documentation updated (N/A: the public limit now matches the AWS-compatible API contract)
- [x] CHANGELOG.md updated under `[Unreleased]` (N/A: this repository does not contain CHANGELOG.md)
- [ ] CI/CD passed (pending remote CI)

## Impact
- [ ] Breaking change (CRD/API compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact: Requests above 12 hours now fail at the Operator boundary instead of being accepted and clamped downstream.

## Verification
```bash
cargo test sts::types::tests::parse_ -- --nocapture
make pre-commit
```

## Additional Notes
- The default remains 3,600 seconds and the minimum remains 900 seconds.
- Values above the maximum are rejected rather than silently clamped, matching AWS STS behavior.
- AWS API reference: https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.