### PR TITLE
fix(security): bound unauthenticated control-plane requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1642,6 +1642,7 @@ dependencies = [
  "hmac",
  "hostname",
  "http",
+ "http-body-util",
  "hyper",
  "hyper-util",
  "k8s-openapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ hyper-util = { version = "0.1", features = ["server-auto", "service", "tokio"] }
 tower = "0.5"
 tower-http = { version = "0.6", features = ["cors", "trace", "compression-gzip", "fs"] }
 http = "1.2"
+http-body-util = "0.1"
 utoipa = { version = "5", features = ["chrono"] }
 utoipa-swagger-ui = { version = "8", features = ["axum", "vendored"] }
 async-trait = { version = "0.1.89", default-features = false }

--- a/deploy/rustfs-operator/templates/console-deployment.yaml
+++ b/deploy/rustfs-operator/templates/console-deployment.yaml
@@ -1,3 +1,4 @@
+{{- $consoleLoginAdmission := default dict .Values.console.loginAdmission -}}
 {{- $reservedConsoleEnv := dict
   "CONSOLE_LOGIN_ADMISSION_REQUESTS_PER_SECOND" "console.loginAdmission.requestsPerSecond"
   "CONSOLE_LOGIN_ADMISSION_BURST" "console.loginAdmission.burst"
@@ -60,16 +61,18 @@ spec:
                 secretKeyRef:
                   name: {{ include "rustfs-operator.fullname" . }}-console-secret
                   key: jwt-secret
+          {{- with $consoleLoginAdmission }}
             - name: CONSOLE_LOGIN_ADMISSION_REQUESTS_PER_SECOND
-              value: {{ .Values.console.loginAdmission.requestsPerSecond | quote }}
+              value: {{ .requestsPerSecond | quote }}
             - name: CONSOLE_LOGIN_ADMISSION_BURST
-              value: {{ .Values.console.loginAdmission.burst | quote }}
+              value: {{ .burst | quote }}
             - name: CONSOLE_LOGIN_ADMISSION_MAX_IN_FLIGHT
-              value: {{ .Values.console.loginAdmission.maxInFlight | quote }}
+              value: {{ .maxInFlight | quote }}
             - name: CONSOLE_LOGIN_ADMISSION_BODY_LIMIT_BYTES
-              value: {{ .Values.console.loginAdmission.bodyLimitBytes | quote }}
+              value: {{ .bodyLimitBytes | quote }}
             - name: CONSOLE_LOGIN_ADMISSION_TIMEOUT_SECONDS
-              value: {{ .Values.console.loginAdmission.timeoutSeconds | quote }}
+              value: {{ .timeoutSeconds | quote }}
+          {{- end }}
             {{- with .Values.console.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/deploy/rustfs-operator/templates/console-deployment.yaml
+++ b/deploy/rustfs-operator/templates/console-deployment.yaml
@@ -1,3 +1,15 @@
+{{- $reservedConsoleEnv := dict
+  "CONSOLE_LOGIN_ADMISSION_REQUESTS_PER_SECOND" "console.loginAdmission.requestsPerSecond"
+  "CONSOLE_LOGIN_ADMISSION_BURST" "console.loginAdmission.burst"
+  "CONSOLE_LOGIN_ADMISSION_MAX_IN_FLIGHT" "console.loginAdmission.maxInFlight"
+  "CONSOLE_LOGIN_ADMISSION_BODY_LIMIT_BYTES" "console.loginAdmission.bodyLimitBytes"
+  "CONSOLE_LOGIN_ADMISSION_TIMEOUT_SECONDS" "console.loginAdmission.timeoutSeconds"
+-}}
+{{- range $env := .Values.console.env }}
+{{- if hasKey $reservedConsoleEnv $env.name -}}
+{{- fail (printf "console.env must not set %s; use %s instead" $env.name (get $reservedConsoleEnv $env.name)) -}}
+{{- end -}}
+{{- end -}}
 {{- if .Values.console.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
@@ -48,6 +60,16 @@ spec:
                 secretKeyRef:
                   name: {{ include "rustfs-operator.fullname" . }}-console-secret
                   key: jwt-secret
+            - name: CONSOLE_LOGIN_ADMISSION_REQUESTS_PER_SECOND
+              value: {{ .Values.console.loginAdmission.requestsPerSecond | quote }}
+            - name: CONSOLE_LOGIN_ADMISSION_BURST
+              value: {{ .Values.console.loginAdmission.burst | quote }}
+            - name: CONSOLE_LOGIN_ADMISSION_MAX_IN_FLIGHT
+              value: {{ .Values.console.loginAdmission.maxInFlight | quote }}
+            - name: CONSOLE_LOGIN_ADMISSION_BODY_LIMIT_BYTES
+              value: {{ .Values.console.loginAdmission.bodyLimitBytes | quote }}
+            - name: CONSOLE_LOGIN_ADMISSION_TIMEOUT_SECONDS
+              value: {{ .Values.console.loginAdmission.timeoutSeconds | quote }}
             {{- with .Values.console.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/deploy/rustfs-operator/templates/deployment.yaml
+++ b/deploy/rustfs-operator/templates/deployment.yaml
@@ -10,6 +10,11 @@
   "OPERATOR_NAMESPACE" "namespace"
   "OPERATOR_STS_ENABLED" "sts.enabled"
   "OPERATOR_STS_AUDIENCE" "sts.audience"
+  "OPERATOR_STS_ADMISSION_REQUESTS_PER_SECOND" "sts.admission.requestsPerSecond"
+  "OPERATOR_STS_ADMISSION_BURST" "sts.admission.burst"
+  "OPERATOR_STS_ADMISSION_MAX_IN_FLIGHT" "sts.admission.maxInFlight"
+  "OPERATOR_STS_ADMISSION_BODY_LIMIT_BYTES" "sts.admission.bodyLimitBytes"
+  "OPERATOR_STS_ADMISSION_TIMEOUT_SECONDS" "sts.admission.timeoutSeconds"
   "OPERATOR_STS_PORT" "sts.port"
   "OPERATOR_STS_SERVICE_NAME" "the generated STS Service name"
   "OPERATOR_STS_TLS_ENABLED" "sts.tls.enabled"
@@ -107,6 +112,16 @@ spec:
               value: {{ .Values.sts.enabled | quote }}
             - name: OPERATOR_STS_AUDIENCE
               value: {{ .Values.sts.audience | quote }}
+            - name: OPERATOR_STS_ADMISSION_REQUESTS_PER_SECOND
+              value: {{ .Values.sts.admission.requestsPerSecond | quote }}
+            - name: OPERATOR_STS_ADMISSION_BURST
+              value: {{ .Values.sts.admission.burst | quote }}
+            - name: OPERATOR_STS_ADMISSION_MAX_IN_FLIGHT
+              value: {{ .Values.sts.admission.maxInFlight | quote }}
+            - name: OPERATOR_STS_ADMISSION_BODY_LIMIT_BYTES
+              value: {{ .Values.sts.admission.bodyLimitBytes | quote }}
+            - name: OPERATOR_STS_ADMISSION_TIMEOUT_SECONDS
+              value: {{ .Values.sts.admission.timeoutSeconds | quote }}
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/deploy/rustfs-operator/templates/deployment.yaml
+++ b/deploy/rustfs-operator/templates/deployment.yaml
@@ -1,5 +1,6 @@
 {{- $livenessProbe := default dict .Values.operator.livenessProbe -}}
 {{- $readinessProbe := default dict .Values.operator.readinessProbe -}}
+{{- $stsAdmission := default dict .Values.sts.admission -}}
 {{- if and (not .Values.operator.metrics.enabled) (or (hasKey $livenessProbe "httpGet") (hasKey $readinessProbe "httpGet")) -}}
 {{- fail "operator.metrics.enabled=false requires overriding operator.livenessProbe and operator.readinessProbe because the chart defaults use the metrics port" -}}
 {{- end -}}
@@ -112,16 +113,18 @@ spec:
               value: {{ .Values.sts.enabled | quote }}
             - name: OPERATOR_STS_AUDIENCE
               value: {{ .Values.sts.audience | quote }}
+          {{- with $stsAdmission }}
             - name: OPERATOR_STS_ADMISSION_REQUESTS_PER_SECOND
-              value: {{ .Values.sts.admission.requestsPerSecond | quote }}
+              value: {{ .requestsPerSecond | quote }}
             - name: OPERATOR_STS_ADMISSION_BURST
-              value: {{ .Values.sts.admission.burst | quote }}
+              value: {{ .burst | quote }}
             - name: OPERATOR_STS_ADMISSION_MAX_IN_FLIGHT
-              value: {{ .Values.sts.admission.maxInFlight | quote }}
+              value: {{ .maxInFlight | quote }}
             - name: OPERATOR_STS_ADMISSION_BODY_LIMIT_BYTES
-              value: {{ .Values.sts.admission.bodyLimitBytes | quote }}
+              value: {{ .bodyLimitBytes | quote }}
             - name: OPERATOR_STS_ADMISSION_TIMEOUT_SECONDS
-              value: {{ .Values.sts.admission.timeoutSeconds | quote }}
+              value: {{ .timeoutSeconds | quote }}
+          {{- end }}
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/deploy/rustfs-operator/templates/prometheusrule.yaml
+++ b/deploy/rustfs-operator/templates/prometheusrule.yaml
@@ -26,6 +26,14 @@ spec:
           annotations:
             summary: RustFS Operator reconcile errors
             description: RustFS Operator has reported reconcile errors in the last 10 minutes.
+        - alert: RustfsUnauthenticatedAdmissionRejections
+          expr: sum by (endpoint, reason) (increase(rustfs_operator_unauthenticated_admission_rejections_total[5m])) > 10
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: RustFS unauthenticated endpoint requests are being rejected
+            description: Admission control rejected more than 10 unauthenticated endpoint requests in five minutes.
         - alert: RustfsTenantStorageUnhealthy
           expr: rustfs_operator_tenant_storage_poll_success == 1 and rustfs_operator_tenant_storage_healthy == 0
           for: 10m

--- a/deploy/rustfs-operator/templates/prometheusrule.yaml
+++ b/deploy/rustfs-operator/templates/prometheusrule.yaml
@@ -28,7 +28,6 @@ spec:
             description: RustFS Operator has reported reconcile errors in the last 10 minutes.
         - alert: RustfsUnauthenticatedAdmissionRejections
           expr: sum by (endpoint, reason) (increase(rustfs_operator_unauthenticated_admission_rejections_total[5m])) > 10
-          for: 5m
           labels:
             severity: warning
           annotations:

--- a/deploy/rustfs-operator/values.schema.json
+++ b/deploy/rustfs-operator/values.schema.json
@@ -16,6 +16,61 @@
         }
       ],
       "description": "Kubernetes cluster DNS domain used for Tenant peer URLs, generated TLS SANs, and operator STS auto TLS."
+    },
+    "sts": {
+      "type": "object",
+      "properties": {
+        "admission": {
+          "$ref": "#/definitions/admission"
+        }
+      }
+    },
+    "console": {
+      "type": "object",
+      "properties": {
+        "loginAdmission": {
+          "$ref": "#/definitions/admission"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "admission": {
+      "type": "object",
+      "required": [
+        "requestsPerSecond",
+        "burst",
+        "maxInFlight",
+        "bodyLimitBytes",
+        "timeoutSeconds"
+      ],
+      "properties": {
+        "requestsPerSecond": {
+          "type": "number",
+          "minimum": 0.1,
+          "maximum": 1000
+        },
+        "burst": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 10000
+        },
+        "maxInFlight": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1024
+        },
+        "bodyLimitBytes": {
+          "type": "integer",
+          "minimum": 1024,
+          "maximum": 1048576
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 300
+        }
+      }
     }
   }
 }

--- a/deploy/rustfs-operator/values.yaml
+++ b/deploy/rustfs-operator/values.yaml
@@ -111,6 +111,13 @@ sts:
   audience: sts.rustfs.com
   # STS service/port in operator pods
   port: 4223
+  # Per-operator-process admission limits for the unauthenticated STS route.
+  admission:
+    requestsPerSecond: 5
+    burst: 10
+    maxInFlight: 16
+    bodyLimitBytes: 65536
+    timeoutSeconds: 30
   tls:
     # Operator STS listens with TLS by default and uses this Secret for server certs.
     enabled: true
@@ -163,6 +170,14 @@ console:
 
   # Log level for console (trace, debug, info, warn, error)
   logLevel: info
+
+  # Per-Console-process admission limits for the unauthenticated login route.
+  loginAdmission:
+    requestsPerSecond: 5
+    burst: 10
+    maxInFlight: 16
+    bodyLimitBytes: 65536
+    timeoutSeconds: 30
 
   # Secret used to encrypt Console session cookies.
   # All Console replicas must use the same secret.

--- a/docs/operator-user-guide.md
+++ b/docs/operator-user-guide.md
@@ -178,6 +178,13 @@ Common chart sections:
 | `namespace` | Namespace override for chart resources; defaults to the Helm release namespace. |
 | `commonLabels` / `commonAnnotations` | Labels and annotations added to chart-managed resources. |
 
+The unauthenticated STS and Console login routes use separate, per-process admission controls.
+Their Helm settings are `sts.admission` and `console.loginAdmission`; each configures requests per
+second, burst capacity, maximum in-flight requests, body size, and end-to-end timeout. Defaults are
+5 requests/second, burst 10, 16 in flight, 64 KiB, and 30 seconds. Because limits are per process,
+aggregate STS capacity increases with `operator.replicas` and aggregate login capacity increases
+with `console.replicas`.
+
 Example production-oriented values:
 
 ```yaml
@@ -205,6 +212,12 @@ console:
   enabled: true
   replicas: 2
   jwtSecret: "<stable-base64-or-random-secret>"
+  loginAdmission:
+    requestsPerSecond: 5
+    burst: 10
+    maxInFlight: 16
+    bodyLimitBytes: 65536
+    timeoutSeconds: 30
   ingress:
     enabled: true
     className: nginx
@@ -214,6 +227,12 @@ console:
 sts:
   enabled: true
   audience: sts.rustfs.com
+  admission:
+    requestsPerSecond: 5
+    burst: 10
+    maxInFlight: 16
+    bodyLimitBytes: 65536
+    timeoutSeconds: 30
   tls:
     enabled: true
     auto: true

--- a/docs/operator-user-guide.md
+++ b/docs/operator-user-guide.md
@@ -183,7 +183,11 @@ Their Helm settings are `sts.admission` and `console.loginAdmission`; each confi
 second, burst capacity, maximum in-flight requests, body size, and end-to-end timeout. Defaults are
 5 requests/second, burst 10, 16 in flight, 64 KiB, and 30 seconds. Because limits are per process,
 aggregate STS capacity increases with `operator.replicas` and aggregate login capacity increases
-with `console.replicas`.
+with `console.replicas`. Within a process, every client and tenant path for an endpoint shares the
+same token bucket and concurrency pool. This is a global load-shedding ceiling, not a per-client
+fairness guarantee: one busy or malicious source can exhaust the local allowance and cause other
+clients or tenants routed to that process to be rejected. Enforce source-aware fairness at a trusted
+ingress or another identity-aware layer when required.
 
 Example production-oriented values:
 
@@ -964,6 +968,14 @@ kubectl -n rustfs-system port-forward svc/rustfs-operator-metrics 18080:8080
 curl http://127.0.0.1:18080/healthz
 curl http://127.0.0.1:18080/readyz
 curl http://127.0.0.1:18080/metrics
+```
+
+The fixed-cardinality `rustfs_operator_unauthenticated_requests_total{endpoint,outcome}` counter
+covers all STS and Console login requests. Use the following query to monitor aggregate endpoint
+QPS across replicas; `outcome` is `success`, `error`, or `rejected`:
+
+```promql
+sum by (endpoint) (rate(rustfs_operator_unauthenticated_requests_total[5m]))
 ```
 
 Enable Prometheus Operator integration:

--- a/docs/operator-user-guide.zh-CN.md
+++ b/docs/operator-user-guide.zh-CN.md
@@ -175,7 +175,10 @@ helm upgrade --install rustfs-operator deploy/rustfs-operator/ \
 `sts.admission` 与 `console.loginAdmission`，分别控制每秒请求数、突发容量、最大并发、
 请求体大小和端到端超时。默认值为每秒 5 个请求、突发 10、最大并发 16、64 KiB 和
 30 秒。限制按进程生效，因此 STS 总容量随 `operator.replicas` 增长，登录总容量随
-`console.replicas` 增长。
+`console.replicas` 增长。同一进程内，一个端点的所有客户端和 Tenant 路径共享同一个
+令牌桶与并发池；它是全局负载卸载上限，并不保证客户端之间的公平性。繁忙或恶意来源
+可以耗尽本进程配额，导致路由到该进程的其他客户端或 Tenant 请求被拒绝。如需按来源
+保证公平性，应在可信 Ingress 或其他能够可靠识别身份的边界实施。
 
 生产风格 values 示例：
 
@@ -941,6 +944,14 @@ kubectl -n rustfs-system port-forward svc/rustfs-operator-metrics 18080:8080
 curl http://127.0.0.1:18080/healthz
 curl http://127.0.0.1:18080/readyz
 curl http://127.0.0.1:18080/metrics
+```
+
+固定基数指标 `rustfs_operator_unauthenticated_requests_total{endpoint,outcome}` 覆盖所有
+STS 与 Console 登录请求。可用以下查询汇总所有副本的端点 QPS；`outcome` 取值为
+`success`、`error` 或 `rejected`：
+
+```promql
+sum by (endpoint) (rate(rustfs_operator_unauthenticated_requests_total[5m]))
 ```
 
 启用 Prometheus Operator 集成：

--- a/docs/operator-user-guide.zh-CN.md
+++ b/docs/operator-user-guide.zh-CN.md
@@ -171,6 +171,12 @@ helm upgrade --install rustfs-operator deploy/rustfs-operator/ \
 | `namespace` | Chart 资源命名空间覆盖；默认使用 Helm release namespace。 |
 | `commonLabels` / `commonAnnotations` | 添加到 Chart 管理资源上的统一 label 和 annotation。 |
 
+未认证的 STS 与 Console 登录路由使用彼此独立的进程级准入控制。对应 Helm 配置为
+`sts.admission` 与 `console.loginAdmission`，分别控制每秒请求数、突发容量、最大并发、
+请求体大小和端到端超时。默认值为每秒 5 个请求、突发 10、最大并发 16、64 KiB 和
+30 秒。限制按进程生效，因此 STS 总容量随 `operator.replicas` 增长，登录总容量随
+`console.replicas` 增长。
+
 生产风格 values 示例：
 
 ```yaml
@@ -198,6 +204,12 @@ console:
   enabled: true
   replicas: 2
   jwtSecret: "<stable-base64-or-random-secret>"
+  loginAdmission:
+    requestsPerSecond: 5
+    burst: 10
+    maxInFlight: 16
+    bodyLimitBytes: 65536
+    timeoutSeconds: 30
   ingress:
     enabled: true
     className: nginx
@@ -207,6 +219,12 @@ console:
 sts:
   enabled: true
   audience: sts.rustfs.com
+  admission:
+    requestsPerSecond: 5
+    burst: 10
+    maxInFlight: 16
+    bodyLimitBytes: 65536
+    timeoutSeconds: 30
   tls:
     enabled: true
     auto: true

--- a/e2e/Cargo.lock
+++ b/e2e/Cargo.lock
@@ -2529,6 +2529,7 @@ dependencies = [
  "hmac 0.12.1",
  "hostname",
  "http 1.4.0",
+ "http-body-util",
  "hyper 1.9.0",
  "hyper-util",
  "k8s-openapi",

--- a/e2e/tests/sts_manifest.rs
+++ b/e2e/tests/sts_manifest.rs
@@ -13,8 +13,11 @@
 // limitations under the License.
 
 use serde_yaml_ng::Value;
-use std::collections::BTreeSet;
-use std::process::{Command, Output};
+use std::{
+    collections::BTreeSet,
+    path::Path,
+    process::{Command, Output},
+};
 
 const RESERVED_OPERATOR_ENV: &[(&str, &str)] = &[
     ("OPERATOR_CLUSTER_DOMAIN", "clusterDomain"),
@@ -23,6 +26,23 @@ const RESERVED_OPERATOR_ENV: &[(&str, &str)] = &[
     ("OPERATOR_NAMESPACE", "namespace"),
     ("OPERATOR_STS_ENABLED", "sts.enabled"),
     ("OPERATOR_STS_AUDIENCE", "sts.audience"),
+    (
+        "OPERATOR_STS_ADMISSION_REQUESTS_PER_SECOND",
+        "sts.admission.requestsPerSecond",
+    ),
+    ("OPERATOR_STS_ADMISSION_BURST", "sts.admission.burst"),
+    (
+        "OPERATOR_STS_ADMISSION_MAX_IN_FLIGHT",
+        "sts.admission.maxInFlight",
+    ),
+    (
+        "OPERATOR_STS_ADMISSION_BODY_LIMIT_BYTES",
+        "sts.admission.bodyLimitBytes",
+    ),
+    (
+        "OPERATOR_STS_ADMISSION_TIMEOUT_SECONDS",
+        "sts.admission.timeoutSeconds",
+    ),
     ("OPERATOR_STS_PORT", "sts.port"),
     (
         "OPERATOR_STS_SERVICE_NAME",
@@ -195,6 +215,12 @@ fn helm_template_renders_sts_enabled_disabled_and_rejects_external_plaintext() {
     assert!(default_stdout.contains("value: \"true\""));
     assert!(default_stdout.contains("name: OPERATOR_STS_TLS_AUTO"));
     assert!(!default_stdout.contains("name: OPERATOR_STS_TLS_SECRET_NAME"));
+    for name in admission_env_names() {
+        assert!(
+            default_stdout.contains(&format!("name: {name}")),
+            "default chart values must configure {name}"
+        );
+    }
     let default_documents = yaml_documents(&default_stdout, "helm-default-render");
     assert_reference_cluster_role_is_read_only(&default_documents, "rustfs-operator");
     assert_sts_tls_role_is_minimal(
@@ -325,6 +351,102 @@ fn helm_template_renders_sts_enabled_disabled_and_rejects_external_plaintext() {
     assert!(external_stderr.contains("operator STS currently supports only ClusterIP"));
 }
 
+#[test]
+fn helm_template_renders_reused_values_without_admission_maps() {
+    if !helm_is_available() {
+        assert!(
+            std::env::var_os("CI").is_none(),
+            "helm must be installed in CI so chart render assertions cannot be skipped"
+        );
+        eprintln!("skipping helm template assertions: helm binary is not available");
+        return;
+    }
+
+    let chart = chart_without_admission_defaults();
+    let render = helm_template_chart(chart.path(), &[]);
+    assert!(
+        render.status.success(),
+        "values reused from a release without admission maps must render successfully: {}",
+        String::from_utf8_lossy(&render.stderr)
+    );
+
+    let stdout = String::from_utf8(render.stdout).expect("reused-values helm stdout is utf8");
+    let documents = yaml_documents(&stdout, "helm-reused-values-render");
+    assert!(
+        find_document(&documents, "Deployment", "rustfs-operator").is_some(),
+        "operator Deployment must still render"
+    );
+    assert!(
+        find_document(&documents, "Deployment", "rustfs-operator-console").is_some(),
+        "Console Deployment must still render"
+    );
+    for name in admission_env_names() {
+        assert!(
+            !stdout.contains(&format!("name: {name}")),
+            "missing admission values must leave {name} unset so the binary default is used"
+        );
+    }
+}
+
+fn admission_env_names() -> [&'static str; 10] {
+    [
+        "OPERATOR_STS_ADMISSION_REQUESTS_PER_SECOND",
+        "OPERATOR_STS_ADMISSION_BURST",
+        "OPERATOR_STS_ADMISSION_MAX_IN_FLIGHT",
+        "OPERATOR_STS_ADMISSION_BODY_LIMIT_BYTES",
+        "OPERATOR_STS_ADMISSION_TIMEOUT_SECONDS",
+        "CONSOLE_LOGIN_ADMISSION_REQUESTS_PER_SECOND",
+        "CONSOLE_LOGIN_ADMISSION_BURST",
+        "CONSOLE_LOGIN_ADMISSION_MAX_IN_FLIGHT",
+        "CONSOLE_LOGIN_ADMISSION_BODY_LIMIT_BYTES",
+        "CONSOLE_LOGIN_ADMISSION_TIMEOUT_SECONDS",
+    ]
+}
+
+fn chart_without_admission_defaults() -> tempfile::TempDir {
+    let chart = tempfile::tempdir().expect("temporary chart directory is created");
+    copy_directory(Path::new("../deploy/rustfs-operator"), chart.path());
+
+    let values_path = chart.path().join("values.yaml");
+    let mut values: Value = serde_yaml_ng::from_str(
+        &std::fs::read_to_string(&values_path).expect("temporary chart values exist"),
+    )
+    .expect("chart values parse");
+    remove_mapping_key(&mut values, "sts", "admission");
+    remove_mapping_key(&mut values, "console", "loginAdmission");
+    std::fs::write(
+        values_path,
+        serde_yaml_ng::to_string(&values).expect("old release values serialize"),
+    )
+    .expect("old release values are written");
+    chart
+}
+
+fn remove_mapping_key(values: &mut Value, section: &str, key: &str) {
+    values[section]
+        .as_mapping_mut()
+        .unwrap_or_else(|| panic!("chart values must contain the {section} mapping"))
+        .remove(Value::String(key.to_string()));
+}
+
+fn copy_directory(source: &Path, destination: &Path) {
+    std::fs::create_dir_all(destination).expect("temporary chart directory is created");
+    for entry in std::fs::read_dir(source).expect("chart directory is readable") {
+        let entry = entry.expect("chart entry is readable");
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+        if entry
+            .file_type()
+            .expect("chart entry type is readable")
+            .is_dir()
+        {
+            copy_directory(&source_path, &destination_path);
+        } else {
+            std::fs::copy(source_path, destination_path).expect("chart file is copied");
+        }
+    }
+}
+
 fn helm_template(args: &[&str]) -> Option<Output> {
     if !helm_is_available() {
         assert!(
@@ -335,11 +457,17 @@ fn helm_template(args: &[&str]) -> Option<Output> {
         return None;
     }
 
-    let mut command = Command::new("helm");
-    command.args(["template", "rustfs-operator", "../deploy/rustfs-operator"]);
-    command.args(args);
+    Some(helm_template_chart(
+        Path::new("../deploy/rustfs-operator"),
+        args,
+    ))
+}
 
-    Some(command.output().expect("helm template command runs"))
+fn helm_template_chart(chart: &Path, args: &[&str]) -> Output {
+    let mut command = Command::new("helm");
+    command.arg("template").arg("rustfs-operator").arg(chart);
+    command.args(args);
+    command.output().expect("helm template command runs")
 }
 
 fn helm_is_available() -> bool {

--- a/src/console/openapi.rs
+++ b/src/console/openapi.rs
@@ -217,6 +217,8 @@ pub struct ApiDoc;
         (status = 415, body = ConsoleErrorResponse),
         (status = 422, body = ConsoleErrorResponse),
         (status = 401, body = ConsoleErrorResponse),
+        (status = 429, body = ConsoleErrorResponse),
+        (status = 503, body = ConsoleErrorResponse),
         (status = 500, body = ConsoleErrorResponse)
     ),
     tag = "auth"

--- a/src/console/routes/mod.rs
+++ b/src/console/routes/mod.rs
@@ -24,6 +24,7 @@ use axum::{
 use crate::{
     console::{handlers, models::common::ConsoleErrorResponse, state::AppState},
     http_admission::{AdmissionConfig, AdmissionControl, AdmissionEndpoint, AdmissionRejection},
+    metrics::UnauthenticatedRequestOutcome,
 };
 
 /// Login / session routes (partially unauthenticated)
@@ -63,54 +64,58 @@ async fn enforce_login_admission(
         })
         .await;
 
-    match result {
-        Ok(response) => response,
-        Err(rejection) => {
-            crate::metrics::record_unauthenticated_admission_rejection(
-                AdmissionEndpoint::ConsoleLogin,
-                rejection.reason(),
-            );
-            login_admission_rejection_response(rejection)
+    let (response, outcome) = match result {
+        Ok(response) => {
+            let outcome = UnauthenticatedRequestOutcome::from_status(response.status());
+            (response, outcome)
         }
-    }
+        Err(rejection) => (
+            login_admission_rejection_response(rejection),
+            UnauthenticatedRequestOutcome::Rejected(rejection.reason()),
+        ),
+    };
+    crate::metrics::record_unauthenticated_request(AdmissionEndpoint::ConsoleLogin, outcome);
+    response
 }
 
 fn login_admission_rejection_response(rejection: AdmissionRejection) -> Response {
     let (status, code, reason, message, retry_after) = match rejection {
-        AdmissionRejection::RateLimited => (
+        AdmissionRejection::RateLimited {
+            retry_after_seconds,
+        } => (
             StatusCode::TOO_MANY_REQUESTS,
             "TooManyRequests",
             "LoginRateLimited",
             "Login request rate exceeded; retry later.",
-            true,
+            Some(retry_after_seconds),
         ),
         AdmissionRejection::ConcurrencyLimited => (
             StatusCode::TOO_MANY_REQUESTS,
             "TooManyRequests",
             "LoginConcurrencyLimited",
             "Too many login requests are already in progress.",
-            true,
+            Some(1),
         ),
         AdmissionRejection::BodyTooLarge => (
             StatusCode::PAYLOAD_TOO_LARGE,
             "RequestBodyError",
             "InvalidRequestBody",
             "The login request body exceeds the maximum allowed size.",
-            false,
+            None,
         ),
         AdmissionRejection::BodyReadFailed => (
             StatusCode::BAD_REQUEST,
             "RequestBodyError",
             "InvalidRequestBody",
             "The login request body could not be read.",
-            false,
+            None,
         ),
         AdmissionRejection::TimedOut => (
             StatusCode::SERVICE_UNAVAILABLE,
             "ServiceUnavailable",
             "LoginTimedOut",
             "The login request timed out; retry later.",
-            true,
+            Some(1),
         ),
     };
     let mut response = (
@@ -124,10 +129,12 @@ fn login_admission_rejection_response(rejection: AdmissionRejection) -> Response
         }),
     )
         .into_response();
-    if retry_after {
+    if let Some(retry_after_seconds) = retry_after
+        && let Ok(retry_after) = retry_after_seconds.to_string().parse::<HeaderValue>()
+    {
         response
             .headers_mut()
-            .insert(header::RETRY_AFTER, HeaderValue::from_static("1"));
+            .insert(header::RETRY_AFTER, retry_after);
     }
     response
 }
@@ -278,6 +285,7 @@ mod tests {
     use crate::console::error::JSON_REJECTION_MESSAGE_MAX_BYTES;
     use crate::console::state::{AppState, Claims};
     use crate::http_admission::{AdmissionConfig, AdmissionControl, AdmissionRejection};
+    use crate::metrics::{UnauthenticatedRequestOutcome, capture_request_metrics};
     use axum::{
         Extension, Router,
         body::{Body, to_bytes},
@@ -328,7 +336,7 @@ mod tests {
 
     fn restrictive_admission(body_limit_bytes: usize) -> AdmissionControl {
         AdmissionControl::new(AdmissionConfig {
-            requests_per_second: 0.000_001,
+            requests_per_second: 0.1,
             burst: 1,
             max_in_flight: 1,
             body_limit_bytes,
@@ -347,34 +355,47 @@ mod tests {
         let app = auth_routes_with_admission(admission)
             .with_state(AppState::new("test-secret".to_string()));
 
-        let response = app
-            .clone()
-            .oneshot(
+        let (response, captured) = capture_request_metrics(
+            app.clone().oneshot(
                 Request::builder()
                     .method(Method::POST)
                     .uri("/login")
                     .header(header::CONTENT_TYPE, "application/json")
                     .body(Body::from(r#"{"token":"test"}"#))?,
-            )
-            .await?;
+            ),
+        )
+        .await;
+        let response = response?;
         assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
         assert_eq!(
+            captured.unauthenticated_requests,
+            vec![(
+                crate::http_admission::AdmissionEndpoint::ConsoleLogin,
+                UnauthenticatedRequestOutcome::Rejected(
+                    crate::http_admission::AdmissionReason::RateLimit
+                ),
+            )]
+        );
+        assert_eq!(
             response.headers().get(header::RETRY_AFTER),
-            Some(&HeaderValue::from_static("1"))
+            Some(&HeaderValue::from_static("10"))
         );
         let body = to_bytes(response.into_body(), usize::MAX).await?;
         let body: Value = serde_json::from_slice(&body)?;
         assert_error_envelope(&body, "TooManyRequests", "LoginRateLimited");
 
-        let response = app
-            .oneshot(
+        let (response, captured) = capture_request_metrics(
+            app.oneshot(
                 Request::builder()
                     .method(Method::POST)
                     .uri("/logout")
                     .body(Body::empty())?,
-            )
-            .await?;
+            ),
+        )
+        .await;
+        let response = response?;
         assert_eq!(response.status(), StatusCode::OK);
+        assert!(captured.unauthenticated_requests.is_empty());
         Ok(())
     }
 
@@ -393,6 +414,7 @@ mod tests {
             )
             .await?;
         assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+        assert!(response.headers().get(header::RETRY_AFTER).is_none());
         let body = to_bytes(response.into_body(), usize::MAX).await?;
         let body: Value = serde_json::from_slice(&body)?;
         assert_error_envelope(&body, "RequestBodyError", "InvalidRequestBody");

--- a/src/console/routes/mod.rs
+++ b/src/console/routes/mod.rs
@@ -13,18 +13,123 @@
 // limitations under the License.
 
 use axum::{
-    Router,
+    Json, Router,
+    extract::{Request, State},
+    http::{HeaderValue, StatusCode, header},
+    middleware::{self, Next},
+    response::{IntoResponse, Response},
     routing::{delete, get, post, put},
 };
 
-use crate::console::{handlers, state::AppState};
+use crate::{
+    console::{handlers, models::common::ConsoleErrorResponse, state::AppState},
+    http_admission::{AdmissionConfig, AdmissionControl, AdmissionEndpoint, AdmissionRejection},
+};
 
 /// Login / session routes (partially unauthenticated)
 pub fn auth_routes() -> Router<AppState> {
+    auth_routes_with_config(AdmissionConfig::for_endpoint(
+        AdmissionEndpoint::ConsoleLogin,
+    ))
+}
+
+pub(crate) fn auth_routes_with_config(config: AdmissionConfig) -> Router<AppState> {
+    auth_routes_with_admission(AdmissionControl::new(config))
+}
+
+fn auth_routes_with_admission(admission: AdmissionControl) -> Router<AppState> {
+    let login = Router::new().route(
+        "/login",
+        post(handlers::auth::login).route_layer(middleware::from_fn_with_state(
+            admission,
+            enforce_login_admission,
+        )),
+    );
     Router::new()
-        .route("/login", post(handlers::auth::login))
+        .merge(login)
         .route("/logout", post(handlers::auth::logout))
         .route("/session", get(handlers::auth::session_check))
+}
+
+async fn enforce_login_admission(
+    State(admission): State<AdmissionControl>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let result = admission
+        .execute(async {
+            let request = admission.read_bounded_request(request).await?;
+            Ok(next.run(request).await)
+        })
+        .await;
+
+    match result {
+        Ok(response) => response,
+        Err(rejection) => {
+            crate::metrics::record_unauthenticated_admission_rejection(
+                AdmissionEndpoint::ConsoleLogin,
+                rejection.reason(),
+            );
+            login_admission_rejection_response(rejection)
+        }
+    }
+}
+
+fn login_admission_rejection_response(rejection: AdmissionRejection) -> Response {
+    let (status, code, reason, message, retry_after) = match rejection {
+        AdmissionRejection::RateLimited => (
+            StatusCode::TOO_MANY_REQUESTS,
+            "TooManyRequests",
+            "LoginRateLimited",
+            "Login request rate exceeded; retry later.",
+            true,
+        ),
+        AdmissionRejection::ConcurrencyLimited => (
+            StatusCode::TOO_MANY_REQUESTS,
+            "TooManyRequests",
+            "LoginConcurrencyLimited",
+            "Too many login requests are already in progress.",
+            true,
+        ),
+        AdmissionRejection::BodyTooLarge => (
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "RequestBodyError",
+            "InvalidRequestBody",
+            "The login request body exceeds the maximum allowed size.",
+            false,
+        ),
+        AdmissionRejection::BodyReadFailed => (
+            StatusCode::BAD_REQUEST,
+            "RequestBodyError",
+            "InvalidRequestBody",
+            "The login request body could not be read.",
+            false,
+        ),
+        AdmissionRejection::TimedOut => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "ServiceUnavailable",
+            "LoginTimedOut",
+            "The login request timed out; retry later.",
+            true,
+        ),
+    };
+    let mut response = (
+        status,
+        Json(ConsoleErrorResponse {
+            code: code.to_string(),
+            reason: reason.to_string(),
+            message: message.to_string(),
+            next_actions: Vec::new(),
+            details: None,
+        }),
+    )
+        .into_response();
+    if retry_after {
+        response
+            .headers_mut()
+            .insert(header::RETRY_AFTER, HeaderValue::from_static("1"));
+    }
+    response
 }
 
 /// Tenant CRUD, YAML, encryption, security context
@@ -166,13 +271,17 @@ pub fn topology_routes() -> Router<AppState> {
 
 #[cfg(test)]
 mod tests {
-    use super::{auth_routes, cluster_routes, pod_routes, pool_routes, tenant_routes};
+    use super::{
+        auth_routes, auth_routes_with_admission, cluster_routes,
+        login_admission_rejection_response, pod_routes, pool_routes, tenant_routes,
+    };
     use crate::console::error::JSON_REJECTION_MESSAGE_MAX_BYTES;
     use crate::console::state::{AppState, Claims};
+    use crate::http_admission::{AdmissionConfig, AdmissionControl, AdmissionRejection};
     use axum::{
         Extension, Router,
         body::{Body, to_bytes},
-        http::{Method, Request, StatusCode, header},
+        http::{HeaderValue, Method, Request, StatusCode, header},
     };
     use serde_json::Value;
     use tower::ServiceExt;
@@ -215,6 +324,94 @@ mod tests {
         assert_eq!(body.get("code").and_then(Value::as_str), Some(code));
         assert_eq!(body.get("reason").and_then(Value::as_str), Some(reason));
         assert!(body.get("message").and_then(Value::as_str).is_some());
+    }
+
+    fn restrictive_admission(body_limit_bytes: usize) -> AdmissionControl {
+        AdmissionControl::new(AdmissionConfig {
+            requests_per_second: 0.000_001,
+            burst: 1,
+            max_in_flight: 1,
+            body_limit_bytes,
+            timeout: std::time::Duration::from_secs(1),
+        })
+    }
+
+    #[tokio::test]
+    async fn login_rate_limit_uses_console_error_contract_and_does_not_cover_logout() -> TestResult
+    {
+        let admission = restrictive_admission(64 * 1024);
+        admission
+            .execute(async { Ok::<(), AdmissionRejection>(()) })
+            .await
+            .expect("test should consume the initial token");
+        let app = auth_routes_with_admission(admission)
+            .with_state(AppState::new("test-secret".to_string()));
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/login")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"token":"test"}"#))?,
+            )
+            .await?;
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(
+            response.headers().get(header::RETRY_AFTER),
+            Some(&HeaderValue::from_static("1"))
+        );
+        let body = to_bytes(response.into_body(), usize::MAX).await?;
+        let body: Value = serde_json::from_slice(&body)?;
+        assert_error_envelope(&body, "TooManyRequests", "LoginRateLimited");
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/logout")
+                    .body(Body::empty())?,
+            )
+            .await?;
+        assert_eq!(response.status(), StatusCode::OK);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn login_oversized_body_is_rejected_before_json_extraction() -> TestResult {
+        let app = auth_routes_with_admission(restrictive_admission(4))
+            .with_state(AppState::new("test-secret".to_string()));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/login")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"token":"test"}"#))?,
+            )
+            .await?;
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+        let body = to_bytes(response.into_body(), usize::MAX).await?;
+        let body: Value = serde_json::from_slice(&body)?;
+        assert_error_envelope(&body, "RequestBodyError", "InvalidRequestBody");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn login_timeout_uses_retryable_console_error_contract() -> TestResult {
+        let response = login_admission_rejection_response(AdmissionRejection::TimedOut);
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            response.headers().get(header::RETRY_AFTER),
+            Some(&HeaderValue::from_static("1"))
+        );
+        let body = to_bytes(response.into_body(), usize::MAX).await?;
+        let body: Value = serde_json::from_slice(&body)?;
+        assert_error_envelope(&body, "ServiceUnavailable", "LoginTimedOut");
+        Ok(())
     }
 
     #[tokio::test]

--- a/src/console/server.rs
+++ b/src/console/server.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::console::{openapi::ApiDoc, routes, state::AppState};
+use crate::http_admission::{AdmissionConfig, AdmissionEndpoint};
 use axum::body::Body;
 use axum::http::{HeaderValue, Method, Request, Response, StatusCode, Uri, header};
 use axum::{Router, middleware, response::IntoResponse, routing::get};
@@ -62,6 +63,17 @@ pub async fn run(port: u16) -> Result<(), Box<dyn std::error::Error>> {
 
     tracing::info!(port, "Starting RustFS Operator Console");
 
+    let login_admission_config = AdmissionConfig::from_env(AdmissionEndpoint::ConsoleLogin)?;
+    tracing::info!(
+        requests_per_second = login_admission_config.requests_per_second,
+        burst = login_admission_config.burst,
+        max_in_flight = login_admission_config.max_in_flight,
+        body_limit_bytes = login_admission_config.body_limit_bytes,
+        timeout_seconds = login_admission_config.timeout.as_secs(),
+        scope = "per-process",
+        "Console login admission configured"
+    );
+
     let jwt_secret = load_jwt_secret();
 
     let state = match Client::try_default().await {
@@ -89,7 +101,7 @@ pub async fn run(port: u16) -> Result<(), Box<dyn std::error::Error>> {
         // OpenAPI / Swagger (unauthenticated)
         .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", ApiDoc::openapi()))
         // REST API v1
-        .nest("/api/v1", api_routes())
+        .nest("/api/v1", api_routes(login_admission_config))
         // Shared state
         .with_state(state.clone());
     let app = with_static_frontend(app)
@@ -131,9 +143,9 @@ pub async fn run(port: u16) -> Result<(), Box<dyn std::error::Error>> {
 }
 
 /// Merge all `/api/v1` route trees.
-fn api_routes() -> Router<AppState> {
+fn api_routes(login_admission_config: AdmissionConfig) -> Router<AppState> {
     Router::new()
-        .merge(routes::auth_routes())
+        .merge(routes::auth_routes_with_config(login_admission_config))
         .merge(routes::tenant_routes())
         .merge(routes::pool_routes())
         .merge(routes::pod_routes())

--- a/src/http_admission.rs
+++ b/src/http_admission.rs
@@ -125,7 +125,7 @@ impl AdmissionConfig {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum AdmissionRejection {
-    RateLimited,
+    RateLimited { retry_after_seconds: u64 },
     ConcurrencyLimited,
     BodyTooLarge,
     BodyReadFailed,
@@ -135,7 +135,7 @@ pub(crate) enum AdmissionRejection {
 impl AdmissionRejection {
     pub(crate) fn reason(self) -> AdmissionReason {
         match self {
-            Self::RateLimited => AdmissionReason::RateLimit,
+            Self::RateLimited { .. } => AdmissionReason::RateLimit,
             Self::ConcurrencyLimited => AdmissionReason::ConcurrencyLimit,
             Self::BodyTooLarge => AdmissionReason::BodyTooLarge,
             Self::BodyReadFailed => AdmissionReason::BodyReadFailure,
@@ -264,7 +264,13 @@ impl AdmissionControl {
         bucket.last_refill = now;
 
         if bucket.tokens < 1.0 {
-            return Err(AdmissionRejection::RateLimited);
+            let retry_after_seconds = ((1.0 - bucket.tokens)
+                / self.inner.config.requests_per_second)
+                .ceil()
+                .max(1.0) as u64;
+            return Err(AdmissionRejection::RateLimited {
+                retry_after_seconds,
+            });
         }
         bucket.tokens -= 1.0;
         Ok(permit)
@@ -419,7 +425,26 @@ mod tests {
         assert_eq!(admission.execute(async { Ok(()) }).await, Ok(()));
         assert_eq!(
             admission.execute(async { Ok(()) }).await,
-            Err(AdmissionRejection::RateLimited)
+            Err(AdmissionRejection::RateLimited {
+                retry_after_seconds: 1_000_000,
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn rate_limit_retry_delay_tracks_the_refill_rate() {
+        let admission = AdmissionControl::new(AdmissionConfig {
+            requests_per_second: 0.1,
+            burst: 1,
+            ..test_config()
+        });
+
+        assert_eq!(admission.execute(async { Ok(()) }).await, Ok(()));
+        assert_eq!(
+            admission.execute(async { Ok(()) }).await,
+            Err(AdmissionRejection::RateLimited {
+                retry_after_seconds: 10,
+            })
         );
     }
 

--- a/src/http_admission.rs
+++ b/src/http_admission.rs
@@ -1,0 +1,483 @@
+// Copyright 2025 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use axum::{
+    body::{Body, to_bytes},
+    extract::Request,
+};
+use http_body_util::LengthLimitError;
+use snafu::Snafu;
+use std::{
+    error::Error as _,
+    future::Future,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+const DEFAULT_REQUESTS_PER_SECOND: f64 = 5.0;
+const DEFAULT_BURST: u32 = 10;
+const DEFAULT_MAX_IN_FLIGHT: usize = 16;
+const DEFAULT_BODY_LIMIT_BYTES: usize = 64 * 1024;
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+const MIN_REQUESTS_PER_SECOND: f64 = 0.1;
+const MAX_REQUESTS_PER_SECOND: f64 = 1_000.0;
+const MAX_BURST: u32 = 10_000;
+const MAX_IN_FLIGHT: usize = 1_024;
+const MIN_BODY_LIMIT_BYTES: usize = 1_024;
+const MAX_BODY_LIMIT_BYTES: usize = 1024 * 1024;
+const MAX_TIMEOUT_SECONDS: u64 = 300;
+
+#[derive(Debug, Snafu)]
+pub(crate) enum AdmissionConfigError {
+    #[snafu(display("{name} contains non-UTF-8 data"))]
+    NonUtf8 { name: &'static str },
+
+    #[snafu(display("invalid {name} value {value:?}; expected {expected}"))]
+    InvalidValue {
+        name: &'static str,
+        value: String,
+        expected: &'static str,
+    },
+}
+
+#[derive(Clone, Copy)]
+struct AdmissionEnvNames {
+    requests_per_second: &'static str,
+    burst: &'static str,
+    max_in_flight: &'static str,
+    body_limit_bytes: &'static str,
+    timeout_seconds: &'static str,
+}
+
+/// Per-process admission settings for an unauthenticated, control-plane-backed endpoint.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct AdmissionConfig {
+    pub(crate) requests_per_second: f64,
+    pub(crate) burst: u32,
+    pub(crate) max_in_flight: usize,
+    pub(crate) body_limit_bytes: usize,
+    pub(crate) timeout: Duration,
+}
+
+impl Default for AdmissionConfig {
+    fn default() -> Self {
+        Self {
+            requests_per_second: DEFAULT_REQUESTS_PER_SECOND,
+            burst: DEFAULT_BURST,
+            max_in_flight: DEFAULT_MAX_IN_FLIGHT,
+            body_limit_bytes: DEFAULT_BODY_LIMIT_BYTES,
+            timeout: DEFAULT_TIMEOUT,
+        }
+    }
+}
+
+impl AdmissionConfig {
+    pub(crate) fn for_endpoint(endpoint: AdmissionEndpoint) -> Self {
+        match endpoint {
+            AdmissionEndpoint::Sts | AdmissionEndpoint::ConsoleLogin => Self::default(),
+        }
+    }
+
+    pub(crate) fn from_env(endpoint: AdmissionEndpoint) -> Result<Self, AdmissionConfigError> {
+        let names = endpoint.env_names();
+        let defaults = Self::for_endpoint(endpoint);
+        Ok(Self {
+            requests_per_second: env_f64(
+                names.requests_per_second,
+                defaults.requests_per_second,
+                MIN_REQUESTS_PER_SECOND,
+                MAX_REQUESTS_PER_SECOND,
+            )?,
+            burst: env_u32(names.burst, defaults.burst, 1, MAX_BURST)?,
+            max_in_flight: env_usize(
+                names.max_in_flight,
+                defaults.max_in_flight,
+                1,
+                MAX_IN_FLIGHT,
+            )?,
+            body_limit_bytes: env_usize(
+                names.body_limit_bytes,
+                defaults.body_limit_bytes,
+                MIN_BODY_LIMIT_BYTES,
+                MAX_BODY_LIMIT_BYTES,
+            )?,
+            timeout: Duration::from_secs(env_u64(
+                names.timeout_seconds,
+                defaults.timeout.as_secs(),
+                1,
+                MAX_TIMEOUT_SECONDS,
+            )?),
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum AdmissionRejection {
+    RateLimited,
+    ConcurrencyLimited,
+    BodyTooLarge,
+    BodyReadFailed,
+    TimedOut,
+}
+
+impl AdmissionRejection {
+    pub(crate) fn reason(self) -> AdmissionReason {
+        match self {
+            Self::RateLimited => AdmissionReason::RateLimit,
+            Self::ConcurrencyLimited => AdmissionReason::ConcurrencyLimit,
+            Self::BodyTooLarge => AdmissionReason::BodyTooLarge,
+            Self::BodyReadFailed => AdmissionReason::BodyReadFailure,
+            Self::TimedOut => AdmissionReason::Timeout,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(crate) enum AdmissionEndpoint {
+    Sts,
+    ConsoleLogin,
+}
+
+impl AdmissionEndpoint {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Sts => "sts",
+            Self::ConsoleLogin => "console_login",
+        }
+    }
+
+    fn env_names(self) -> AdmissionEnvNames {
+        match self {
+            Self::Sts => AdmissionEnvNames {
+                requests_per_second: "OPERATOR_STS_ADMISSION_REQUESTS_PER_SECOND",
+                burst: "OPERATOR_STS_ADMISSION_BURST",
+                max_in_flight: "OPERATOR_STS_ADMISSION_MAX_IN_FLIGHT",
+                body_limit_bytes: "OPERATOR_STS_ADMISSION_BODY_LIMIT_BYTES",
+                timeout_seconds: "OPERATOR_STS_ADMISSION_TIMEOUT_SECONDS",
+            },
+            Self::ConsoleLogin => AdmissionEnvNames {
+                requests_per_second: "CONSOLE_LOGIN_ADMISSION_REQUESTS_PER_SECOND",
+                burst: "CONSOLE_LOGIN_ADMISSION_BURST",
+                max_in_flight: "CONSOLE_LOGIN_ADMISSION_MAX_IN_FLIGHT",
+                body_limit_bytes: "CONSOLE_LOGIN_ADMISSION_BODY_LIMIT_BYTES",
+                timeout_seconds: "CONSOLE_LOGIN_ADMISSION_TIMEOUT_SECONDS",
+            },
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(crate) enum AdmissionReason {
+    RateLimit,
+    ConcurrencyLimit,
+    BodyTooLarge,
+    BodyReadFailure,
+    Timeout,
+}
+
+impl AdmissionReason {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::RateLimit => "rate_limit",
+            Self::ConcurrencyLimit => "concurrency_limit",
+            Self::BodyTooLarge => "body_too_large",
+            Self::BodyReadFailure => "body_read_failure",
+            Self::Timeout => "timeout",
+        }
+    }
+}
+
+#[derive(Debug)]
+struct TokenBucket {
+    tokens: f64,
+    last_refill: tokio::time::Instant,
+}
+
+#[derive(Debug)]
+struct AdmissionInner {
+    config: AdmissionConfig,
+    bucket: Mutex<TokenBucket>,
+    semaphore: Arc<Semaphore>,
+}
+
+/// Shared state for one endpoint. Create separate instances for STS and Console login.
+#[derive(Clone, Debug)]
+pub(crate) struct AdmissionControl {
+    inner: Arc<AdmissionInner>,
+}
+
+impl Default for AdmissionControl {
+    fn default() -> Self {
+        Self::new(AdmissionConfig::default())
+    }
+}
+
+impl AdmissionControl {
+    pub(crate) fn new(config: AdmissionConfig) -> Self {
+        debug_assert!(config.requests_per_second.is_finite());
+        debug_assert!(config.requests_per_second > 0.0);
+        debug_assert!(config.burst > 0);
+        debug_assert!(config.max_in_flight > 0);
+        debug_assert!(config.body_limit_bytes > 0);
+        debug_assert!(!config.timeout.is_zero());
+
+        let now = tokio::time::Instant::now();
+        Self {
+            inner: Arc::new(AdmissionInner {
+                config,
+                bucket: Mutex::new(TokenBucket {
+                    tokens: f64::from(config.burst),
+                    last_refill: now,
+                }),
+                semaphore: Arc::new(Semaphore::new(config.max_in_flight)),
+            }),
+        }
+    }
+
+    fn try_enter(&self) -> Result<OwnedSemaphorePermit, AdmissionRejection> {
+        let permit = Arc::clone(&self.inner.semaphore)
+            .try_acquire_owned()
+            .map_err(|_| AdmissionRejection::ConcurrencyLimited)?;
+
+        let now = tokio::time::Instant::now();
+        let mut bucket = self
+            .inner
+            .bucket
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let elapsed = now.saturating_duration_since(bucket.last_refill);
+        bucket.tokens = (bucket.tokens
+            + elapsed.as_secs_f64() * self.inner.config.requests_per_second)
+            .min(f64::from(self.inner.config.burst));
+        bucket.last_refill = now;
+
+        if bucket.tokens < 1.0 {
+            return Err(AdmissionRejection::RateLimited);
+        }
+        bucket.tokens -= 1.0;
+        Ok(permit)
+    }
+
+    /// Run one admitted operation while holding its concurrency permit and enforcing a deadline.
+    pub(crate) async fn execute<F, T>(&self, operation: F) -> Result<T, AdmissionRejection>
+    where
+        F: Future<Output = Result<T, AdmissionRejection>>,
+    {
+        let _permit = self.try_enter()?;
+        tokio::time::timeout(self.inner.config.timeout, operation)
+            .await
+            .map_err(|_| AdmissionRejection::TimedOut)?
+    }
+
+    /// Buffer a small authentication request before its extractor can allocate an unbounded body.
+    pub(crate) async fn read_bounded_request(
+        &self,
+        request: Request,
+    ) -> Result<Request, AdmissionRejection> {
+        let (parts, body) = request.into_parts();
+        let bytes = to_bytes(body, self.inner.config.body_limit_bytes)
+            .await
+            .map_err(|error| {
+                if error
+                    .source()
+                    .is_some_and(|source| source.is::<LengthLimitError>())
+                {
+                    AdmissionRejection::BodyTooLarge
+                } else {
+                    AdmissionRejection::BodyReadFailed
+                }
+            })?;
+        Ok(Request::from_parts(parts, Body::from(bytes)))
+    }
+}
+
+fn env_value(name: &'static str) -> Result<Option<String>, AdmissionConfigError> {
+    match std::env::var(name) {
+        Ok(value) => Ok(Some(value)),
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(std::env::VarError::NotUnicode(_)) => Err(AdmissionConfigError::NonUtf8 { name }),
+    }
+}
+
+fn env_f64(
+    name: &'static str,
+    default: f64,
+    minimum: f64,
+    maximum: f64,
+) -> Result<f64, AdmissionConfigError> {
+    let Some(value) = env_value(name)? else {
+        return Ok(default);
+    };
+    let parsed = value
+        .parse::<f64>()
+        .ok()
+        .filter(|parsed| parsed.is_finite() && (minimum..=maximum).contains(parsed))
+        .ok_or_else(|| AdmissionConfigError::InvalidValue {
+            name,
+            value: value.clone(),
+            expected: "a finite number from 0.1 through 1000",
+        })?;
+    Ok(parsed)
+}
+
+fn env_u32(
+    name: &'static str,
+    default: u32,
+    minimum: u32,
+    maximum: u32,
+) -> Result<u32, AdmissionConfigError> {
+    let Some(value) = env_value(name)? else {
+        return Ok(default);
+    };
+    value
+        .parse::<u32>()
+        .ok()
+        .filter(|parsed| (minimum..=maximum).contains(parsed))
+        .ok_or(AdmissionConfigError::InvalidValue {
+            name,
+            value,
+            expected: "an integer from 1 through 10000",
+        })
+}
+
+fn env_usize(
+    name: &'static str,
+    default: usize,
+    minimum: usize,
+    maximum: usize,
+) -> Result<usize, AdmissionConfigError> {
+    let Some(value) = env_value(name)? else {
+        return Ok(default);
+    };
+    value
+        .parse::<usize>()
+        .ok()
+        .filter(|parsed| (minimum..=maximum).contains(parsed))
+        .ok_or(AdmissionConfigError::InvalidValue {
+            name,
+            value,
+            expected: if minimum == MIN_BODY_LIMIT_BYTES {
+                "an integer from 1024 through 1048576"
+            } else {
+                "an integer from 1 through 1024"
+            },
+        })
+}
+
+fn env_u64(
+    name: &'static str,
+    default: u64,
+    minimum: u64,
+    maximum: u64,
+) -> Result<u64, AdmissionConfigError> {
+    let Some(value) = env_value(name)? else {
+        return Ok(default);
+    };
+    value
+        .parse::<u64>()
+        .ok()
+        .filter(|parsed| (minimum..=maximum).contains(parsed))
+        .ok_or(AdmissionConfigError::InvalidValue {
+            name,
+            value,
+            expected: "an integer from 1 through 300",
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::future::pending;
+
+    fn test_config() -> AdmissionConfig {
+        AdmissionConfig {
+            requests_per_second: 0.000_001,
+            burst: 2,
+            max_in_flight: 1,
+            body_limit_bytes: 4,
+            timeout: Duration::from_millis(5),
+        }
+    }
+
+    #[tokio::test]
+    async fn rejects_immediately_when_burst_is_exhausted() {
+        let admission = AdmissionControl::new(test_config());
+
+        assert_eq!(admission.execute(async { Ok(()) }).await, Ok(()));
+        assert_eq!(admission.execute(async { Ok(()) }).await, Ok(()));
+        assert_eq!(
+            admission.execute(async { Ok(()) }).await,
+            Err(AdmissionRejection::RateLimited)
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_concurrent_work_without_consuming_an_extra_token() {
+        let admission = AdmissionControl::new(test_config());
+        let first = admission.try_enter().expect("first request is admitted");
+
+        assert!(matches!(
+            admission.try_enter(),
+            Err(AdmissionRejection::ConcurrencyLimited)
+        ));
+        drop(first);
+        assert!(admission.try_enter().is_ok());
+    }
+
+    #[tokio::test]
+    async fn timeout_releases_the_concurrency_permit() {
+        let admission = AdmissionControl::new(test_config());
+
+        let result = admission
+            .execute(pending::<Result<(), AdmissionRejection>>())
+            .await;
+        assert_eq!(result, Err(AdmissionRejection::TimedOut));
+        assert!(admission.try_enter().is_ok());
+    }
+
+    #[tokio::test]
+    async fn rejects_oversized_bodies_before_the_handler() {
+        let admission = AdmissionControl::new(test_config());
+        let request = Request::new(Body::from("12345"));
+
+        assert!(matches!(
+            admission.read_bounded_request(request).await,
+            Err(AdmissionRejection::BodyTooLarge)
+        ));
+    }
+
+    #[tokio::test]
+    async fn accepts_a_body_at_the_exact_limit() {
+        let admission = AdmissionControl::new(test_config());
+        let request = admission
+            .read_bounded_request(Request::new(Body::from("1234")))
+            .await;
+
+        assert!(request.is_ok());
+    }
+
+    #[tokio::test]
+    async fn distinguishes_body_transport_failures_from_size_limits() {
+        let admission = AdmissionControl::new(test_config());
+        let body = Body::from_stream(futures::stream::once(async {
+            Err::<axum::body::Bytes, _>(std::io::Error::other("test body failure"))
+        }));
+
+        assert!(matches!(
+            admission.read_bounded_request(Request::new(body)).await,
+            Err(AdmissionRejection::BodyReadFailed)
+        ));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,7 @@ pub fn init_tracing() {
 
 mod cluster_dns;
 mod context;
+mod http_admission;
 pub mod metrics;
 pub mod reconcile;
 mod status;
@@ -129,6 +130,17 @@ pub async fn run(options: ServerOptions) -> Result<(), Box<dyn std::error::Error
     }
 
     if operator_sts_enabled() {
+        let sts_admission_config =
+            http_admission::AdmissionConfig::from_env(http_admission::AdmissionEndpoint::Sts)?;
+        info!(
+            requests_per_second = sts_admission_config.requests_per_second,
+            burst = sts_admission_config.burst,
+            max_in_flight = sts_admission_config.max_in_flight,
+            body_limit_bytes = sts_admission_config.body_limit_bytes,
+            timeout_seconds = sts_admission_config.timeout.as_secs(),
+            scope = "per-process",
+            "operator STS admission configured"
+        );
         let sts_port = operator_sts_port();
         let sts_state = crate::console::state::AppState::new(String::new())
             .with_kube_client(client.clone())
@@ -148,7 +160,14 @@ pub async fn run(options: ServerOptions) -> Result<(), Box<dyn std::error::Error
         };
         let sts_listener = bind_sts_listener(sts_port, tls_server_config.is_some()).await?;
         tokio::spawn(async move {
-            if let Err(error) = run_sts_server(sts_listener, sts_state, tls_server_config).await {
+            if let Err(error) = run_sts_server(
+                sts_listener,
+                sts_state,
+                tls_server_config,
+                sts_admission_config,
+            )
+            .await
+            {
                 warn!(%error, "Operator STS server stopped unexpectedly");
             }
         });
@@ -770,9 +789,10 @@ async fn run_sts_server(
     listener: tokio::net::TcpListener,
     state: crate::console::state::AppState,
     tls_config: Option<Arc<rustls::ServerConfig>>,
+    admission_config: http_admission::AdmissionConfig,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let app = Router::new()
-        .merge(crate::sts::server::routes())
+        .merge(crate::sts::server::routes_with_config(admission_config))
         .with_state(state);
 
     if let Some(tls_config) = tls_config {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::http_admission::{AdmissionEndpoint, AdmissionReason};
 use axum::{
     extract::Request,
     http::{HeaderMap, HeaderValue, StatusCode, header},
@@ -38,6 +39,7 @@ struct Metrics {
     operator_leader: AtomicU64,
     sts_requests_total: Mutex<BTreeMap<String, u64>>,
     sts_request_duration: Mutex<BTreeMap<String, DurationSummary>>,
+    unauthenticated_admission_rejections_total: Mutex<BTreeMap<AdmissionKey, u64>>,
     http_requests_total: Mutex<BTreeMap<HttpKey, u64>>,
     http_request_duration: Mutex<BTreeMap<HttpKey, DurationSummary>>,
     tenant_monitor_polls_total: Mutex<BTreeMap<String, u64>>,
@@ -50,6 +52,12 @@ struct HttpKey {
     component: String,
     method: String,
     status: String,
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct AdmissionKey {
+    endpoint: &'static str,
+    reason: &'static str,
 }
 
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -129,6 +137,33 @@ pub fn record_sts_request(success: bool, duration: Duration) {
     let result = result_label(success);
     increment_string_counter(&metrics().sts_requests_total, result);
     observe_string_duration(&metrics().sts_request_duration, result, duration);
+}
+
+#[cfg(test)]
+pub(crate) fn sts_request_count(success: bool) -> u64 {
+    let result = result_label(success);
+    metrics()
+        .sts_requests_total
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(result)
+        .copied()
+        .unwrap_or_default()
+}
+
+pub(crate) fn record_unauthenticated_admission_rejection(
+    endpoint: AdmissionEndpoint,
+    reason: AdmissionReason,
+) {
+    let key = AdmissionKey {
+        endpoint: endpoint.as_str(),
+        reason: reason.as_str(),
+    };
+    let mut counters = metrics()
+        .unauthenticated_admission_rejections_total
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    *counters.entry(key).or_default() += 1;
 }
 
 pub fn record_http_request(component: &str, method: &str, status: StatusCode, duration: Duration) {
@@ -296,6 +331,7 @@ pub fn render() -> String {
         "result",
         &metrics().sts_request_duration,
     );
+    render_admission_rejection_counter(&mut output);
 
     render_http_counter(&mut output);
     render_http_duration_summary(&mut output);
@@ -317,6 +353,24 @@ pub fn render() -> String {
     render_tenant_storage(&mut output);
 
     output
+}
+
+fn render_admission_rejection_counter(output: &mut String) {
+    let name = "rustfs_operator_unauthenticated_admission_rejections_total";
+    output.push_str(&format!(
+        "# HELP {name} Total number of unauthenticated endpoint requests rejected by admission control.\n# TYPE {name} counter\n"
+    ));
+    let counters = metrics()
+        .unauthenticated_admission_rejections_total
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    for (key, value) in counters.iter() {
+        output.push_str(&format!(
+            "{name}{{{}}} {}\n",
+            labels(&[("endpoint", key.endpoint), ("reason", key.reason)]),
+            value
+        ));
+    }
 }
 
 fn update_tenant_storage_snapshot(namespace: &str, tenant: &str, snapshot: TenantStorageSnapshot) {
@@ -601,6 +655,18 @@ mod tests {
         assert_eq!(status_class(StatusCode::OK), "2xx");
         assert_eq!(status_class(StatusCode::NOT_FOUND), "4xx");
         assert_eq!(status_class(StatusCode::INTERNAL_SERVER_ERROR), "5xx");
+    }
+
+    #[test]
+    fn admission_rejection_metrics_use_fixed_labels() {
+        record_unauthenticated_admission_rejection(
+            AdmissionEndpoint::Sts,
+            AdmissionReason::RateLimit,
+        );
+
+        assert!(render().contains(
+            "rustfs_operator_unauthenticated_admission_rejections_total{endpoint=\"sts\",reason=\"rate_limit\"}"
+        ));
     }
 
     #[test]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -40,6 +40,7 @@ struct Metrics {
     sts_requests_total: Mutex<BTreeMap<String, u64>>,
     sts_request_duration: Mutex<BTreeMap<String, DurationSummary>>,
     unauthenticated_admission_rejections_total: Mutex<BTreeMap<AdmissionKey, u64>>,
+    unauthenticated_requests_total: Mutex<BTreeMap<UnauthenticatedRequestKey, u64>>,
     http_requests_total: Mutex<BTreeMap<HttpKey, u64>>,
     http_request_duration: Mutex<BTreeMap<HttpKey, DurationSummary>>,
     tenant_monitor_polls_total: Mutex<BTreeMap<String, u64>>,
@@ -58,6 +59,44 @@ struct HttpKey {
 struct AdmissionKey {
     endpoint: &'static str,
     reason: &'static str,
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct UnauthenticatedRequestKey {
+    endpoint: &'static str,
+    outcome: &'static str,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum UnauthenticatedRequestOutcome {
+    Success,
+    Error,
+    Rejected(AdmissionReason),
+}
+
+impl UnauthenticatedRequestOutcome {
+    pub(crate) fn from_status(status: StatusCode) -> Self {
+        if status.is_success() {
+            Self::Success
+        } else {
+            Self::Error
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Success => "success",
+            Self::Error => "error",
+            Self::Rejected(_) => "rejected",
+        }
+    }
+
+    fn rejection_reason(self) -> Option<AdmissionReason> {
+        match self {
+            Self::Rejected(reason) => Some(reason),
+            Self::Success | Self::Error => None,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -107,7 +146,51 @@ pub struct TenantStorageMetrics {
 
 fn metrics() -> &'static Metrics {
     static METRICS: OnceLock<Metrics> = OnceLock::new();
-    METRICS.get_or_init(Metrics::default)
+    METRICS.get_or_init(|| Metrics {
+        unauthenticated_admission_rejections_total: Mutex::new(
+            initial_admission_rejection_counters(),
+        ),
+        unauthenticated_requests_total: Mutex::new(initial_unauthenticated_request_counters()),
+        ..Metrics::default()
+    })
+}
+
+fn initial_admission_rejection_counters() -> BTreeMap<AdmissionKey, u64> {
+    let mut counters = BTreeMap::new();
+    for endpoint in [AdmissionEndpoint::Sts, AdmissionEndpoint::ConsoleLogin] {
+        for reason in [
+            AdmissionReason::RateLimit,
+            AdmissionReason::ConcurrencyLimit,
+            AdmissionReason::BodyTooLarge,
+            AdmissionReason::BodyReadFailure,
+            AdmissionReason::Timeout,
+        ] {
+            counters.insert(
+                AdmissionKey {
+                    endpoint: endpoint.as_str(),
+                    reason: reason.as_str(),
+                },
+                0,
+            );
+        }
+    }
+    counters
+}
+
+fn initial_unauthenticated_request_counters() -> BTreeMap<UnauthenticatedRequestKey, u64> {
+    let mut counters = BTreeMap::new();
+    for endpoint in [AdmissionEndpoint::Sts, AdmissionEndpoint::ConsoleLogin] {
+        for outcome in ["success", "error", "rejected"] {
+            counters.insert(
+                UnauthenticatedRequestKey {
+                    endpoint: endpoint.as_str(),
+                    outcome,
+                },
+                0,
+            );
+        }
+    }
+    counters
 }
 
 pub fn set_operator_leader(is_leader: bool) {
@@ -137,33 +220,75 @@ pub fn record_sts_request(success: bool, duration: Duration) {
     let result = result_label(success);
     increment_string_counter(&metrics().sts_requests_total, result);
     observe_string_duration(&metrics().sts_request_duration, result, duration);
+    #[cfg(test)]
+    let _ = TEST_REQUEST_METRICS.try_with(|captured| {
+        captured.borrow_mut().sts_request_results.push(success);
+    });
 }
 
-#[cfg(test)]
-pub(crate) fn sts_request_count(success: bool) -> u64 {
-    let result = result_label(success);
-    metrics()
-        .sts_requests_total
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .get(result)
-        .copied()
-        .unwrap_or_default()
-}
-
-pub(crate) fn record_unauthenticated_admission_rejection(
+pub(crate) fn record_unauthenticated_request(
     endpoint: AdmissionEndpoint,
-    reason: AdmissionReason,
+    outcome: UnauthenticatedRequestOutcome,
 ) {
-    let key = AdmissionKey {
+    let key = UnauthenticatedRequestKey {
         endpoint: endpoint.as_str(),
-        reason: reason.as_str(),
+        outcome: outcome.as_str(),
     };
     let mut counters = metrics()
-        .unauthenticated_admission_rejections_total
+        .unauthenticated_requests_total
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     *counters.entry(key).or_default() += 1;
+    drop(counters);
+
+    if let Some(reason) = outcome.rejection_reason() {
+        let key = AdmissionKey {
+            endpoint: endpoint.as_str(),
+            reason: reason.as_str(),
+        };
+        let mut counters = metrics()
+            .unauthenticated_admission_rejections_total
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *counters.entry(key).or_default() += 1;
+    }
+
+    #[cfg(test)]
+    let _ = TEST_REQUEST_METRICS.try_with(|captured| {
+        captured
+            .borrow_mut()
+            .unauthenticated_requests
+            .push((endpoint, outcome));
+    });
+}
+
+#[cfg(test)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct TestRequestMetrics {
+    pub(crate) sts_request_results: Vec<bool>,
+    pub(crate) unauthenticated_requests: Vec<(AdmissionEndpoint, UnauthenticatedRequestOutcome)>,
+}
+
+#[cfg(test)]
+tokio::task_local! {
+    static TEST_REQUEST_METRICS: std::cell::RefCell<TestRequestMetrics>;
+}
+
+#[cfg(test)]
+pub(crate) async fn capture_request_metrics<F>(future: F) -> (F::Output, TestRequestMetrics)
+where
+    F: std::future::Future,
+{
+    TEST_REQUEST_METRICS
+        .scope(
+            std::cell::RefCell::new(TestRequestMetrics::default()),
+            async {
+                let output = future.await;
+                let captured = TEST_REQUEST_METRICS.with(|metrics| metrics.borrow().clone());
+                (output, captured)
+            },
+        )
+        .await
 }
 
 pub fn record_http_request(component: &str, method: &str, status: StatusCode, duration: Duration) {
@@ -332,6 +457,7 @@ pub fn render() -> String {
         &metrics().sts_request_duration,
     );
     render_admission_rejection_counter(&mut output);
+    render_unauthenticated_request_counter(&mut output);
 
     render_http_counter(&mut output);
     render_http_duration_summary(&mut output);
@@ -368,6 +494,24 @@ fn render_admission_rejection_counter(output: &mut String) {
         output.push_str(&format!(
             "{name}{{{}}} {}\n",
             labels(&[("endpoint", key.endpoint), ("reason", key.reason)]),
+            value
+        ));
+    }
+}
+
+fn render_unauthenticated_request_counter(output: &mut String) {
+    let name = "rustfs_operator_unauthenticated_requests_total";
+    output.push_str(&format!(
+        "# HELP {name} Total number of requests to unauthenticated control-plane-backed endpoints.\n# TYPE {name} counter\n"
+    ));
+    let counters = metrics()
+        .unauthenticated_requests_total
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    for (key, value) in counters.iter() {
+        output.push_str(&format!(
+            "{name}{{{}}} {}\n",
+            labels(&[("endpoint", key.endpoint), ("outcome", key.outcome)]),
             value
         ));
     }
@@ -659,14 +803,61 @@ mod tests {
 
     #[test]
     fn admission_rejection_metrics_use_fixed_labels() {
-        record_unauthenticated_admission_rejection(
+        record_unauthenticated_request(
             AdmissionEndpoint::Sts,
-            AdmissionReason::RateLimit,
+            UnauthenticatedRequestOutcome::Rejected(AdmissionReason::RateLimit),
         );
 
         assert!(render().contains(
             "rustfs_operator_unauthenticated_admission_rejections_total{endpoint=\"sts\",reason=\"rate_limit\"}"
         ));
+    }
+
+    #[test]
+    fn unauthenticated_request_metrics_use_fixed_endpoint_and_outcome_labels() {
+        record_unauthenticated_request(
+            AdmissionEndpoint::ConsoleLogin,
+            UnauthenticatedRequestOutcome::Success,
+        );
+        record_unauthenticated_request(
+            AdmissionEndpoint::Sts,
+            UnauthenticatedRequestOutcome::Rejected(AdmissionReason::Timeout),
+        );
+
+        let rendered = render();
+        assert!(rendered.contains(
+            "rustfs_operator_unauthenticated_requests_total{endpoint=\"console_login\",outcome=\"success\"}"
+        ));
+        assert!(rendered.contains(
+            "rustfs_operator_unauthenticated_requests_total{endpoint=\"sts\",outcome=\"rejected\"}"
+        ));
+    }
+
+    #[test]
+    fn unauthenticated_request_outcome_keeps_downstream_errors_distinct() {
+        assert_eq!(
+            UnauthenticatedRequestOutcome::from_status(StatusCode::OK),
+            UnauthenticatedRequestOutcome::Success
+        );
+        assert_eq!(
+            UnauthenticatedRequestOutcome::from_status(StatusCode::BAD_REQUEST),
+            UnauthenticatedRequestOutcome::Error
+        );
+        assert_eq!(
+            UnauthenticatedRequestOutcome::from_status(StatusCode::INTERNAL_SERVER_ERROR),
+            UnauthenticatedRequestOutcome::Error
+        );
+    }
+
+    #[test]
+    fn unauthenticated_metric_series_have_zero_baselines() {
+        let rejection_counters = initial_admission_rejection_counters();
+        let request_counters = initial_unauthenticated_request_counters();
+
+        assert_eq!(rejection_counters.len(), 10);
+        assert!(rejection_counters.values().all(|value| *value == 0));
+        assert_eq!(request_counters.len(), 6);
+        assert!(request_counters.values().all(|value| *value == 0));
     }
 
     #[test]

--- a/src/sts/error.rs
+++ b/src/sts/error.rs
@@ -18,6 +18,21 @@ pub const STS_XML_NAMESPACE: &str = "https://sts.amazonaws.com/doc/2011-06-15/";
 /// Placeholder request id for deterministic test payloads.
 pub const STS_REQUEST_ID: &str = "00000000-0000-0000-0000-000000000000";
 
+#[derive(Clone, Copy)]
+pub(crate) enum StsErrorType {
+    Sender,
+    Receiver,
+}
+
+impl StsErrorType {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Sender => "Sender",
+            Self::Receiver => "Receiver",
+        }
+    }
+}
+
 /// Validation and stub errors for STS request handling.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StsError {
@@ -103,11 +118,20 @@ pub fn escape_xml(value: &str) -> String {
 }
 
 pub fn render_sts_error_xml(code: &str, message: &str) -> String {
+    render_sts_error_xml_with_type(StsErrorType::Sender, code, message)
+}
+
+pub(crate) fn render_sts_error_xml_with_type(
+    error_type: StsErrorType,
+    code: &str,
+    message: &str,
+) -> String {
     let message = escape_xml(message);
     let request_id = STS_REQUEST_ID;
+    let error_type = error_type.as_str();
 
     format!(
-        "<ErrorResponse xmlns=\"{ns}\"><Error><Type>Sender</Type><Code>{code}</Code><Message>{message}</Message></Error><RequestId>{request_id}</RequestId></ErrorResponse>",
+        "<ErrorResponse xmlns=\"{ns}\"><Error><Type>{error_type}</Type><Code>{code}</Code><Message>{message}</Message></Error><RequestId>{request_id}</RequestId></ErrorResponse>",
         ns = STS_XML_NAMESPACE,
     )
 }

--- a/src/sts/server.rs
+++ b/src/sts/server.rs
@@ -29,6 +29,7 @@ use crate::console::state::AppState;
 use crate::http_admission::{
     AdmissionConfig, AdmissionControl, AdmissionEndpoint, AdmissionRejection,
 };
+use crate::metrics::UnauthenticatedRequestOutcome;
 use crate::sts::binding;
 use crate::sts::error::{StsError, StsErrorType, render_sts_error_xml_with_type};
 use crate::sts::rustfs_client::{RustfsAdminClient, RustfsClientError};
@@ -74,23 +75,24 @@ async fn enforce_sts_admission(
         })
         .await;
 
-    let response = match result {
-        Ok(response) => response,
-        Err(rejection) => {
-            crate::metrics::record_unauthenticated_admission_rejection(
-                AdmissionEndpoint::Sts,
-                rejection.reason(),
-            );
-            sts_admission_rejection_response(rejection)
+    let (response, outcome) = match result {
+        Ok(response) => {
+            let outcome = UnauthenticatedRequestOutcome::from_status(response.status());
+            (response, outcome)
         }
+        Err(rejection) => (
+            sts_admission_rejection_response(rejection),
+            UnauthenticatedRequestOutcome::Rejected(rejection.reason()),
+        ),
     };
+    crate::metrics::record_unauthenticated_request(AdmissionEndpoint::Sts, outcome);
     crate::metrics::record_sts_request(response.status().is_success(), started.elapsed());
     response
 }
 
 fn sts_admission_rejection_response(rejection: AdmissionRejection) -> Response {
     let (status, code, message, retry_after, error_type) = match rejection {
-        AdmissionRejection::RateLimited => (
+        AdmissionRejection::RateLimited { .. } => (
             StatusCode::BAD_REQUEST,
             "ThrottlingException",
             "Rate exceeded for this STS endpoint.",
@@ -690,7 +692,8 @@ mod tests {
     use std::sync::Mutex;
 
     use super::*;
-    use crate::http_admission::AdmissionConfig;
+    use crate::http_admission::{AdmissionConfig, AdmissionReason};
+    use crate::metrics::{UnauthenticatedRequestOutcome, capture_request_metrics};
     use crate::sts::types::{STS_API_VERSION, STS_WEB_IDENTITY_ACTION, StsAssumeRoleCredentials};
     use crate::types::v1alpha1::policy_binding::{PolicyBindingApplication, PolicyBindingSpec};
     use axum::{
@@ -701,7 +704,7 @@ mod tests {
 
     fn restrictive_admission(body_limit_bytes: usize) -> AdmissionControl {
         AdmissionControl::new(AdmissionConfig {
-            requests_per_second: 0.000_001,
+            requests_per_second: 0.1,
             burst: 1,
             max_in_flight: 1,
             body_limit_bytes,
@@ -786,8 +789,8 @@ mod tests {
         let app =
             routes_with_admission(admission).with_state(AppState::new("test-secret".to_string()));
 
-        let response = app
-            .oneshot(
+        let (response, captured) = capture_request_metrics(
+            app.oneshot(
                 Request::builder()
                     .method("POST")
                     .uri("/sts/tenant-a/rustfs-a")
@@ -796,11 +799,20 @@ mod tests {
                         "Version=2011-06-15&Action=AssumeRoleWithWebIdentity&WebIdentityToken=abc",
                     ))
                     .expect("request should build"),
-            )
-            .await
-            .expect("request should complete");
+            ),
+        )
+        .await;
+        let response = response.expect("request should complete");
 
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(captured.sts_request_results, vec![false]);
+        assert_eq!(
+            captured.unauthenticated_requests,
+            vec![(
+                AdmissionEndpoint::Sts,
+                UnauthenticatedRequestOutcome::Rejected(AdmissionReason::RateLimit),
+            )]
+        );
         assert_eq!(
             response.headers().get(header::CONTENT_TYPE),
             Some(&HeaderValue::from_static("application/xml"))
@@ -844,22 +856,26 @@ mod tests {
 
     #[tokio::test]
     async fn sts_extractor_rejections_are_included_in_request_metrics() {
-        let before = crate::metrics::sts_request_count(false);
         let app = routes().with_state(AppState::new("test-secret".to_string()));
 
-        let response = app
-            .oneshot(
+        let (response, captured) = capture_request_metrics(
+            app.oneshot(
                 Request::builder()
                     .method("POST")
                     .uri("/sts/tenant-a/rustfs-a")
                     .body(Body::from("not-a-form"))
                     .expect("request should build"),
-            )
-            .await
-            .expect("request should complete");
+            ),
+        )
+        .await;
+        let response = response.expect("request should complete");
 
         assert_eq!(response.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
-        assert!(crate::metrics::sts_request_count(false) > before);
+        assert_eq!(captured.sts_request_results, vec![false]);
+        assert_eq!(
+            captured.unauthenticated_requests,
+            vec![(AdmissionEndpoint::Sts, UnauthenticatedRequestOutcome::Error)]
+        );
     }
 
     #[tokio::test]

--- a/src/sts/server.rs
+++ b/src/sts/server.rs
@@ -15,8 +15,9 @@
 use async_trait::async_trait;
 use axum::{
     Router,
-    extract::{Form, Path, State},
-    http::{StatusCode, header},
+    extract::{Form, Path, Request, State},
+    http::{HeaderValue, StatusCode, header},
+    middleware::{self, Next},
     response::{IntoResponse, Response},
     routing::post,
 };
@@ -25,8 +26,11 @@ use kube::{Api, Client, api::ListParams};
 use std::time::Instant;
 
 use crate::console::state::AppState;
+use crate::http_admission::{
+    AdmissionConfig, AdmissionControl, AdmissionEndpoint, AdmissionRejection,
+};
 use crate::sts::binding;
-use crate::sts::error::StsError;
+use crate::sts::error::{StsError, StsErrorType, render_sts_error_xml_with_type};
 use crate::sts::rustfs_client::{RustfsAdminClient, RustfsClientError};
 use crate::sts::session_policy;
 use crate::sts::token_review::{self, TokenReviewError};
@@ -40,10 +44,98 @@ const DEFAULT_STS_AUDIENCE: &str = "sts.rustfs.com";
 
 /// Build STS routes mounted at root path `/sts`.
 pub fn routes() -> Router<AppState> {
+    routes_with_config(AdmissionConfig::for_endpoint(AdmissionEndpoint::Sts))
+}
+
+pub(crate) fn routes_with_config(config: AdmissionConfig) -> Router<AppState> {
+    routes_with_admission(AdmissionControl::new(config))
+}
+
+fn routes_with_admission(admission: AdmissionControl) -> Router<AppState> {
     Router::new().route(
         "/sts/:tenant_namespace/:tenant_name",
-        post(assume_role_with_web_identity_for_tenant),
+        post(assume_role_with_web_identity_for_tenant).route_layer(middleware::from_fn_with_state(
+            admission,
+            enforce_sts_admission,
+        )),
     )
+}
+
+async fn enforce_sts_admission(
+    State(admission): State<AdmissionControl>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let started = Instant::now();
+    let result = admission
+        .execute(async {
+            let request = admission.read_bounded_request(request).await?;
+            Ok(next.run(request).await)
+        })
+        .await;
+
+    let response = match result {
+        Ok(response) => response,
+        Err(rejection) => {
+            crate::metrics::record_unauthenticated_admission_rejection(
+                AdmissionEndpoint::Sts,
+                rejection.reason(),
+            );
+            sts_admission_rejection_response(rejection)
+        }
+    };
+    crate::metrics::record_sts_request(response.status().is_success(), started.elapsed());
+    response
+}
+
+fn sts_admission_rejection_response(rejection: AdmissionRejection) -> Response {
+    let (status, code, message, retry_after, error_type) = match rejection {
+        AdmissionRejection::RateLimited => (
+            StatusCode::BAD_REQUEST,
+            "ThrottlingException",
+            "Rate exceeded for this STS endpoint.",
+            false,
+            StsErrorType::Sender,
+        ),
+        AdmissionRejection::ConcurrencyLimited => (
+            StatusCode::BAD_REQUEST,
+            "ThrottlingException",
+            "Too many STS requests are already in progress.",
+            false,
+            StsErrorType::Sender,
+        ),
+        AdmissionRejection::BodyTooLarge => (
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "RequestEntityTooLarge",
+            "The request body exceeds the maximum allowed size.",
+            false,
+            StsErrorType::Sender,
+        ),
+        AdmissionRejection::BodyReadFailed => (
+            StatusCode::BAD_REQUEST,
+            "InvalidQueryParameter",
+            "The request body could not be read.",
+            false,
+            StsErrorType::Sender,
+        ),
+        AdmissionRejection::TimedOut => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "ServiceUnavailable",
+            "The STS request timed out.",
+            true,
+            StsErrorType::Receiver,
+        ),
+    };
+    let mut response = xml_response(
+        status,
+        render_sts_error_xml_with_type(error_type, code, message),
+    );
+    if retry_after {
+        response
+            .headers_mut()
+            .insert(header::RETRY_AFTER, HeaderValue::from_static("1"));
+    }
+    response
 }
 
 /// Handle POST /sts/{tenantNamespace}/{tenantName}.
@@ -52,10 +144,7 @@ async fn assume_role_with_web_identity_for_tenant(
     Path((tenant_namespace, tenant_name)): Path<(String, String)>,
     Form(form): Form<AssumeRoleWithWebIdentityForm>,
 ) -> Response {
-    let started = Instant::now();
-    let response = assume_role_with_web_identity(state, tenant_namespace, tenant_name, form).await;
-    crate::metrics::record_sts_request(response.status().is_success(), started.elapsed());
-    response
+    assume_role_with_web_identity(state, tenant_namespace, tenant_name, form).await
 }
 
 async fn assume_role_with_web_identity(
@@ -601,6 +690,7 @@ mod tests {
     use std::sync::Mutex;
 
     use super::*;
+    use crate::http_admission::AdmissionConfig;
     use crate::sts::types::{STS_API_VERSION, STS_WEB_IDENTITY_ACTION, StsAssumeRoleCredentials};
     use crate::types::v1alpha1::policy_binding::{PolicyBindingApplication, PolicyBindingSpec};
     use axum::{
@@ -608,6 +698,16 @@ mod tests {
         http::{Request, StatusCode},
     };
     use tower::ServiceExt;
+
+    fn restrictive_admission(body_limit_bytes: usize) -> AdmissionControl {
+        AdmissionControl::new(AdmissionConfig {
+            requests_per_second: 0.000_001,
+            burst: 1,
+            max_in_flight: 1,
+            body_limit_bytes,
+            timeout: std::time::Duration::from_secs(1),
+        })
+    }
 
     #[tokio::test]
     async fn namespace_only_route_is_not_registered() {
@@ -674,6 +774,109 @@ mod tests {
         let text = String::from_utf8(body.to_vec()).unwrap();
         assert!(text.contains("<ErrorResponse"));
         assert!(text.contains("<Code>MissingParameter</Code>"));
+    }
+
+    #[tokio::test]
+    async fn sts_rate_limit_is_immediate_and_preserves_xml_contract() {
+        let admission = restrictive_admission(64 * 1024);
+        admission
+            .execute(async { Ok::<(), AdmissionRejection>(()) })
+            .await
+            .expect("test should consume the initial token");
+        let app =
+            routes_with_admission(admission).with_state(AppState::new("test-secret".to_string()));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/sts/tenant-a/rustfs-a")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::from(
+                        "Version=2011-06-15&Action=AssumeRoleWithWebIdentity&WebIdentityToken=abc",
+                    ))
+                    .expect("request should build"),
+            )
+            .await
+            .expect("request should complete");
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            response.headers().get(header::CONTENT_TYPE),
+            Some(&HeaderValue::from_static("application/xml"))
+        );
+        assert!(response.headers().get(header::RETRY_AFTER).is_none());
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("response body should be readable");
+        let text = String::from_utf8(body.to_vec()).expect("response should be UTF-8");
+        assert!(text.contains("<Code>ThrottlingException</Code>"));
+    }
+
+    #[tokio::test]
+    async fn sts_oversized_body_is_rejected_with_xml_before_form_extraction() {
+        let app = routes_with_admission(restrictive_admission(4))
+            .with_state(AppState::new("test-secret".to_string()));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/sts/tenant-a/rustfs-a")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::from("12345"))
+                    .expect("request should build"),
+            )
+            .await
+            .expect("request should complete");
+
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+        assert_eq!(
+            response.headers().get(header::CONTENT_TYPE),
+            Some(&HeaderValue::from_static("application/xml"))
+        );
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("response body should be readable");
+        let text = String::from_utf8(body.to_vec()).expect("response should be UTF-8");
+        assert!(text.contains("<Code>RequestEntityTooLarge</Code>"));
+    }
+
+    #[tokio::test]
+    async fn sts_extractor_rejections_are_included_in_request_metrics() {
+        let before = crate::metrics::sts_request_count(false);
+        let app = routes().with_state(AppState::new("test-secret".to_string()));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/sts/tenant-a/rustfs-a")
+                    .body(Body::from("not-a-form"))
+                    .expect("request should build"),
+            )
+            .await
+            .expect("request should complete");
+
+        assert_eq!(response.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+        assert!(crate::metrics::sts_request_count(false) > before);
+    }
+
+    #[tokio::test]
+    async fn sts_timeout_is_a_retryable_receiver_error() {
+        let response = sts_admission_rejection_response(AdmissionRejection::TimedOut);
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            response.headers().get(header::RETRY_AFTER),
+            Some(&HeaderValue::from_static("1"))
+        );
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("response body should be readable");
+        let text = String::from_utf8(body.to_vec()).expect("response should be UTF-8");
+        assert!(text.contains("<Type>Receiver</Type>"));
+        assert!(text.contains("<Code>ServiceUnavailable</Code>"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [x] Documentation
- [x] Performance Improvement
- [x] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
Closes rustfs/backlog#1088

## Summary of Changes
- Add independent, route-scoped admission controls for unauthenticated Operator STS and Console login requests.
- Bound each endpoint to configurable per-process token-bucket rate, burst, in-flight concurrency, body size, and end-to-end timeout limits.
- Preserve protocol contracts: AWS STS throttling uses `400 ThrottlingException` XML, STS timeouts use a retryable `503 ServiceUnavailable` receiver error, and Console login keeps the existing JSON error envelope.
- Return a Console `Retry-After` derived from the token refill delay instead of a fixed one-second value.
- Export fixed-cardinality total request and rejection counters, with zero-valued series initialized before traffic so first rejection bursts remain observable.
- Keep Helm upgrades compatible with reused values that predate the admission maps by omitting those env vars and using binary defaults.
- Trigger the rejection alert for isolated five-minute bursts without an additional five-minute `for` delay.

Default per-process limits are 5 requests/second, burst 10, 16 in-flight requests, 64 KiB request bodies, and a 30-second deadline.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit` (fmt-check + clippy + test + console-lint + console-fmt-check)
- [x] Added/updated necessary tests
- [x] Documentation updated (if needed)
- [x] CHANGELOG.md updated under `[Unreleased]` (if user-visible change) — N/A: this repository has no CHANGELOG.md
- [x] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (CRD/API compatibility)
- [x] Requires doc/config/deployment update
- [x] Other impact: unauthenticated Kubernetes API amplification is bounded per Operator or Console process; old reused Helm values continue to render with runtime defaults.

## Verification
```bash
cargo test rate_limit -- --nocapture
cargo test sts_extractor_rejections_are_included_in_request_metrics -- --nocapture
cargo test unauthenticated_metric -- --nocapture
cargo test --manifest-path e2e/Cargo.toml --test sts_manifest
make pre-commit
```

## Additional Notes
The limits are per process, not cluster-global, so aggregate capacity scales with replica count. All clients and tenants routed to one process share its bucket and concurrency pool; this is a load-shedding boundary, not a per-client fairness guarantee.

Total endpoint QPS is available from `rustfs_operator_unauthenticated_requests_total{endpoint,outcome}`. Admission rejections remain available from `rustfs_operator_unauthenticated_admission_rejections_total{endpoint,reason}`. Both label sets are closed and fixed-cardinality.

This change deliberately leaves the Console user-token Kubernetes client and Operator `AppState` boundary unchanged. It also does not cache TokenReview results: connection reuse and authentication caching require separate identity-preserving and revocation-aware designs. Slow TLS handshakes and incomplete HTTP headers occur before route admission; they remain a process-layer concern but cannot amplify requests to the Kubernetes API through these handlers.

AWS STS common errors document `ThrottlingException` as HTTP 400 and `ServiceUnavailable` as HTTP 503: https://docs.aws.amazon.com/STS/latest/APIReference/CommonErrors.html

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
