### PR TITLE
fix(operator): tolerate transient node lookup failures

### DIFF
--- a/src/reconcile.rs
+++ b/src/reconcile.rs
@@ -25,7 +25,7 @@ use kube::runtime::controller::Action;
 use kube::runtime::events::EventType;
 use kube::{Resource, ResourceExt};
 use snafu::Snafu;
-use std::collections::HashMap;
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::{debug, info, warn};
@@ -89,7 +89,7 @@ pub async fn reconcile_rustfs(tenant: Arc<Tenant>, ctx: Arc<Context>) -> Result<
     validate_tenant_prerequisites(&ctx, &latest_tenant).await?;
     let tls_plan = tls::reconcile_tls(&ctx, &latest_tenant, &ns).await?;
 
-    maybe_cleanup_terminating_pods(&ctx, &latest_tenant, &ns).await?;
+    let pod_cleanup_outcome = maybe_cleanup_terminating_pods(&ctx, &latest_tenant, &ns).await?;
 
     reconcile_service_account(&ctx, &latest_tenant, &ns).await?;
 
@@ -117,7 +117,7 @@ pub async fn reconcile_rustfs(tenant: Arc<Tenant>, ctx: Arc<Context>) -> Result<
         &removed_pool_cleanup,
     )
     .await?;
