### PR TITLE
fix(rbac): allow tenant finalizer updates

### DIFF
--- a/deploy/k8s-dev/operator-rbac.yaml
+++ b/deploy/k8s-dev/operator-rbac.yaml
@@ -18,6 +18,11 @@ rules:
   - apiGroups: ["rustfs.com"]
     resources: ["tenants/status"]
     verbs: ["update", "patch"]
+  # Required when deleting dependents whose ownerReference uses
+  # blockOwnerDeletion=true.
+  - apiGroups: ["rustfs.com"]
+    resources: ["tenants/finalizers"]
+    verbs: ["update"]
   - apiGroups: [""]
     resources: ["configmaps", "secrets"]
     verbs: ["get", "list", "watch"]

--- a/deploy/rustfs-operator/templates/clusterrole.yaml
+++ b/deploy/rustfs-operator/templates/clusterrole.yaml
@@ -13,6 +13,11 @@ rules:
   - apiGroups: ["rustfs.com"]
     resources: ["tenants/status"]
     verbs: ["update", "patch"]
+  # Required when deleting dependents whose ownerReference uses
+  # blockOwnerDeletion=true.
+  - apiGroups: ["rustfs.com"]
+    resources: ["tenants/finalizers"]
+    verbs: ["update"]
 
   # Referenced Secrets and ConfigMaps are watched cluster-wide but never mutated.
   - apiGroups: [""]

--- a/e2e/tests/finalizer_rbac_manifest.rs
+++ b/e2e/tests/finalizer_rbac_manifest.rs
@@ -1,0 +1,114 @@
+// Copyright 2025 RustFS Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use serde_yaml_ng::Value;
+use std::{collections::BTreeSet, path::PathBuf, process::Command};
+
+#[test]
+fn operator_rbac_can_update_tenant_finalizers() {
+    let root = repository_root();
+    let dev_rbac = std::fs::read_to_string(root.join("deploy/k8s-dev/operator-rbac.yaml"))
+        .expect("k8s-dev operator RBAC exists");
+    let dev_documents = yaml_documents(&dev_rbac, "k8s-dev operator RBAC");
+    assert_finalizer_update_rule(&dev_documents, "rustfs-operator");
+
+    let Some(rendered) = helm_template() else {
+        return;
+    };
+    assert!(
+        rendered.status.success(),
+        "default chart render failed: {}",
+        String::from_utf8_lossy(&rendered.stderr)
+    );
+    let output = String::from_utf8(rendered.stdout).expect("helm output is UTF-8");
+    assert_finalizer_update_rule(&yaml_documents(&output, "default chart"), "rustfs-operator");
+}
+
+fn repository_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("e2e crate has a repository parent")
+        .to_path_buf()
+}
+
+fn helm_template() -> Option<std::process::Output> {
+    if Command::new("helm").arg("version").output().is_err() {
+        assert!(
+            std::env::var_os("CI").is_none(),
+            "helm must be installed in CI"
+        );
+        eprintln!("skipping helm template assertions: helm is not installed");
+        return None;
+    }
+
+    Some(
+        Command::new("helm")
+            .arg("template")
+            .arg("rustfs-operator")
+            .arg(repository_root().join("deploy/rustfs-operator"))
+            .output()
+            .expect("helm template runs"),
+    )
+}
+
+fn yaml_documents(input: &str, description: &str) -> Vec<Value> {
+    input
+        .split("---")
+        .filter(|document| !document.trim().is_empty())
+        .map(|document| {
+            serde_yaml_ng::from_str(document)
+                .unwrap_or_else(|error| panic!("{description} contains invalid YAML: {error}"))
+        })
+        .collect()
+}
+
+fn assert_finalizer_update_rule(documents: &[Value], name: &str) {
+    let cluster_role = documents
+        .iter()
+        .find(|document| {
+            document["kind"].as_str() == Some("ClusterRole")
+                && document["metadata"]["name"].as_str() == Some(name)
+        })
+        .unwrap_or_else(|| panic!("missing ClusterRole {name}"));
+    let rules = cluster_role["rules"]
+        .as_sequence()
+        .expect("ClusterRole rules are a sequence");
+    let matching = rules
+        .iter()
+        .filter(|rule| yaml_strings(&rule["resources"]).contains("tenants/finalizers"))
+        .collect::<Vec<_>>();
+
+    assert_eq!(matching.len(), 1, "expected one Tenant finalizer rule");
+    assert_eq!(
+        yaml_strings(&matching[0]["apiGroups"]),
+        BTreeSet::from(["rustfs.com"])
+    );
+    assert_eq!(
+        yaml_strings(&matching[0]["resources"]),
+        BTreeSet::from(["tenants/finalizers"])
+    );
+    assert_eq!(
+        yaml_strings(&matching[0]["verbs"]),
+        BTreeSet::from(["update"])
+    );
+}
+
+fn yaml_strings(value: &Value) -> BTreeSet<&str> {
+    value
+        .as_sequence()
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .collect()
+}


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [x] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
Part of #206.

## Summary of Changes
- grant the Operator the `update` verb on the `tenants/finalizers` subresource
- keep the finalizer permission isolated from normal Tenant resource verbs
- cover both the Helm ClusterRole and the development RBAC manifest with an exact contract test

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit` (fmt-check + clippy + test + console-lint + console-fmt-check)
- [x] Added/updated necessary tests
- [x] Documentation updated (if needed) — N/A; the manifest change is self-contained
- [x] CHANGELOG.md updated under `[Unreleased]` (if user-visible change) — N/A; this repository does not currently contain `CHANGELOG.md`
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (CRD/API compatibility)
- [x] Requires doc/config/deployment update
- [x] Other impact: additive RBAC repair only; no workload rollout

### Update impact
- Helm-managed installations update the ClusterRole in place. No CRD, Tenant, StatefulSet, Pod, Service, or PVC is rewritten or rolled by this PR.
- Reconciles that previously failed while adding or removing the Tenant finalizer can proceed after the RBAC update.
- Installations with `rbac.create=false` must add `update` on `rustfs.com` `tenants/finalizers` to their externally managed ClusterRole before upgrading the Operator.
- Rollback removes the permission and can reintroduce forbidden finalizer updates; it does not roll Tenant workloads by itself.

## Verification
```bash
make pre-commit
cargo test --manifest-path e2e/Cargo.toml --test finalizer_rbac_manifest
```

## Additional Notes
This PR is intentionally independent from the security-context and OpenShift delivery changes for #206 and can be reviewed and released separately.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
