### PR TITLE
fix(console): enforce protected API routing

### DIFF
--- a/src/console/handlers/auth.rs
+++ b/src/console/handlers/auth.rs
@@ -342,11 +342,16 @@ mod tests {
         let state = AppState::new("test-secret".to_string());
         let session_id = state.create_session("k8s-token".to_string())?;
         let cookie = format!("session={session_id}");
+        let protected = Router::new()
+            .route("/api/v1/protected", get(|| async { "ok" }))
+            .route_layer(middleware::from_fn_with_state(
+                state.clone(),
+                auth_middleware,
+            ));
         let app = Router::new()
             .route("/api/v1/logout", post(logout))
-            .route("/api/v1/protected", get(|| async { "ok" }))
-            .with_state(state.clone())
-            .layer(middleware::from_fn_with_state(state, auth_middleware));
+            .merge(protected)
+            .with_state(state);
 
         let logout_response = app
             .clone()

--- a/src/console/middleware/auth.rs
+++ b/src/console/middleware/auth.rs
@@ -34,20 +34,6 @@ pub async fn auth_middleware(
     if request.method() == Method::OPTIONS {
         return Ok(next.run(request).await);
     }
-    // Unauthenticated paths
-    let path = request.uri().path();
-    if path == "/healthz"
-        || path == "/readyz"
-        || path == "/metrics"
-        || path.starts_with("/api/v1/login")
-        || path.starts_with("/api/v1/logout")
-        || path.starts_with("/swagger-ui")
-        || path.starts_with("/api-docs")
-        || !path.starts_with("/api/v1")
-    {
-        return Ok(next.run(request).await);
-    }
-
     // Parse session cookie
     let cookies = request
         .headers()
@@ -124,18 +110,23 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn static_paths_do_not_require_session() -> Result<(), Box<dyn std::error::Error>> {
+    async fn options_requests_bypass_authentication() -> Result<(), Box<dyn std::error::Error>> {
         let state = AppState::new("test-secret".to_string());
         let app = Router::new()
-            .route("/", get(|| async { "ui" }))
+            .route("/protected", get(|| async { "ok" }))
             .with_state(state.clone())
             .layer(middleware::from_fn_with_state(state, auth_middleware));
 
         let response = app
-            .oneshot(Request::builder().uri("/").body(Body::empty())?)
+            .oneshot(
+                Request::builder()
+                    .method(Method::OPTIONS)
+                    .uri("/protected")
+                    .body(Body::empty())?,
+            )
             .await?;
 
-        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
         Ok(())
     }
 }

--- a/src/console/middleware/auth.rs
+++ b/src/console/middleware/auth.rs
@@ -29,10 +29,10 @@ pub async fn auth_middleware(
     State(state): State<AppState>,
     mut request: Request,
     next: Next,
-) -> Result<Response, Response> {
+) -> Response {
     // Allow CORS preflight without 401 (browser would treat as CORS failure)
     if request.method() == Method::OPTIONS {
-        return Ok(next.run(request).await);
+        return next.run(request).await;
     }
     // Parse session cookie
     let cookies = request
@@ -41,18 +41,20 @@ pub async fn auth_middleware(
         .and_then(|v| v.to_str().ok())
         .unwrap_or("");
 
-    let token = session_cookie_value(cookies)
-        .ok_or_else(|| unauthorized_response("Missing or invalid session"))?;
+    let Some(token) = session_cookie_value(cookies) else {
+        return unauthorized_response("Missing or invalid session");
+    };
 
-    let claims = state
-        .resolve_session(token)
-        .map_err(|source| Error::Session { source }.into_response())?
-        .ok_or_else(|| unauthorized_response("Missing or invalid session"))?;
+    let claims = match state.resolve_session(token) {
+        Ok(Some(claims)) => claims,
+        Ok(None) => return unauthorized_response("Missing or invalid session"),
+        Err(source) => return Error::Session { source }.into_response(),
+    };
 
     // Stash claims for handlers
     request.extensions_mut().insert(claims);
 
-    Ok(next.run(request).await)
+    next.run(request).await
 }
 
 fn unauthorized_response(message: &str) -> Response {

--- a/src/console/routes/mod.rs
+++ b/src/console/routes/mod.rs
@@ -29,16 +29,22 @@ use crate::{
 
 /// Login / session routes (partially unauthenticated)
 pub fn auth_routes() -> Router<AppState> {
-    auth_routes_with_config(AdmissionConfig::for_endpoint(
+    public_auth_routes_with_config(AdmissionConfig::for_endpoint(
         AdmissionEndpoint::ConsoleLogin,
     ))
+    .merge(session_routes())
 }
 
-pub(crate) fn auth_routes_with_config(config: AdmissionConfig) -> Router<AppState> {
-    auth_routes_with_admission(AdmissionControl::new(config))
+pub(crate) fn public_auth_routes_with_config(config: AdmissionConfig) -> Router<AppState> {
+    public_auth_routes_with_admission(AdmissionControl::new(config))
 }
 
+#[cfg(test)]
 fn auth_routes_with_admission(admission: AdmissionControl) -> Router<AppState> {
+    public_auth_routes_with_admission(admission).merge(session_routes())
+}
+
+fn public_auth_routes_with_admission(admission: AdmissionControl) -> Router<AppState> {
     let login = Router::new().route(
         "/login",
         post(handlers::auth::login).route_layer(middleware::from_fn_with_state(
@@ -49,7 +55,10 @@ fn auth_routes_with_admission(admission: AdmissionControl) -> Router<AppState> {
     Router::new()
         .merge(login)
         .route("/logout", post(handlers::auth::logout))
-        .route("/session", get(handlers::auth::session_check))
+}
+
+pub(crate) fn session_routes() -> Router<AppState> {
+    Router::new().route("/session", get(handlers::auth::session_check))
 }
 
 async fn enforce_login_admission(

--- a/src/console/server.rs
+++ b/src/console/server.rs
@@ -102,15 +102,11 @@ pub async fn run(port: u16) -> Result<(), Box<dyn std::error::Error>> {
         // OpenAPI / Swagger (unauthenticated)
         .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", ApiDoc::openapi()))
         // REST API v1
-        .nest("/api/v1", api_routes(login_admission_config))
+        .nest("/api/v1", api_routes(login_admission_config, state.clone()))
         // Shared state
         .with_state(state.clone());
     let app = with_static_frontend(app)
-        // Middleware runs in reverse order: Trace -> Compression -> Cors -> auth
-        .layer(middleware::from_fn_with_state(
-            state.clone(),
-            crate::console::middleware::auth::auth_middleware,
-        ))
+        // Middleware runs in reverse order: Trace -> Compression -> Cors
         .layer(
             CorsLayer::new()
                 .allow_origin(cors_origins)
@@ -144,15 +140,25 @@ pub async fn run(port: u16) -> Result<(), Box<dyn std::error::Error>> {
 }
 
 /// Merge all `/api/v1` route trees.
-fn api_routes(login_admission_config: AdmissionConfig) -> Router<AppState> {
-    Router::new()
-        .merge(routes::auth_routes_with_config(login_admission_config))
+fn api_routes(login_admission_config: AdmissionConfig, state: AppState) -> Router<AppState> {
+    let protected = Router::new()
+        .merge(routes::session_routes())
         .merge(routes::tenant_routes())
         .merge(routes::pool_routes())
         .merge(routes::pod_routes())
         .merge(routes::event_routes())
         .merge(routes::cluster_routes())
         .merge(routes::topology_routes())
+        .route_layer(middleware::from_fn_with_state(
+            state,
+            crate::console::middleware::auth::auth_middleware,
+        ));
+
+    Router::new()
+        .merge(routes::public_auth_routes_with_config(
+            login_admission_config,
+        ))
+        .merge(protected)
 }
 
 fn with_static_frontend(app: Router) -> Router {
@@ -318,6 +324,29 @@ mod tests {
         assert_eq!(first.len(), 64);
         assert!(first.bytes().all(|byte| byte.is_ascii_hexdigit()));
         assert_ne!(first, second);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn api_router_only_exposes_explicit_public_auth_routes()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let state = AppState::new("test-secret".to_string());
+        let app = api_routes(
+            AdmissionConfig::for_endpoint(AdmissionEndpoint::ConsoleLogin),
+            state.clone(),
+        )
+        .with_state(state);
+
+        let protected = app
+            .clone()
+            .oneshot(Request::get("/session").body(Body::empty())?)
+            .await?;
+        assert_eq!(protected.status(), StatusCode::UNAUTHORIZED);
+
+        let public = app
+            .oneshot(Request::post("/logout").body(Body::empty())?)
+            .await?;
+        assert_eq!(public.status(), StatusCode::OK);
         Ok(())
     }
 

--- a/src/reconcile/pool_lifecycle.rs
+++ b/src/reconcile/pool_lifecycle.rs
@@ -224,7 +224,7 @@ async fn reconcile_single_pool_lifecycle(
         .await
         {
             Ok(status) => status,
-            Err(decision) => return decision,
+            Err(decision) => return *decision,
         };
 
         return cleanup_decommissioned_pool(ctx, tenant, namespace, pool, status).await;
@@ -570,69 +570,69 @@ async fn verify_decommissioned_pool_for_cleanup(
     pool: &Pool,
     existing: &PoolDecommissionStatus,
     cluster_domain: &str,
-) -> Result<PoolDecommissionStatus, PoolLifecycleDecision> {
+) -> Result<PoolDecommissionStatus, Box<PoolLifecycleDecision>> {
     let matched_pool = match find_rustfs_pool(client, tenant, namespace, pool, cluster_domain).await
     {
         Ok(matched_pool) => matched_pool,
         Err(error) if error.is_retriable() => {
-            return Err(cleanup_retriable_decision(
+            return Err(Box::new(cleanup_retriable_decision(
                 existing.clone(),
                 error.reason(),
                 error.message(),
-            ));
+            )));
         }
         Err(error) => {
-            return Err(failed_decision(
+            return Err(Box::new(failed_decision(
                 existing.request_id.clone(),
                 error.reason(),
                 error.message(),
-            ));
+            )));
         }
     };
     let pool_id = matched_pool.item.id.to_string();
 
     let Some(existing_pool_id) = existing.rustfs_pool_id.as_deref() else {
-        return Err(failed_decision(
+        return Err(Box::new(failed_decision(
             existing.request_id.clone(),
             "RustfsPoolIdentityMissing",
             "recorded decommission status is missing rustfsPoolID; refusing cleanup",
-        ));
+        )));
     };
     if existing_pool_id != pool_id {
         let message = format!(
             "recorded RustFS pool id '{}' no longer matches observed pool id '{}'",
             existing_pool_id, pool_id
         );
-        return Err(failed_decision(
+        return Err(Box::new(failed_decision(
             existing.request_id.clone(),
             "RustfsPoolIdentityMismatch",
             &message,
-        ));
+        )));
     }
 
     let Some(existing_hash) = existing.endpoint_set_hash.as_deref() else {
-        return Err(failed_decision(
+        return Err(Box::new(failed_decision(
             existing.request_id.clone(),
             "RustfsPoolIdentityMissing",
             "recorded decommission status is missing endpointSetHash; refusing cleanup",
-        ));
+        )));
     };
     if existing_hash != matched_pool.expected_endpoint_set_hash {
-        return Err(failed_decision(
+        return Err(Box::new(failed_decision(
             existing.request_id.clone(),
             "RustfsPoolIdentityMismatch",
             "recorded endpoint set hash no longer matches the expected pool cmdline",
-        ));
+        )));
     }
 
     let rustfs_status = match client.pool_status_by_id(&pool_id).await {
         Ok(status) => status,
         Err(error) => {
-            return Err(cleanup_retriable_decision(
+            return Err(Box::new(cleanup_retriable_decision(
                 existing.clone(),
                 "RustfsDecommissionStatusFailed",
                 &error.to_string(),
-            ));
+            )));
         }
     };
 
@@ -656,19 +656,19 @@ async fn verify_decommissioned_pool_for_cleanup(
         &matched_pool.expected_endpoint_set_hash,
     )
     .map_err(|message| {
-        failed_decision(
+        Box::new(failed_decision(
             existing.request_id.clone(),
             "RustfsPoolIdentityMismatch",
             &message,
-        )
+        ))
     })?;
 
     if !matches!(status.phase, Some(PoolDecommissionPhase::Complete)) {
-        return Err(failed_decision(
+        return Err(Box::new(failed_decision(
             existing.request_id.clone(),
             "RustfsDecommissionNotComplete",
             "RustFS no longer reports the pool decommission as complete; refusing cleanup",
-        ));
+        )));
     }
 
     Ok(status)


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
Closes rustfs/backlog#1099

## Summary of Changes
- Split Console API routing into explicit public and protected route trees.
- Apply session authentication directly to the protected router, including `/session` and all tenant, pool, pod, event, cluster, and topology APIs.
- Remove path-prefix and static-path exemptions from the authentication middleware.
- Add regression coverage proving `/session` is protected while `/logout` remains explicitly public.
- Preserve response and pool lifecycle semantics while satisfying Rust 1.98 `result_large_err` clippy checks.

The previous global middleware used request path strings as a fail-open allowlist, including every path outside `/api/v1`. Router composition now defines the trust boundary, so newly added protected API routes cannot silently bypass authentication because of their path.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit` (fmt-check + clippy + test + console-lint + console-fmt-check)
- [x] Added/updated necessary tests
- [x] Documentation updated (N/A: public endpoints and session behavior are unchanged)
- [x] CHANGELOG.md updated under `[Unreleased]` (N/A: no changelog file exists in the repository)
- [x] CI/CD passed

## Impact
- [ ] Breaking change (CRD/API compatibility)
- [ ] Requires doc/config/deployment update
- [x] Other impact: health, readiness, metrics, OpenAPI, Swagger UI, static assets, login, and logout remain explicitly unauthenticated.

## Verification
```bash
rustc --version
# rustc 1.98.0 (88d9e12ae 2026-08-18)
make pre-commit
```

## Additional Notes
`OPTIONS` requests continue to bypass session validation so browser CORS preflight behavior is preserved.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