-    finalize_tenant_status(&ctx, &latest_tenant, summary, tls_plan).await
+    finalize_tenant_status(&ctx, &latest_tenant, summary, tls_plan, pod_cleanup_outcome).await
 }
 
 async fn context_result<T>(
@@ -428,10 +428,11 @@ enum NodePodDeletionSafety {
     Fenced,
 }
 
-enum CachedNodeLookup {
-    Found(Box<corev1::Node>),
-    NotFound,
-    Failed,
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(super) enum PodCleanupOutcome {
+    #[default]
+    Complete,
+    RetryNeeded,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -476,7 +477,7 @@ async fn cleanup_stuck_terminating_pods_on_down_nodes(
     namespace: &str,
     ctx: &Context,
     policy: crate::types::v1alpha1::k8s::PodDeletionPolicyWhenNodeIsDown,
-) -> Result<(), Error> {
+) -> Result<PodCleanupOutcome, Error> {
     let pods_api: kube::Api<corev1::Pod> = kube::Api::namespaced(ctx.client.clone(), namespace);
     let nodes_api: kube::Api<corev1::Node> = kube::Api::all(ctx.client.clone());
     let statefulsets_api: kube::Api<appsv1::StatefulSet> =
@@ -493,7 +494,7 @@ async fn cleanup_stuck_terminating_pods_on_down_nodes(
         .map_err(|source| Error::Context {
             source: context::Error::Kube { source },
         })?;
-    let mut node_lookup_by_name = HashMap::new();
+    let mut failed_node_names = HashSet::new();
 
     for pod in pods.items {
         // Only act on terminating pods to keep the behavior conservative.
@@ -603,40 +604,27 @@ async fn cleanup_stuck_terminating_pods_on_down_nodes(
             continue;
         };
 
-        if !node_lookup_by_name.contains_key(&node_name) {
-            let lookup = match nodes_api.get(&node_name).await {
-                Ok(node) => CachedNodeLookup::Found(Box::new(node)),
-                Err(kube::Error::Api(ae)) if ae.code == 404 => CachedNodeLookup::NotFound,
-                Err(source) => {
-                    warn!(
-                        tenant = %tenant.name(),
-                        namespace = %namespace,
-                        node = %node_name,
-                        error = %source,
-                        "skipping terminating pod cleanup because the Node could not be inspected"
-                    );
-                    let _ = ctx
-                        .record(
-                            tenant,
-                            EventType::Warning,
-                            "PodCleanupNodeLookupFailed",
-                            &format!(
-                                "Skipped terminating Pod cleanup because Node '{}' could not be inspected; the Operator will retry on a later reconcile",
-                                node_name
-                            ),
-                        )
-                        .await;
-                    CachedNodeLookup::Failed
-                }
-            };
-            node_lookup_by_name.insert(node_name.clone(), lookup);
+        if failed_node_names.contains(&node_name) {
+            continue;
         }
 
-        let node_deletion_safety = match node_lookup_by_name.get(&node_name) {
-            Some(CachedNodeLookup::Found(node)) => node_pod_deletion_safety(node, &pod),
-            Some(CachedNodeLookup::NotFound) => NodePodDeletionSafety::Fenced,
-            Some(CachedNodeLookup::Failed) => continue,
-            None => continue,
+        // Fencing is destructive-operation evidence, so refresh it for every Pod instead of
+        // reusing a Node snapshot across the reconcile loop. Only failed lookups are remembered to
+        // avoid repeatedly calling an already failing dependency.
+        let node_deletion_safety = match nodes_api.get(&node_name).await {
+            Ok(node) => node_pod_deletion_safety(&node, &pod),
+            Err(kube::Error::Api(ae)) if ae.code == 404 => NodePodDeletionSafety::Fenced,
+            Err(source) => {
+                warn!(
+                    tenant = %tenant.name(),
+                    namespace = %namespace,
+                    node = %node_name,
+                    error = %source,
+                    "skipping terminating pod cleanup because the Node could not be inspected"
+                );
+                failed_node_names.insert(node_name);
+                continue;
+            }
         };
 
         if node_deletion_safety == NodePodDeletionSafety::Ready {
@@ -716,7 +704,22 @@ async fn cleanup_stuck_terminating_pods_on_down_nodes(
         }
     }
 
-    Ok(())
+    if failed_node_names.is_empty() {
+        Ok(PodCleanupOutcome::Complete)
+    } else {
+        let failed_node_count = failed_node_names.len();
+        let _ = ctx
+            .record(
+                tenant,
+                EventType::Warning,
+                "PodCleanupNodeLookupFailed",
+                &format!(
+                    "Skipped terminating Pod cleanup because {failed_node_count} Node lookup(s) failed; the Operator will retry after a bounded delay"
+                ),
+            )
+            .await;
+        Ok(PodCleanupOutcome::RetryNeeded)
+    }
 }
 
 fn pod_matches_policy_controller_kind(
@@ -1021,7 +1024,7 @@ fn reconcile_error_reason(error: &Error) -> &'static str {
 mod tests {
     use super::is_node_down;
     use super::{
-        NodePodDeletionSafety, PodCleanupDecision, cleanup_decision_for_pod,
+        NodePodDeletionSafety, PodCleanupDecision, PodCleanupOutcome, cleanup_decision_for_pod,
         cleanup_stuck_terminating_pods_on_down_nodes, force_delete_requires_fencing,
         node_pod_deletion_safety, object_owned_by_tenant, pod_controller_owner_name_and_uid,
         pod_has_owner_kind, pod_matches_policy_controller_kind,
@@ -1073,9 +1076,16 @@ mod tests {
     #[tokio::test]
     async fn node_lookup_failure_skips_pod_cleanup_without_repeating_or_deleting() {
         let tenant = crate::tests::create_test_tenant(None, None);
+        let mut pod_on_second_node = terminating_tenant_pod(&tenant, "pod-c");
+        pod_on_second_node
+            .spec
+            .as_mut()
+            .expect("test Pod should have a spec")
+            .node_name = Some("node-b".to_string());
         let pods = vec![
             terminating_tenant_pod(&tenant, "pod-a"),
             terminating_tenant_pod(&tenant, "pod-b"),
+            pod_on_second_node,
         ];
         let request_count = Arc::new(AtomicUsize::new(0));
         let service = service_fn({
@@ -1114,6 +1124,20 @@ mod tests {
                             )
                         }
                         2 => {
+                            assert_eq!(request.method(), Method::GET);
+                            assert_eq!(request.uri().path(), "/api/v1/nodes/node-b");
+                            kube_response(
+                                StatusCode::INTERNAL_SERVER_ERROR,
+                                json!({
+                                    "apiVersion": "v1",
+                                    "kind": "Status",
+                                    "status": "Failure",
+                                    "reason": "InternalError",
+                                    "code": 500
+                                }),
+                            )
+                        }
+                        3 => {
                             assert_eq!(request.method(), Method::POST);
                             assert!(request.uri().path().contains("/events"));
                             kube_response(
@@ -1135,7 +1159,7 @@ mod tests {
         });
         let ctx = Context::new(Client::new(service, "default"));
 
-        cleanup_stuck_terminating_pods_on_down_nodes(
+        let outcome = cleanup_stuck_terminating_pods_on_down_nodes(
             &tenant,
             "default",
             &ctx,
@@ -1144,38 +1168,33 @@ mod tests {
         .await
         .expect("Node lookup failures must not block the main reconcile path");
 
-        assert_eq!(request_count.load(Ordering::SeqCst), 3);
+        assert_eq!(outcome, PodCleanupOutcome::RetryNeeded);
+        assert_eq!(request_count.load(Ordering::SeqCst), 4);
     }
 
     #[tokio::test]
-    async fn cached_node_is_evaluated_against_each_pods_tolerations() {
+    async fn node_fencing_is_refreshed_before_each_pod_deletion() {
         let tenant = crate::tests::create_test_tenant(None, None);
-        let pod_without_toleration = terminating_tenant_pod(&tenant, "pod-a");
-        let mut pod_with_toleration = terminating_tenant_pod(&tenant, "pod-b");
-        pod_with_toleration
-            .spec
-            .as_mut()
-            .expect("test Pod should have a spec")
-            .tolerations = Some(vec![corev1::Toleration {
-            key: Some(super::OUT_OF_SERVICE_TAINT_KEY.to_string()),
-            operator: Some("Exists".to_string()),
-            effect: Some("NoExecute".to_string()),
-            ..Default::default()
-        }]);
-        let pods = vec![pod_without_toleration, pod_with_toleration];
-        let node = node_with_out_of_service_taint();
+        let pods = vec![
+            terminating_tenant_pod(&tenant, "pod-a"),
+            terminating_tenant_pod(&tenant, "pod-b"),
+        ];
+        let fenced_node = node_with_out_of_service_taint();
+        let ready_node = node_with_ready_status("True");
         let node_get_count = Arc::new(AtomicUsize::new(0));
         let pod_delete_count = Arc::new(AtomicUsize::new(0));
         let event_count = Arc::new(AtomicUsize::new(0));
         let service = service_fn({
             let pods = pods.clone();
-            let node = node.clone();
+            let fenced_node = fenced_node.clone();
+            let ready_node = ready_node.clone();
             let node_get_count = Arc::clone(&node_get_count);
             let pod_delete_count = Arc::clone(&pod_delete_count);
             let event_count = Arc::clone(&event_count);
             move |request: Request<Body>| {
                 let pods = pods.clone();
-                let node = node.clone();
+                let fenced_node = fenced_node.clone();
+                let ready_node = ready_node.clone();
                 let node_get_count = Arc::clone(&node_get_count);
                 let pod_delete_count = Arc::clone(&pod_delete_count);
                 let event_count = Arc::clone(&event_count);
@@ -1192,7 +1211,11 @@ mod tests {
                             }),
                         ),
                         (&Method::GET, "/api/v1/nodes/node-a") => {
-                            node_get_count.fetch_add(1, Ordering::SeqCst);
+                            let node = if node_get_count.fetch_add(1, Ordering::SeqCst) == 0 {
+                                fenced_node
+                            } else {
+                                ready_node
+                            };
                             kube_response(
                                 StatusCode::OK,
                                 serde_json::to_value(node).expect("Node should serialize"),
@@ -1230,18 +1253,19 @@ mod tests {
         });
         let ctx = Context::new(Client::new(service, "default"));
 
-        cleanup_stuck_terminating_pods_on_down_nodes(
+        let outcome = cleanup_stuck_terminating_pods_on_down_nodes(
             &tenant,
             "default",
             &ctx,
             crate::types::v1alpha1::k8s::PodDeletionPolicyWhenNodeIsDown::ForceDelete,
         )
         .await
-        .expect("cached Nodes should preserve per-Pod fencing checks");
+        .expect("fencing refresh should preserve safe cleanup");
 
-        assert_eq!(node_get_count.load(Ordering::SeqCst), 1);
+        assert_eq!(outcome, PodCleanupOutcome::Complete);
+        assert_eq!(node_get_count.load(Ordering::SeqCst), 2);
         assert_eq!(pod_delete_count.load(Ordering::SeqCst), 1);
-        assert_eq!(event_count.load(Ordering::SeqCst), 2);
+        assert_eq!(event_count.load(Ordering::SeqCst), 1);
     }
 
     fn node_with_ready_status(status: &str) -> corev1::Node {

--- a/src/reconcile.rs
+++ b/src/reconcile.rs
@@ -25,6 +25,7 @@ use kube::runtime::controller::Action;
 use kube::runtime::events::EventType;
 use kube::{Resource, ResourceExt};
 use snafu::Snafu;
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::{debug, info, warn};
@@ -427,6 +428,12 @@ enum NodePodDeletionSafety {
     Fenced,
 }
 
+enum CachedNodeLookup {
+    Found(Box<corev1::Node>),
+    NotFound,
+    Failed,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct PodDeletionPlan {
     force: bool,
@@ -486,6 +493,7 @@ async fn cleanup_stuck_terminating_pods_on_down_nodes(
         .map_err(|source| Error::Context {
             source: context::Error::Kube { source },
         })?;
+    let mut node_lookup_by_name = HashMap::new();
 
     for pod in pods.items {
         // Only act on terminating pods to keep the behavior conservative.
@@ -595,14 +603,40 @@ async fn cleanup_stuck_terminating_pods_on_down_nodes(
             continue;
         };
 
-        let node_deletion_safety = match nodes_api.get(&node_name).await {
-            Ok(node) => node_pod_deletion_safety(&node, &pod),
-            Err(kube::Error::Api(ae)) if ae.code == 404 => NodePodDeletionSafety::Fenced,
-            Err(source) => {
-                return Err(Error::Context {
-                    source: context::Error::Kube { source },
-                });
-            }
+        if !node_lookup_by_name.contains_key(&node_name) {
+            let lookup = match nodes_api.get(&node_name).await {
+                Ok(node) => CachedNodeLookup::Found(Box::new(node)),
+                Err(kube::Error::Api(ae)) if ae.code == 404 => CachedNodeLookup::NotFound,
+                Err(source) => {
+                    warn!(
+                        tenant = %tenant.name(),
+                        namespace = %namespace,
+                        node = %node_name,
+                        error = %source,
+                        "skipping terminating pod cleanup because the Node could not be inspected"
+                    );
+                    let _ = ctx
+                        .record(
+                            tenant,
+                            EventType::Warning,
+                            "PodCleanupNodeLookupFailed",
+                            &format!(
+                                "Skipped terminating Pod cleanup because Node '{}' could not be inspected; the Operator will retry on a later reconcile",
+                                node_name
+                            ),
+                        )
+                        .await;
+                    CachedNodeLookup::Failed
+                }
+            };
+            node_lookup_by_name.insert(node_name.clone(), lookup);
+        }
+
+        let node_deletion_safety = match node_lookup_by_name.get(&node_name) {
+            Some(CachedNodeLookup::Found(node)) => node_pod_deletion_safety(node, &pod),
+            Some(CachedNodeLookup::NotFound) => NodePodDeletionSafety::Fenced,
+            Some(CachedNodeLookup::Failed) => continue,
+            None => continue,
         };
 
         if node_deletion_safety == NodePodDeletionSafety::Ready {
@@ -988,15 +1022,227 @@ mod tests {
     use super::is_node_down;
     use super::{
         NodePodDeletionSafety, PodCleanupDecision, cleanup_decision_for_pod,
-        force_delete_requires_fencing, node_pod_deletion_safety, object_owned_by_tenant,
-        pod_controller_owner_name_and_uid, pod_has_owner_kind, pod_matches_policy_controller_kind,
+        cleanup_stuck_terminating_pods_on_down_nodes, force_delete_requires_fencing,
+        node_pod_deletion_safety, object_owned_by_tenant, pod_controller_owner_name_and_uid,
+        pod_has_owner_kind, pod_matches_policy_controller_kind,
         replicaset_matches_pod_controller_and_tenant, should_mark_reconcile_started,
         statefulset_matches_pod_controller_and_tenant,
     };
+    use crate::context::Context;
     use crate::types::v1alpha1::status::Status;
+    use http::{Method, Request, Response, StatusCode};
     use k8s_openapi::api::apps::v1 as appsv1;
     use k8s_openapi::api::core::v1 as corev1;
     use k8s_openapi::apimachinery::pkg::apis::meta::v1 as metav1;
+    use kube::{Client, client::Body};
+    use serde_json::{Value, json};
+    use std::convert::Infallible;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+    use tower::service_fn;
+
+    fn kube_response(status: StatusCode, body: Value) -> Response<Body> {
+        Response::builder()
+            .status(status)
+            .body(Body::from(
+                serde_json::to_vec(&body).expect("response should serialize"),
+            ))
+            .expect("response should build")
+    }
+
+    fn terminating_tenant_pod(tenant: &crate::Tenant, name: &str) -> corev1::Pod {
+        corev1::Pod {
+            metadata: metav1::ObjectMeta {
+                name: Some(name.to_string()),
+                namespace: Some("default".to_string()),
+                uid: Some(format!("{name}-uid")),
+                deletion_timestamp: Some(metav1::Time(chrono::Utc::now())),
+                owner_references: Some(vec![tenant.new_owner_ref()]),
+                ..Default::default()
+            },
+            spec: Some(corev1::PodSpec {
+                node_name: Some("node-a".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn node_lookup_failure_skips_pod_cleanup_without_repeating_or_deleting() {
+        let tenant = crate::tests::create_test_tenant(None, None);
+        let pods = vec![
+            terminating_tenant_pod(&tenant, "pod-a"),
+            terminating_tenant_pod(&tenant, "pod-b"),
+        ];
+        let request_count = Arc::new(AtomicUsize::new(0));
+        let service = service_fn({
+            let pods = pods.clone();
+            let request_count = Arc::clone(&request_count);
+            move |request: Request<Body>| {
+                let pods = pods.clone();
+                let request_number = request_count.fetch_add(1, Ordering::SeqCst);
+                async move {
+                    let response = match request_number {
+                        0 => {
+                            assert_eq!(request.method(), Method::GET);
+                            assert_eq!(request.uri().path(), "/api/v1/namespaces/default/pods");
+                            kube_response(
+                                StatusCode::OK,
+                                json!({
+                                    "apiVersion": "v1",
+                                    "kind": "PodList",
+                                    "metadata": {},
+                                    "items": pods
+                                }),
+                            )
+                        }
+                        1 => {
+                            assert_eq!(request.method(), Method::GET);
+                            assert_eq!(request.uri().path(), "/api/v1/nodes/node-a");
+                            kube_response(
+                                StatusCode::INTERNAL_SERVER_ERROR,
+                                json!({
+                                    "apiVersion": "v1",
+                                    "kind": "Status",
+                                    "status": "Failure",
+                                    "reason": "InternalError",
+                                    "code": 500
+                                }),
+                            )
+                        }
+                        2 => {
+                            assert_eq!(request.method(), Method::POST);
+                            assert!(request.uri().path().contains("/events"));
+                            kube_response(
+                                StatusCode::INTERNAL_SERVER_ERROR,
+                                json!({
+                                    "apiVersion": "v1",
+                                    "kind": "Status",
+                                    "status": "Failure",
+                                    "reason": "InternalError",
+                                    "code": 500
+                                }),
+                            )
+                        }
+                        _ => panic!("unexpected Kubernetes request: {request:?}"),
+                    };
+                    Ok::<_, Infallible>(response)
+                }
+            }
+        });
+        let ctx = Context::new(Client::new(service, "default"));
+
+        cleanup_stuck_terminating_pods_on_down_nodes(
+            &tenant,
+            "default",
+            &ctx,
+            crate::types::v1alpha1::k8s::PodDeletionPolicyWhenNodeIsDown::ForceDelete,
+        )
+        .await
+        .expect("Node lookup failures must not block the main reconcile path");
+
+        assert_eq!(request_count.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn cached_node_is_evaluated_against_each_pods_tolerations() {
+        let tenant = crate::tests::create_test_tenant(None, None);
+        let pod_without_toleration = terminating_tenant_pod(&tenant, "pod-a");
+        let mut pod_with_toleration = terminating_tenant_pod(&tenant, "pod-b");
+        pod_with_toleration
+            .spec
+            .as_mut()
+            .expect("test Pod should have a spec")
+            .tolerations = Some(vec![corev1::Toleration {
+            key: Some(super::OUT_OF_SERVICE_TAINT_KEY.to_string()),
+            operator: Some("Exists".to_string()),
+            effect: Some("NoExecute".to_string()),
+            ..Default::default()
+        }]);
+        let pods = vec![pod_without_toleration, pod_with_toleration];
+        let node = node_with_out_of_service_taint();
+        let node_get_count = Arc::new(AtomicUsize::new(0));
+        let pod_delete_count = Arc::new(AtomicUsize::new(0));
+        let event_count = Arc::new(AtomicUsize::new(0));
+        let service = service_fn({
+            let pods = pods.clone();
+            let node = node.clone();
+            let node_get_count = Arc::clone(&node_get_count);
+            let pod_delete_count = Arc::clone(&pod_delete_count);
+            let event_count = Arc::clone(&event_count);
+            move |request: Request<Body>| {
+                let pods = pods.clone();
+                let node = node.clone();
+                let node_get_count = Arc::clone(&node_get_count);
+                let pod_delete_count = Arc::clone(&pod_delete_count);
+                let event_count = Arc::clone(&event_count);
+                async move {
+                    let path = request.uri().path();
+                    let response = match (request.method(), path) {
+                        (&Method::GET, "/api/v1/namespaces/default/pods") => kube_response(
+                            StatusCode::OK,
+                            json!({
+                                "apiVersion": "v1",
+                                "kind": "PodList",
+                                "metadata": {},
+                                "items": pods
+                            }),
+                        ),
+                        (&Method::GET, "/api/v1/nodes/node-a") => {
+                            node_get_count.fetch_add(1, Ordering::SeqCst);
+                            kube_response(
+                                StatusCode::OK,
+                                serde_json::to_value(node).expect("Node should serialize"),
+                            )
+                        }
+                        (&Method::DELETE, "/api/v1/namespaces/default/pods/pod-a") => {
+                            pod_delete_count.fetch_add(1, Ordering::SeqCst);
+                            kube_response(
+                                StatusCode::OK,
+                                json!({
+                                    "apiVersion": "v1",
+                                    "kind": "Status",
+                                    "status": "Success"
+                                }),
+                            )
+                        }
+                        (&Method::POST, path) if path.contains("/events") => {
+                            event_count.fetch_add(1, Ordering::SeqCst);
+                            kube_response(
+                                StatusCode::INTERNAL_SERVER_ERROR,
+                                json!({
+                                    "apiVersion": "v1",
+                                    "kind": "Status",
+                                    "status": "Failure",
+                                    "reason": "InternalError",
+                                    "code": 500
+                                }),
+                            )
+                        }
+                        _ => panic!("unexpected Kubernetes request: {request:?}"),
+                    };
+                    Ok::<_, Infallible>(response)
+                }
+            }
+        });
+        let ctx = Context::new(Client::new(service, "default"));
+
+        cleanup_stuck_terminating_pods_on_down_nodes(
+            &tenant,
+            "default",
+            &ctx,
+            crate::types::v1alpha1::k8s::PodDeletionPolicyWhenNodeIsDown::ForceDelete,
+        )
+        .await
+        .expect("cached Nodes should preserve per-Pod fencing checks");
+
+        assert_eq!(node_get_count.load(Ordering::SeqCst), 1);
+        assert_eq!(pod_delete_count.load(Ordering::SeqCst), 1);
+        assert_eq!(event_count.load(Ordering::SeqCst), 2);
+    }
 
     fn node_with_ready_status(status: &str) -> corev1::Node {
         corev1::Node {

--- a/src/reconcile/phases.rs
+++ b/src/reconcile/phases.rs
@@ -15,8 +15,9 @@
 use super::pool_lifecycle::{PoolLifecycleDecision, PoolLifecycleDecisions};
 use super::provisioning::{ProvisioningOutcome, reconcile_provisioning};
 use super::{
-    Error, cleanup_stuck_terminating_pods_on_down_nodes, context, context_result,
-    patch_status_and_record, patch_status_error, statefulset_owned_by_tenant, types_result,
+    Error, PodCleanupOutcome, cleanup_stuck_terminating_pods_on_down_nodes, context,
+    context_result, patch_status_and_record, patch_status_error, statefulset_owned_by_tenant,
+    types_result,
 };
 use crate::context::Context;
 use crate::status::{StatusBuilder, StatusError};
@@ -148,15 +149,15 @@ pub(super) async fn maybe_cleanup_terminating_pods(
     ctx: &Context,
     tenant: &Tenant,
     namespace: &str,
-) -> Result<(), Error> {
+) -> Result<PodCleanupOutcome, Error> {
     // Optional: unblock StatefulSet pods stuck terminating when their node is down.
     // This is inspired by Longhorn's "Pod Deletion Policy When Node is Down".
     if let Some(policy) = tenant.spec.pod_deletion_policy_when_node_is_down.clone()
         && policy != crate::types::v1alpha1::k8s::PodDeletionPolicyWhenNodeIsDown::DoNothing
     {
-        cleanup_stuck_terminating_pods_on_down_nodes(tenant, namespace, ctx, policy).await?;
+        return cleanup_stuck_terminating_pods_on_down_nodes(tenant, namespace, ctx, policy).await;
     }
-    Ok(())
+    Ok(PodCleanupOutcome::Complete)
 }
 
 pub(super) async fn cleanup_legacy_tenant_rbac(
@@ -823,10 +824,18 @@ fn pod_deletion_policy_requeue_after(
     }
 }
 
-fn reconcile_requeue_after(tenant: &Tenant, summary: &PoolReconcileSummary) -> Option<Duration> {
+fn reconcile_requeue_after(
+    tenant: &Tenant,
+    summary: &PoolReconcileSummary,
+    pod_cleanup_outcome: PodCleanupOutcome,
+) -> Option<Duration> {
     let lifecycle_requeue = summary.lifecycle_requeue_after;
     let updating_requeue = summary.any_updating.then_some(Duration::from_secs(10));
-    let pod_cleanup_requeue = pod_deletion_policy_requeue_after(tenant, summary);
+    let pod_cleanup_requeue = if pod_cleanup_outcome == PodCleanupOutcome::RetryNeeded {
+        Some(POD_DELETION_POLICY_REQUEUE_INTERVAL)
+    } else {
+        pod_deletion_policy_requeue_after(tenant, summary)
+    };
 
     earliest_requeue_after(
         earliest_requeue_after(lifecycle_requeue, updating_requeue),
@@ -1145,10 +1154,11 @@ pub(super) async fn finalize_tenant_status(
     tenant: &Tenant,
     summary: PoolReconcileSummary,
     tls_plan: TlsPlan,
+    pod_cleanup_outcome: PodCleanupOutcome,
 ) -> Result<Action, Error> {
     let mut builder = StatusBuilder::from_tenant(tenant);
     let pool_count = summary.pool_statuses.len();
-    let requeue_after = reconcile_requeue_after(tenant, &summary);
+    let requeue_after = reconcile_requeue_after(tenant, &summary, pod_cleanup_outcome);
     builder.set_pool_statuses(summary.pool_statuses);
     if let Some(tls_status) = tls_plan.status {
         builder.set_tls_status(tls_status);
@@ -2220,8 +2230,25 @@ mod tests {
         };
 
         assert_eq!(
-            reconcile_requeue_after(&tenant, &summary),
+            reconcile_requeue_after(&tenant, &summary, PodCleanupOutcome::Complete),
             Some(Duration::from_secs(10))
+        );
+    }
+
+    #[test]
+    fn failed_node_lookup_requeues_even_when_tenant_summary_is_ready() {
+        let mut tenant = crate::tests::create_test_tenant(None, None);
+        tenant.spec.pod_deletion_policy_when_node_is_down =
+            Some(crate::types::v1alpha1::k8s::PodDeletionPolicyWhenNodeIsDown::ForceDelete);
+        let summary = PoolReconcileSummary {
+            total_replicas: 4,
+            ready_replicas: 4,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            reconcile_requeue_after(&tenant, &summary, PodCleanupOutcome::RetryNeeded),
+            Some(POD_DELETION_POLICY_REQUEUE_INTERVAL)
         );
     }
 }


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
Closes rustfs/backlog#1084

## Summary of Changes
- Treat non-404 Node lookup failures as a fail-safe skip for optional terminating Pod cleanup, allowing the main Tenant reconcile to continue.
- Refresh Node fencing evidence before every destructive Pod cleanup decision; only failed Node names are deduplicated within a reconcile.
- Aggregate lookup failures into one warning event per reconcile instead of serially emitting one event per node.
- Propagate an explicit retry outcome so a failed Node lookup receives a bounded requeue even when the Tenant summary is already Ready.
- Preserve UID delete preconditions and existing error propagation for Pod listing, owner validation, and deletion failures.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit` (fmt-check + clippy + test + console-lint + console-fmt-check)
- [x] Added/updated necessary tests
- [x] Documentation updated (if needed)
- [x] CHANGELOG.md updated under `[Unreleased]` (if user-visible change)
- [x] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (CRD/API compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact: transient Node API failures no longer block unrelated Tenant reconciliation and always schedule a bounded cleanup retry.

## Verification
```bash
cargo test reconcile::tests:: -- --nocapture
make pre-commit
```

## Additional Notes
A missing Node (404) remains fenced. Every successful Node lookup is evaluated immediately before its Pod deletion decision and is not cached across Pods. Other lookup errors skip deletion conservatively, emit one aggregate warning, and request a delayed retry.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
