### PR TITLE
fix(sts): use canonical SigV4 query encoding

### DIFF
--- a/src/sts/admin_ops.rs
+++ b/src/sts/admin_ops.rs
@@ -18,7 +18,9 @@
 
 use std::collections::BTreeMap;
 
-use super::helpers::{body_mentions_not_found, build_query_pairs, extract_canned_policy_document};
+use super::helpers::{
+    body_mentions_not_found, build_canonical_query, extract_canned_policy_document,
+};
 use super::{
     ADD_CANNED_POLICY_PATH, ADD_USER_PATH, ADMIN_SIGNING_SERVICE, INFO_CANNED_POLICY_PATH,
     JSON_CONTENT_TYPE, LIST_CANNED_POLICIES_PATH, RustfsAdminClient, RustfsClientError,
@@ -37,7 +39,7 @@ impl RustfsAdminClient {
             return Err(RustfsClientError::InvalidPolicyName);
         }
 
-        let query = build_query_pairs(&[("name", policy_name)]);
+        let query = build_canonical_query(&[("name", policy_name)]);
         let path = INFO_CANNED_POLICY_PATH;
         let url = format!("{}{}", self.base_url.trim_end_matches('/'), path);
         let url = if query.is_empty() {
@@ -84,7 +86,7 @@ impl RustfsAdminClient {
         serde_json::from_str::<Value>(policy_document)
             .map_err(|_| RustfsClientError::InvalidPolicyDocument)?;
 
-        let query = build_query_pairs(&[("name", policy_name)]);
+        let query = build_canonical_query(&[("name", policy_name)]);
         let path = ADD_CANNED_POLICY_PATH;
         let url = format!("{}{}?{query}", self.base_url.trim_end_matches('/'), path);
 
@@ -158,7 +160,7 @@ impl RustfsAdminClient {
             return Err(RustfsClientError::InvalidCredentialValue { key: "accesskey" });
         }
 
-        let query = build_query_pairs(&[("accessKey", access_key)]);
+        let query = build_canonical_query(&[("accessKey", access_key)]);
         let path = USER_INFO_PATH;
         let url = format!("{}{}?{query}", self.base_url.trim_end_matches('/'), path);
         let signed = self.sign_request("GET", path, &query, "", None, ADMIN_SIGNING_SERVICE)?;
@@ -207,7 +209,7 @@ impl RustfsAdminClient {
             "status": "enabled",
         })
         .to_string();
-        let query = build_query_pairs(&[("accessKey", access_key)]);
+        let query = build_canonical_query(&[("accessKey", access_key)]);
 
         self.send_admin_request("PUT", ADD_USER_PATH, &query, &body, Some(JSON_CONTENT_TYPE))
             .await
@@ -227,7 +229,7 @@ impl RustfsAdminClient {
         }
 
         let policy_names = policies.join(",");
-        let query = build_query_pairs(&[
+        let query = build_canonical_query(&[
             ("isGroup", "false"),
             ("policyName", policy_names.as_str()),
             ("userOrGroup", access_key),

--- a/src/sts/helpers.rs
+++ b/src/sts/helpers.rs
@@ -69,7 +69,8 @@ pub(super) fn get_secret_value(
     Ok(value)
 }
 
-pub(super) fn build_query_pairs(params: &[(&str, &str)]) -> String {
+/// Encode an `application/x-www-form-urlencoded` request body.
+pub(super) fn build_form_body(params: &[(&str, &str)]) -> String {
     let mut pairs: Vec<(String, String)> = params
         .iter()
         .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
@@ -82,6 +83,37 @@ pub(super) fn build_query_pairs(params: &[(&str, &str)]) -> String {
     }
 
     serializer.finish()
+}
+
+/// Encode and sort query parameters according to the AWS SigV4 rules.
+pub(super) fn build_canonical_query(params: &[(&str, &str)]) -> String {
+    let mut pairs: Vec<(String, String)> = params
+        .iter()
+        .map(|(key, value)| (uri_encode(key), uri_encode(value)))
+        .collect();
+    pairs.sort_unstable();
+
+    pairs
+        .into_iter()
+        .map(|(key, value)| format!("{key}={value}"))
+        .collect::<Vec<_>>()
+        .join("&")
+}
+
+fn uri_encode(value: &str) -> String {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+
+    let mut encoded = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~') {
+            encoded.push(char::from(byte));
+        } else {
+            encoded.push('%');
+            encoded.push(char::from(HEX[usize::from(byte >> 4)]));
+            encoded.push(char::from(HEX[usize::from(byte & 0x0f)]));
+        }
+    }
+    encoded
 }
 
 pub(super) fn create_bucket_body(region: Option<&str>) -> String {

--- a/src/sts/pool_ops.rs
+++ b/src/sts/pool_ops.rs
@@ -15,7 +15,7 @@
 //! Pool boundary:
 //!   - list/status and decommission lifecycle operations for tenant pools.
 
-use super::helpers::build_query_pairs;
+use super::helpers::build_canonical_query;
 use super::{
     POOLS_CANCEL_PATH, POOLS_DECOMMISSION_PATH, POOLS_LIST_PATH, POOLS_STATUS_PATH,
     RustfsAdminClient, RustfsClientError, RustfsPoolListItem, RustfsPoolStatus,
@@ -37,7 +37,7 @@ impl RustfsAdminClient {
         &self,
         pool_id: &str,
     ) -> Result<RustfsPoolStatus, RustfsClientError> {
-        let query = build_query_pairs(&[("by-id", "true"), ("pool", pool_id)]);
+        let query = build_canonical_query(&[("by-id", "true"), ("pool", pool_id)]);
         let body = self
             .send_admin_request("GET", POOLS_STATUS_PATH, &query, "", None)
             .await?;
@@ -50,7 +50,7 @@ impl RustfsAdminClient {
         &self,
         pool_id: &str,
     ) -> Result<(), RustfsClientError> {
-        let query = build_query_pairs(&[("by-id", "true"), ("pool", pool_id)]);
+        let query = build_canonical_query(&[("by-id", "true"), ("pool", pool_id)]);
         self.send_admin_request("POST", POOLS_DECOMMISSION_PATH, &query, "", None)
             .await?;
         Ok(())
@@ -60,7 +60,7 @@ impl RustfsAdminClient {
         &self,
         pool_id: &str,
     ) -> Result<(), RustfsClientError> {
-        let query = build_query_pairs(&[("by-id", "true"), ("pool", pool_id)]);
+        let query = build_canonical_query(&[("by-id", "true"), ("pool", pool_id)]);
         self.send_admin_request("POST", POOLS_CANCEL_PATH, &query, "", None)
             .await?;
         Ok(())

--- a/src/sts/s3_ops.rs
+++ b/src/sts/s3_ops.rs
@@ -19,7 +19,7 @@
 use reqwest::StatusCode;
 
 use super::helpers::{
-    body_mentions_not_found, bucket_already_exists, build_query_pairs, create_bucket_body,
+    body_mentions_not_found, bucket_already_exists, build_canonical_query, create_bucket_body,
 };
 use super::{ADMIN_SIGNING_SERVICE, CreateBucketResult, RustfsAdminClient, RustfsClientError};
 
@@ -100,7 +100,7 @@ impl RustfsAdminClient {
         }
 
         let path = format!("/{bucket}");
-        let query = build_query_pairs(&[("object-lock", "")]);
+        let query = build_canonical_query(&[("object-lock", "")]);
         let signed = self.sign_request("GET", &path, &query, "", None, ADMIN_SIGNING_SERVICE)?;
         let host = self.host()?;
 

--- a/src/sts/sts_ops.rs
+++ b/src/sts/sts_ops.rs
@@ -14,7 +14,7 @@
 
 //! STS boundary:
 //!   - temporary credentials and AssumeRole request composition/response parsing.
-use super::helpers::{build_query_pairs, parse_assume_role_response};
+use super::helpers::{build_form_body, parse_assume_role_response};
 use super::{
     ASSUME_ROLE_PATH, FORM_CONTENT_TYPE, RustfsAdminClient, RustfsClientError, STS_SIGNING_SERVICE,
 };
@@ -39,7 +39,7 @@ impl RustfsAdminClient {
             params.push(("Policy", policy.to_string()));
         }
 
-        let body = build_query_pairs(
+        let body = build_form_body(
             &params
                 .iter()
                 .map(|(k, v)| (&k[..], &v[..]))

--- a/src/sts/tests.rs
+++ b/src/sts/tests.rs
@@ -30,9 +30,39 @@ use super::{
     ADD_USER_PATH, CreateBucketResult, LIST_CANNED_POLICIES_PATH, MAX_UPSTREAM_ERROR_BODY_BYTES,
     POOLS_DECOMMISSION_PATH, POOLS_LIST_PATH, POOLS_STATUS_PATH, RustfsAdminClient,
     RustfsClientError, SERVER_INFO_PATH, SET_POLICY_PATH, USER_INFO_PATH,
-    helpers::{extract_canned_policy_document, extract_credentials, parse_assume_role_response},
+    helpers::{
+        build_canonical_query, build_form_body, extract_canned_policy_document,
+        extract_credentials, parse_assume_role_response,
+    },
     tls_tenant_base_url,
 };
+
+#[test]
+fn canonical_query_uses_sigv4_uri_encoding_and_encoded_sort_order() {
+    let query = build_canonical_query(&[
+        ("z", "a b~c/雪"),
+        ("a~", "second"),
+        ("a ", "first"),
+        ("amp", "&="),
+        ("dup", "z"),
+        ("dup", "a"),
+        ("empty", ""),
+        ("雪", "key"),
+    ]);
+
+    assert_eq!(
+        query,
+        "%E9%9B%AA=key&a%20=first&amp=%26%3D&a~=second&dup=a&dup=z&empty=&z=a%20b~c%2F%E9%9B%AA"
+    );
+}
+
+#[test]
+fn form_body_keeps_html_form_encoding() {
+    assert_eq!(
+        build_form_body(&[("Policy", "a b~c/雪")]),
+        "Policy=a+b%7Ec%2F%E9%9B%AA"
+    );
+}
 
 fn secret_with_fields(fields: Vec<(&str, &[u8])>) -> corev1::Secret {
     let mut data = BTreeMap::new();
@@ -802,10 +832,13 @@ async fn add_user_uses_expected_path_query_and_body() {
     let server = tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
 
     let client = RustfsAdminClient::new_with_base_url(format!("http://{addr}"), "access", "secret");
-    client.add_user("app-user", "secret123").await.unwrap();
+    client.add_user("app user~+/雪", "secret123").await.unwrap();
 
     assert_eq!(&*capture.path.lock().await, ADD_USER_PATH);
-    assert_eq!(&*capture.query.lock().await, "accessKey=app-user");
+    assert_eq!(
+        &*capture.query.lock().await,
+        "accessKey=app%20user~%2B%2F%E9%9B%AA"
+    );
     assert_eq!(
         &*capture.body.lock().await,
         r#"{"secretKey":"secret123","status":"enabled"}"#

--- a/src/sts/tests.rs
+++ b/src/sts/tests.rs
@@ -27,15 +27,20 @@ use std::{collections::BTreeMap, sync::Arc};
 use tokio::sync::Mutex;
 
 use super::{
-    ADD_USER_PATH, CreateBucketResult, LIST_CANNED_POLICIES_PATH, MAX_UPSTREAM_ERROR_BODY_BYTES,
-    POOLS_DECOMMISSION_PATH, POOLS_LIST_PATH, POOLS_STATUS_PATH, RustfsAdminClient,
-    RustfsClientError, SERVER_INFO_PATH, SET_POLICY_PATH, USER_INFO_PATH,
+    ADD_USER_PATH, ADMIN_SIGNING_SERVICE, CreateBucketResult, FORM_CONTENT_TYPE, JSON_CONTENT_TYPE,
+    LIST_CANNED_POLICIES_PATH, MAX_UPSTREAM_ERROR_BODY_BYTES, POOLS_DECOMMISSION_PATH,
+    POOLS_LIST_PATH, POOLS_STATUS_PATH, RustfsAdminClient, RustfsClientError, SERVER_INFO_PATH,
+    SET_POLICY_PATH, STS_SIGNING_SERVICE, USER_INFO_PATH,
     helpers::{
-        build_canonical_query, build_form_body, extract_canned_policy_document,
-        extract_credentials, parse_assume_role_response,
+        build_canonical_query, build_form_body, derive_signing_key, extract_canned_policy_document,
+        extract_credentials, hmac_sha256_hex, parse_assume_role_response, sha256_hex,
     },
     tls_tenant_base_url,
 };
+
+const TEST_ACCESS_KEY: &str = "access";
+const TEST_SECRET_KEY: &str = "secret";
+const TEST_REGION: &str = "us-east-1";
 
 #[test]
 fn canonical_query_uses_sigv4_uri_encoding_and_encoded_sort_order() {
@@ -62,6 +67,35 @@ fn form_body_keeps_html_form_encoding() {
         build_form_body(&[("Policy", "a b~c/雪")]),
         "Policy=a+b%7Ec%2F%E9%9B%AA"
     );
+}
+
+#[test]
+fn duplicate_query_values_match_independent_sigv4_verification() {
+    let query =
+        build_canonical_query(&[("dup", "z z"), ("dup", "a+a"), ("dup", "雪"), ("empty", "")]);
+    assert_eq!(query, "dup=%E9%9B%AA&dup=a%2Ba&dup=z%20z&empty=");
+
+    let client = RustfsAdminClient::new_with_base_url(
+        "https://rustfs.example.test:9000",
+        TEST_ACCESS_KEY,
+        TEST_SECRET_KEY,
+    );
+    let signed = client
+        .sign_request("GET", "/synthetic", &query, "", None, ADMIN_SIGNING_SERVICE)
+        .unwrap();
+    let request = CapturedRequest {
+        method: "GET".to_string(),
+        path: "/synthetic".to_string(),
+        query,
+        body: String::new(),
+        host: "rustfs.example.test:9000".to_string(),
+        content_type: String::new(),
+        amz_date: signed.amz_date,
+        payload_hash: signed.payload_hash,
+        authorization: signed.authorization,
+    };
+
+    assert_sigv4_matches_wire(&request, ADMIN_SIGNING_SERVICE);
 }
 
 fn secret_with_fields(fields: Vec<(&str, &[u8])>) -> corev1::Secret {
@@ -293,11 +327,131 @@ async fn unexpected_response_hides_over_limit_unstructured_response_body() {
 
 #[derive(Clone, Default)]
 struct Capture {
+    method: Arc<Mutex<String>>,
     path: Arc<Mutex<String>>,
     query: Arc<Mutex<String>>,
     body: Arc<Mutex<String>>,
+    host: Arc<Mutex<String>>,
+    content_type: Arc<Mutex<String>>,
+    amz_date: Arc<Mutex<String>>,
+    payload_hash: Arc<Mutex<String>>,
     authorization: Arc<Mutex<String>>,
     object_lock_header: Arc<Mutex<String>>,
+}
+
+#[derive(Debug)]
+struct CapturedRequest {
+    method: String,
+    path: String,
+    query: String,
+    body: String,
+    host: String,
+    content_type: String,
+    amz_date: String,
+    payload_hash: String,
+    authorization: String,
+}
+
+impl Capture {
+    async fn request(&self) -> CapturedRequest {
+        CapturedRequest {
+            method: self.method.lock().await.clone(),
+            path: self.path.lock().await.clone(),
+            query: self.query.lock().await.clone(),
+            body: self.body.lock().await.clone(),
+            host: self.host.lock().await.clone(),
+            content_type: self.content_type.lock().await.clone(),
+            amz_date: self.amz_date.lock().await.clone(),
+            payload_hash: self.payload_hash.lock().await.clone(),
+            authorization: self.authorization.lock().await.clone(),
+        }
+    }
+}
+
+fn request_header(req: &Request<Body>, name: &str) -> String {
+    req.headers()
+        .get(name)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("")
+        .to_string()
+}
+
+async fn capture_signed_request(capture: &Capture, req: Request<Body>) {
+    let method = req.method().as_str().to_string();
+    let path = req.uri().path().to_string();
+    let query = req.uri().query().unwrap_or("").to_string();
+    let host = request_header(&req, "host");
+    let content_type = request_header(&req, "content-type");
+    let amz_date = request_header(&req, "x-amz-date");
+    let payload_hash = request_header(&req, "x-amz-content-sha256");
+    let authorization = request_header(&req, "authorization");
+    let body = axum::body::to_bytes(req.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body = String::from_utf8(body.to_vec()).unwrap();
+
+    *capture.method.lock().await = method;
+    *capture.path.lock().await = path;
+    *capture.query.lock().await = query;
+    *capture.body.lock().await = body;
+    *capture.host.lock().await = host;
+    *capture.content_type.lock().await = content_type;
+    *capture.amz_date.lock().await = amz_date;
+    *capture.payload_hash.lock().await = payload_hash;
+    *capture.authorization.lock().await = authorization;
+}
+
+fn assert_sigv4_matches_wire(request: &CapturedRequest, service: &str) {
+    let calculated_payload_hash = sha256_hex(request.body.as_bytes());
+    assert_eq!(request.payload_hash, calculated_payload_hash);
+
+    let signed_header_names = if request.content_type.is_empty() {
+        "host;x-amz-content-sha256;x-amz-date"
+    } else {
+        "content-type;host;x-amz-content-sha256;x-amz-date"
+    };
+    let mut canonical_headers = String::new();
+    if !request.content_type.is_empty() {
+        canonical_headers.push_str("content-type:");
+        canonical_headers.push_str(request.content_type.trim());
+        canonical_headers.push('\n');
+    }
+    canonical_headers.push_str("host:");
+    canonical_headers.push_str(request.host.trim());
+    canonical_headers.push_str("\nx-amz-content-sha256:");
+    canonical_headers.push_str(request.payload_hash.trim());
+    canonical_headers.push_str("\nx-amz-date:");
+    canonical_headers.push_str(request.amz_date.trim());
+    canonical_headers.push('\n');
+
+    let canonical_request = format!(
+        "{}\n{}\n{}\n{}\n{}\n{}",
+        request.method,
+        request.path,
+        request.query,
+        canonical_headers,
+        signed_header_names,
+        request.payload_hash
+    );
+    let date_stamp = request
+        .amz_date
+        .get(..8)
+        .expect("x-amz-date must start with YYYYMMDD");
+    let credential_scope = format!("{date_stamp}/{TEST_REGION}/{service}/aws4_request");
+    let string_to_sign = format!(
+        "AWS4-HMAC-SHA256\n{}\n{}\n{}",
+        request.amz_date,
+        credential_scope,
+        sha256_hex(canonical_request.as_bytes())
+    );
+    let signing_key =
+        derive_signing_key(TEST_SECRET_KEY, date_stamp, TEST_REGION, service).unwrap();
+    let signature = hmac_sha256_hex(&signing_key, &string_to_sign).unwrap();
+    let expected_authorization = format!(
+        "AWS4-HMAC-SHA256 Credential={TEST_ACCESS_KEY}/{credential_scope}, SignedHeaders={signed_header_names}, Signature={signature}"
+    );
+
+    assert_eq!(request.authorization, expected_authorization);
 }
 
 #[tokio::test]
@@ -309,23 +463,7 @@ async fn assume_role_request_targets_root_path_and_action_is_assume_role() {
             "/",
             post(
                 move |State(c): State<Capture>, req: Request<Body>| async move {
-                    let path = req.uri().path().to_string();
-                    let query = req.uri().query().unwrap_or("").to_string();
-                    let authorization = req
-                        .headers()
-                        .get("authorization")
-                        .and_then(|value| value.to_str().ok())
-                        .unwrap_or("")
-                        .to_string();
-                    let body_bytes = axum::body::to_bytes(req.into_body(), usize::MAX)
-                        .await
-                        .unwrap();
-                    let body = String::from_utf8(body_bytes.to_vec()).unwrap();
-
-                    *c.path.lock().await = path;
-                    *c.query.lock().await = query;
-                    *c.body.lock().await = body;
-                    *c.authorization.lock().await = authorization;
+                    capture_signed_request(&c, req).await;
 
                     let response =
                         "<AssumeRoleResponse><AssumeRoleResult><Credentials><AccessKeyId>AKI</AccessKeyId><SecretAccessKey>SEC</SecretAccessKey><SessionToken>TOKEN</SessionToken><Expiration>2026-01-01T00:00:00Z</Expiration></Credentials></AssumeRoleResult></AssumeRoleResponse>";
@@ -344,23 +482,20 @@ async fn assume_role_request_targets_root_path_and_action_is_assume_role() {
     let client = RustfsAdminClient::new_with_base_url(format!("http://{addr}"), "access", "secret");
 
     let creds = client
-        .assume_role(Some("{\"Statement\": []}"), 3600)
+        .assume_role(Some(r#"{"Statement":[{"Resource":"a b~+/雪"}]}"#), 3600)
         .await
         .unwrap();
     assert_eq!(creds.access_key_id, "AKI");
 
-    assert_eq!(&*capture.path.lock().await, "/");
-    assert!(capture.body.lock().await.contains("Action=AssumeRole"));
-    assert!(capture.body.lock().await.contains("Version=2011-06-15"));
-    assert!(capture.body.lock().await.contains("DurationSeconds=3600"));
-    assert!(capture.query.lock().await.is_empty());
-    assert!(
-        capture
-            .authorization
-            .lock()
-            .await
-            .contains("/sts/aws4_request")
+    let request = capture.request().await;
+    assert_eq!(request.path, "/");
+    assert_eq!(
+        request.body,
+        "Action=AssumeRole&DurationSeconds=3600&Policy=%7B%22Statement%22%3A%5B%7B%22Resource%22%3A%22a+b%7E%2B%2F%E9%9B%AA%22%7D%5D%7D&Version=2011-06-15"
     );
+    assert!(request.query.is_empty());
+    assert_eq!(request.content_type, FORM_CONTENT_TYPE);
+    assert_sigv4_matches_wire(&request, STS_SIGNING_SERVICE);
 
     server.abort();
 }
@@ -813,12 +948,7 @@ async fn add_user_uses_expected_path_query_and_body() {
             ADD_USER_PATH,
             put(
                 move |State(c): State<Capture>, req: Request<Body>| async move {
-                    *c.path.lock().await = req.uri().path().to_string();
-                    *c.query.lock().await = req.uri().query().unwrap_or("").to_string();
-                    let body_bytes = axum::body::to_bytes(req.into_body(), usize::MAX)
-                        .await
-                        .unwrap();
-                    *c.body.lock().await = String::from_utf8(body_bytes.to_vec()).unwrap();
+                    capture_signed_request(&c, req).await;
                     StatusCode::OK
                 },
             ),
@@ -834,15 +964,15 @@ async fn add_user_uses_expected_path_query_and_body() {
     let client = RustfsAdminClient::new_with_base_url(format!("http://{addr}"), "access", "secret");
     client.add_user("app user~+/雪", "secret123").await.unwrap();
 
-    assert_eq!(&*capture.path.lock().await, ADD_USER_PATH);
+    let request = capture.request().await;
+    assert_eq!(request.path, ADD_USER_PATH);
+    assert_eq!(request.query, "accessKey=app%20user~%2B%2F%E9%9B%AA");
     assert_eq!(
-        &*capture.query.lock().await,
-        "accessKey=app%20user~%2B%2F%E9%9B%AA"
-    );
-    assert_eq!(
-        &*capture.body.lock().await,
+        request.body,
         r#"{"secretKey":"secret123","status":"enabled"}"#
     );
+    assert_eq!(request.content_type, JSON_CONTENT_TYPE);
+    assert_sigv4_matches_wire(&request, ADMIN_SIGNING_SERVICE);
 
     server.abort();
 }


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [x] Test/CI
- [ ] Refactor
- [ ] Other: N/A

## Related Issues
Closes rustfs/backlog#1089

## Summary of Changes
- Separate STS form-body encoding from signed URL query encoding.
- Encode SigV4 query keys and values by UTF-8 byte using the AWS unreserved set and uppercase percent escapes.
- Sort encoded key/value pairs and use the same canonical query on the request wire.
- Independently reconstruct SigV4 from captured wire requests so tests do not reuse the production canonical-request builder.
- Cover spaces, tildes, plus signs, slashes, Unicode, empty values, duplicate parameters, and encoded sort order.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit` (fmt-check + clippy + test + console-lint + console-fmt-check)
- [x] Added/updated necessary tests
- [x] Documentation updated (if needed) — N/A; no public API change
- [ ] CHANGELOG.md updated under `[Unreleased]` (if user-visible change)
- [x] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (CRD/API compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact: Signed admin, pool, and S3 query parameters now follow AWS SigV4 URI encoding.

## Verification
```bash
make pre-commit
```

## Additional Notes
The RustFS verifier consumes the raw query and only normalizes `+` to `%20`. Sending strict `%20`, literal `~`, uppercase percent escapes, and signing the same raw query remains compatible while removing the previous space-signature mismatch.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
