### PR TITLE
fix(console): prevent pool volume count overflow

### DIFF
--- a/src/console/handlers/pools.rs
+++ b/src/console/handlers/pools.rs
@@ -511,7 +511,10 @@ pub async fn list_pools(
             name: pool.name.clone(),
             servers: pool.servers,
             volumes_per_server: pool.persistence.volumes_per_server,
-            total_volumes: pool.servers * pool.persistence.volumes_per_server,
+            total_volumes: PoolDetails::total_volumes(
+                pool.servers,
+                pool.persistence.volumes_per_server,
+            ),
             storage_class,
             volume_size,
             replicas,
@@ -575,7 +578,7 @@ pub async fn add_pool(
             ),
         });
     }
-    let total_volumes = req.servers.saturating_mul(req.volumes_per_server);
+    let total_volumes = PoolDetails::total_volumes(req.servers, req.volumes_per_server);
 
     // Build Pool spec
     let new_pool = Pool {

--- a/src/console/models/pool.rs
+++ b/src/console/models/pool.rs
@@ -21,7 +21,7 @@ pub struct PoolDetails {
     pub name: String,
     pub servers: i32,
     pub volumes_per_server: i32,
-    pub total_volumes: i32,
+    pub total_volumes: i64,
     pub storage_class: Option<String>,
     pub volume_size: Option<String>,
     pub replicas: i32,
@@ -41,6 +41,17 @@ pub struct PoolDetails {
     pub decommission_last_error: Option<String>,
     pub decommission_last_poll_time: Option<String>,
     pub created_at: Option<String>,
+}
+
+impl PoolDetails {
+    /// Return the exact volume count derived from the CRD's `i32` pool dimensions.
+    ///
+    /// Widening both operands before multiplication is lossless because every `i32 * i32`
+    /// product fits in an `i64`. This preserves the real count instead of rejecting or clamping a
+    /// valid CRD value.
+    pub(crate) fn total_volumes(servers: i32, volumes_per_server: i32) -> i64 {
+        i64::from(servers) * i64::from(volumes_per_server)
+    }
 }
 
 /// Response listing pools for a tenant
@@ -119,4 +130,18 @@ pub struct PoolDecommissionRequestResponse {
     pub pool_name: String,
     pub request_id: String,
     pub action: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PoolDetails;
+
+    #[test]
+    fn total_volumes_widens_before_multiplication() {
+        assert_eq!(PoolDetails::total_volumes(i32::MAX, 2), 4_294_967_294);
+        assert_eq!(
+            PoolDetails::total_volumes(i32::MAX, i32::MAX),
+            4_611_686_014_132_420_609
+        );
+    }
 }

--- a/src/console/openapi.rs
+++ b/src/console/openapi.rs
@@ -737,6 +737,23 @@ mod tests {
     }
 
     #[test]
+    fn pool_total_volumes_documents_widened_integer() {
+        let spec = serde_json::to_value(ApiDoc::openapi()).expect("OpenAPI spec serializes");
+        let total_volumes = spec
+            .pointer("/components/schemas/PoolDetails/properties/total_volumes")
+            .expect("PoolDetails.total_volumes schema exists");
+
+        assert_eq!(
+            total_volumes.get("type").and_then(Value::as_str),
+            Some("integer")
+        );
+        assert_eq!(
+            total_volumes.get("format").and_then(Value::as_str),
+            Some("int64")
+        );
+    }
+
+    #[test]
     fn tenant_api_documents_provisioning_fields() {
         let spec = serde_json::to_value(ApiDoc::openapi()).expect("OpenAPI spec serializes");
         let schemas = spec


### PR DESCRIPTION
## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues

Fixes rustfs/backlog#1095

## Summary of Changes

- widen `PoolDetails.total_volumes` to `i64`
- widen both pool dimensions before multiplication so the result cannot overflow
- reuse the same derivation in list and add-pool response paths
- document the widened OpenAPI contract and add overflow regression coverage

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit` (fmt-check + clippy + test + console-lint + console-fmt-check)
- [x] Added/updated necessary tests
- Documentation: N/A; the generated OpenAPI contract is covered by a schema test
- CHANGELOG: N/A; this is a focused correctness fix
- [ ] CI/CD passed (pending GitHub Actions)

## Impact

- [ ] Breaking change (CRD/API compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact: OpenAPI widens `total_volumes` from `int32` to `int64`; the JSON field remains numeric

## Verification

```bash
make pre-commit
```

## Additional Notes

Every `i32 * i32` result fits exactly in `i64`, so widening preserves the real volume count without clamping. Values above JavaScript's safe-integer range remain a theoretical client-side limitation; changing the field to a string would break the existing Console contract and is outside this fix.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.