### PR TITLE
fix: reconcile private bucket policies and IP family changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ All notable changes to RustFS Operator are documented in this file. The format i
 
 ### Fixed
 
+- Explicit private bucket access now removes operator-managed policies, and primary Service IP
+  family changes recreate managed Services instead of repeatedly failing immutable-field updates.
 - Provisioning now requeues transient RustFS admin/S3 and Kubernetes failures instead of leaving
   policies, users, and buckets failed until an unrelated object change.
 

--- a/deploy/rustfs-operator/crds/tenant-crd.yaml
+++ b/deploy/rustfs-operator/crds/tenant-crd.yaml
@@ -31,12 +31,16 @@ spec:
                 items:
                   properties:
                     anonymous:
-                      description: Canned anonymous access for this bucket. Mutually exclusive with `policy`.
+                      description: |-
+                        Canned anonymous access for this bucket. Mutually exclusive with `policy`. Explicit
+                        `Private` removes an operator-managed bucket policy; omission leaves the live policy alone.
                       enum:
                       - Private
                       - Download
                       - Upload
                       - Public
+                      - null
+                      nullable: true
                       type: string
                     deletionPolicy:
                       enum:
@@ -82,7 +86,7 @@ spec:
                   type: object
                   x-kubernetes-validations:
                   - message: bucket policy and anonymous access are mutually exclusive
-                    rule: '!(has(self.policy) && has(self.anonymous) && self.anonymous != ''Private'')'
+                    rule: '!(has(self.policy) && has(self.anonymous))'
                 maxItems: 1024
                 type: array
                 x-kubernetes-list-map-keys:
@@ -627,7 +631,10 @@ spec:
                       type: string
                     maxItems: 2
                     type: array
-                    x-kubernetes-list-type: set
+                    x-kubernetes-list-type: atomic
+                    x-kubernetes-validations:
+                    - message: ipFamilies must not contain duplicates
+                      rule: self.size() != 2 || self[0] != self[1]
                   ipFamilyPolicy:
                     description: Kubernetes Service IP family policy values.
                     enum:

--- a/deploy/rustfs-operator/crds/tenant-crd.yaml
+++ b/deploy/rustfs-operator/crds/tenant-crd.yaml
@@ -32,8 +32,9 @@ spec:
                   properties:
                     anonymous:
                       description: |-
-                        Canned anonymous access for this bucket. Mutually exclusive with `policy`. Explicit
-                        `Private` removes an operator-managed bucket policy; omission leaves the live policy alone.
+                        Canned anonymous access for this bucket. Non-private values are mutually exclusive with
+                        `policy`. Explicit `Private` removes an operator-managed bucket policy when `policy` is
+                        absent; omission leaves the live policy alone.
                       enum:
                       - Private
                       - Download
@@ -58,7 +59,9 @@ spec:
                       nullable: true
                       type: boolean
                     policy:
-                      description: Custom bucket policy document sourced from a ConfigMap. Mutually exclusive with `anonymous`.
+                      description: |-
+                        Custom bucket policy document sourced from a ConfigMap. Mutually exclusive with non-private
+                        `anonymous`; legacy `Private` plus `policy` configurations keep the custom policy.
                       nullable: true
                       properties:
                         configMapKeyRef:
@@ -85,8 +88,8 @@ spec:
                   - name
                   type: object
                   x-kubernetes-validations:
-                  - message: bucket policy and anonymous access are mutually exclusive
-                    rule: '!(has(self.policy) && has(self.anonymous))'
+                  - message: bucket policy and non-private anonymous access are mutually exclusive
+                    rule: '!(has(self.policy) && has(self.anonymous) && self.anonymous != ''Private'')'
                 maxItems: 1024
                 type: array
                 x-kubernetes-list-map-keys:

--- a/docs/operator-user-guide.md
+++ b/docs/operator-user-guide.md
@@ -548,7 +548,7 @@ Useful Tenant-level fields:
 | `securityContext` | Pod SecurityContext overrides for all RustFS Pools. |
 | `containerSecurityContext` | RustFS container SecurityContext overrides for all Pools. |
 | `hostUsers` | Optional Pod `hostUsers`. `false` isolates the user namespace (`restricted-v3`). An OpenShift empty security-context pair also defaults this to `false`. |
-| `network` | Optional Service `ipFamilyPolicy`/`ipFamilies` and RustFS listen addresses. Omitted Tenants keep IPv4 `0.0.0.0` listen addresses. IPv6 or dual-stack clusters should set `ipFamilies: [IPv6]` or `ipFamilyPolicy: PreferDualStack` so Services and `RUSTFS_ADDRESS` use `[::]`. |
+| `network` | Optional Service `ipFamilyPolicy`/`ipFamilies` and RustFS listen addresses. Omitted Tenants keep IPv4 `0.0.0.0` listen addresses. IPv6 or dual-stack clusters should set `ipFamilies: [IPv6]` or `ipFamilyPolicy: PreferDualStack` so Services and `RUSTFS_ADDRESS` use `[::]`. `ipFamilies` is ordered and its first entry is the primary family; changing the primary family recreates Tenant Services and can briefly interrupt endpoints. |
 
 Both fields are also available on each `spec.pools[]` entry. Pool values are
 merged over Tenant values, which are merged over the Operator's defaults. By
@@ -856,7 +856,7 @@ The operator can create RustFS policies, users, and buckets after the Tenant wor
 - `spec.credsSecret` for RustFS admin credentials.
 - `spec.policies` for canned policies sourced from ConfigMaps.
 - `spec.users` for regular users. Each user must have at least one direct policy mapping.
-- `spec.buckets` for buckets, optional object lock, canned anonymous access (`Private`, `Download`, `Upload`, `Public`), or a custom bucket policy ConfigMap. `anonymous` and `policy` are mutually exclusive. When both are omitted, the operator does not change a live bucket policy.
+- `spec.buckets` for buckets, optional object lock, canned anonymous access (`Private`, `Download`, `Upload`, `Public`), or a custom bucket policy ConfigMap. `anonymous` and `policy` are mutually exclusive. Explicit `anonymous: Private` removes a bucket policy previously applied by the Operator; it reports a conflict instead of deleting an unowned live policy. When both fields are omitted, the Operator does not change a live bucket policy.
 
 Transient Kubernetes and RustFS admin/S3 failures (timeouts, 429, 5xx, connection errors, TLS not ready) leave provisioning items `Pending` and requeue instead of marking the Tenant `Failed`. Permanent 4xx configuration errors still fail and wait for a spec or object change.
 

--- a/docs/operator-user-guide.md
+++ b/docs/operator-user-guide.md
@@ -548,7 +548,7 @@ Useful Tenant-level fields:
 | `securityContext` | Pod SecurityContext overrides for all RustFS Pools. |
 | `containerSecurityContext` | RustFS container SecurityContext overrides for all Pools. |
 | `hostUsers` | Optional Pod `hostUsers`. `false` isolates the user namespace (`restricted-v3`). An OpenShift empty security-context pair also defaults this to `false`. |
-| `network` | Optional Service `ipFamilyPolicy`/`ipFamilies` and RustFS listen addresses. Omitted Tenants keep IPv4 `0.0.0.0` listen addresses. IPv6 or dual-stack clusters should set `ipFamilies: [IPv6]` or `ipFamilyPolicy: PreferDualStack` so Services and `RUSTFS_ADDRESS` use `[::]`. `ipFamilies` is ordered and its first entry is the primary family; changing the primary family recreates Tenant Services and can briefly interrupt endpoints. |
+| `network` | Optional Service `ipFamilyPolicy`/`ipFamilies` and RustFS listen addresses. Omitted Tenants keep IPv4 `0.0.0.0` listen addresses. IPv6 or dual-stack clusters should set `ipFamilies: [IPv6]` or `ipFamilyPolicy: PreferDualStack` so Services and `RUSTFS_ADDRESS` use `[::]`. `ipFamilies` is ordered and its first entry is the primary family; changing the primary family or removing an explicit list recreates Tenant Services and can briefly interrupt endpoints. |
 
 Both fields are also available on each `spec.pools[]` entry. Pool values are
 merged over Tenant values, which are merged over the Operator's defaults. By
@@ -856,7 +856,7 @@ The operator can create RustFS policies, users, and buckets after the Tenant wor
 - `spec.credsSecret` for RustFS admin credentials.
 - `spec.policies` for canned policies sourced from ConfigMaps.
 - `spec.users` for regular users. Each user must have at least one direct policy mapping.
-- `spec.buckets` for buckets, optional object lock, canned anonymous access (`Private`, `Download`, `Upload`, `Public`), or a custom bucket policy ConfigMap. `anonymous` and `policy` are mutually exclusive. Explicit `anonymous: Private` removes a bucket policy previously applied by the Operator; it reports a conflict instead of deleting an unowned live policy. When both fields are omitted, the Operator does not change a live bucket policy.
+- `spec.buckets` for buckets, optional object lock, canned anonymous access (`Private`, `Download`, `Upload`, `Public`), or a custom bucket policy ConfigMap. Non-private `anonymous` values and `policy` are mutually exclusive. Explicit `anonymous: Private` without `policy` removes a bucket policy previously applied by the Operator; it reports a conflict instead of deleting an unowned live policy. For compatibility, legacy `Private` plus `policy` configurations keep the custom policy. When both fields are omitted, the Operator does not change a live bucket policy and retains its ownership record for a later explicit `Private` transition.
 
 Transient Kubernetes and RustFS admin/S3 failures (timeouts, 429, 5xx, connection errors, TLS not ready) leave provisioning items `Pending` and requeue instead of marking the Tenant `Failed`. Permanent 4xx configuration errors still fail and wait for a spec or object change.
 

--- a/docs/operator-user-guide.zh-CN.md
+++ b/docs/operator-user-guide.zh-CN.md
@@ -520,7 +520,7 @@ spec:
 | `securityContext` | 所有 RustFS Pool 的 Pod SecurityContext 覆盖。 |
 | `containerSecurityContext` | 所有 Pool 的 RustFS 容器 SecurityContext 覆盖。 |
 | `hostUsers` | 可选的 Pod `hostUsers`。`false` 会隔离用户命名空间（`restricted-v3`）。OpenShift 空 securityContext 对也会默认渲染为 `false`。 |
-| `network` | 可选的 Service `ipFamilyPolicy`/`ipFamilies` 以及 RustFS 监听地址。省略时保持 IPv4 `0.0.0.0`。IPv6 或双栈集群应设置 `ipFamilies: [IPv6]` 或 `ipFamilyPolicy: PreferDualStack`，使 Service 和 `RUSTFS_ADDRESS` 使用 `[::]`。 |
+| `network` | 可选的 Service `ipFamilyPolicy`/`ipFamilies` 以及 RustFS 监听地址。省略时保持 IPv4 `0.0.0.0`。IPv6 或双栈集群应设置 `ipFamilies: [IPv6]` 或 `ipFamilyPolicy: PreferDualStack`，使 Service 和 `RUSTFS_ADDRESS` 使用 `[::]`。`ipFamilies` 有顺序，第一个元素是主地址族；修改主地址族会重建 Tenant Service，并可能造成短暂的端点中断。 |
 
 这两个字段也可配置在每个 `spec.pools[]` 条目上。Pool 级字段会按字段覆盖
 Tenant 级字段，Tenant 级字段再覆盖 Operator 默认值。Operator 默认设置
@@ -812,7 +812,7 @@ Operator 可以在 Tenant workload Ready 后自动创建 RustFS policy、user �
 - `spec.credsSecret`：RustFS 管理员凭据。
 - `spec.policies`：从 ConfigMap 读取 policy document。
 - `spec.users`：普通用户。每个 user 必须至少直接绑定一个 policy。
-- `spec.buckets`：bucket，以及可选的 object lock、匿名访问（`Private` / `Download` / `Upload` / `Public`）或来自 ConfigMap 的自定义 bucket policy。`anonymous` 与 `policy` 互斥。两者都省略时，Operator 不会改写已有 bucket policy。
+- `spec.buckets`：bucket，以及可选的 object lock、匿名访问（`Private` / `Download` / `Upload` / `Public`）或来自 ConfigMap 的自定义 bucket policy。`anonymous` 与 `policy` 互斥。显式设置 `anonymous: Private` 会删除此前由 Operator 应用的 bucket policy；若现有 policy 不归 Operator 管理，则报告冲突而不删除。两者都省略时，Operator 不会改写已有 bucket policy。
 
 Kubernetes 或 RustFS 管理/S3 API 的瞬时失败（超时、429、5xx、连接错误、TLS 未就绪）会把 provisioning 条目保持为 `Pending` 并重新入队，而不会把 Tenant 标为 `Failed`。永久性 4xx 配置错误仍会失败并等待 spec 或对象变更。
 

--- a/docs/operator-user-guide.zh-CN.md
+++ b/docs/operator-user-guide.zh-CN.md
@@ -520,7 +520,7 @@ spec:
 | `securityContext` | 所有 RustFS Pool 的 Pod SecurityContext 覆盖。 |
 | `containerSecurityContext` | 所有 Pool 的 RustFS 容器 SecurityContext 覆盖。 |
 | `hostUsers` | 可选的 Pod `hostUsers`。`false` 会隔离用户命名空间（`restricted-v3`）。OpenShift 空 securityContext 对也会默认渲染为 `false`。 |
-| `network` | 可选的 Service `ipFamilyPolicy`/`ipFamilies` 以及 RustFS 监听地址。省略时保持 IPv4 `0.0.0.0`。IPv6 或双栈集群应设置 `ipFamilies: [IPv6]` 或 `ipFamilyPolicy: PreferDualStack`，使 Service 和 `RUSTFS_ADDRESS` 使用 `[::]`。`ipFamilies` 有顺序，第一个元素是主地址族；修改主地址族会重建 Tenant Service，并可能造成短暂的端点中断。 |
+| `network` | 可选的 Service `ipFamilyPolicy`/`ipFamilies` 以及 RustFS 监听地址。省略时保持 IPv4 `0.0.0.0`。IPv6 或双栈集群应设置 `ipFamilies: [IPv6]` 或 `ipFamilyPolicy: PreferDualStack`，使 Service 和 `RUSTFS_ADDRESS` 使用 `[::]`。`ipFamilies` 有顺序，第一个元素是主地址族；修改主地址族或移除显式列表会重建 Tenant Service，并可能造成短暂的端点中断。 |
 
 这两个字段也可配置在每个 `spec.pools[]` 条目上。Pool 级字段会按字段覆盖
 Tenant 级字段，Tenant 级字段再覆盖 Operator 默认值。Operator 默认设置
@@ -812,7 +812,7 @@ Operator 可以在 Tenant workload Ready 后自动创建 RustFS policy、user �
 - `spec.credsSecret`：RustFS 管理员凭据。
 - `spec.policies`：从 ConfigMap 读取 policy document。
 - `spec.users`：普通用户。每个 user 必须至少直接绑定一个 policy。
-- `spec.buckets`：bucket，以及可选的 object lock、匿名访问（`Private` / `Download` / `Upload` / `Public`）或来自 ConfigMap 的自定义 bucket policy。`anonymous` 与 `policy` 互斥。显式设置 `anonymous: Private` 会删除此前由 Operator 应用的 bucket policy；若现有 policy 不归 Operator 管理，则报告冲突而不删除。两者都省略时，Operator 不会改写已有 bucket policy。
+- `spec.buckets`：bucket，以及可选的 object lock、匿名访问（`Private` / `Download` / `Upload` / `Public`）或来自 ConfigMap 的自定义 bucket policy。非 `Private` 的 `anonymous` 值与 `policy` 互斥。未设置 `policy` 时，显式设置 `anonymous: Private` 会删除此前由 Operator 应用的 bucket policy；若现有 policy 不归 Operator 管理，则报告冲突而不删除。为兼容旧对象，`Private` 与 `policy` 同时存在时继续以自定义 policy 为准。两者都省略时，Operator 不会改写已有 bucket policy，并会保留所有权记录供后续显式切换为 `Private` 时校验。
 
 Kubernetes 或 RustFS 管理/S3 API 的瞬时失败（超时、429、5xx、连接错误、TLS 未就绪）会把 provisioning 条目保持为 `Pending` 并重新入队，而不会把 Tenant 标为 `Failed`。永久性 4xx 配置错误仍会失败并等待 spec 或对象变更。
 

--- a/src/reconcile.rs
+++ b/src/reconcile.rs
@@ -38,10 +38,11 @@ mod tls;
 const OUT_OF_SERVICE_TAINT_KEY: &str = "node.kubernetes.io/out-of-service";
 
 use phases::{
-    cleanup_legacy_tenant_rbac, cleanup_removed_decommissioned_pool_statefulsets,
-    finalize_tenant_status, harden_existing_tenant_workload_identity,
-    maybe_cleanup_terminating_pods, reconcile_pool_statefulsets, reconcile_service_account,
-    reconcile_services, validate_no_pool_rename, validate_tenant_prerequisites,
+    ServiceReconcileOutcome, cleanup_legacy_tenant_rbac,
+    cleanup_removed_decommissioned_pool_statefulsets, finalize_tenant_status,
+    harden_existing_tenant_workload_identity, maybe_cleanup_terminating_pods,
+    reconcile_pool_statefulsets, reconcile_service_account, reconcile_services,
+    validate_no_pool_rename, validate_tenant_prerequisites,
 };
 use pool_lifecycle::reconcile_pool_lifecycle;
 
@@ -93,7 +94,11 @@ pub async fn reconcile_rustfs(tenant: Arc<Tenant>, ctx: Arc<Context>) -> Result<
 
     reconcile_service_account(&ctx, &latest_tenant, &ns).await?;
 
-    reconcile_services(&ctx, &latest_tenant, &ns, &tls_plan).await?;
+    if let ServiceReconcileOutcome::Requeue(duration) =
+        reconcile_services(&ctx, &latest_tenant, &ns, &tls_plan).await?
+    {
+        return Ok(requeue_after(duration));
+    }
 
     let removed_pool_cleanup =
         cleanup_removed_decommissioned_pool_statefulsets(&ctx, &latest_tenant, &ns).await?;

--- a/src/reconcile/phases.rs
+++ b/src/reconcile/phases.rs
@@ -499,41 +499,35 @@ pub(super) async fn reconcile_services(
     ];
     let mut services_to_recreate = Vec::new();
 
-    if desired_services
-        .first()
-        .and_then(service_primary_ip_family)
-        .is_some()
-    {
-        for desired in &desired_services {
-            let name = desired.name_any();
-            let existing = match ctx.get::<Service>(&name, namespace).await {
-                Ok(existing) => existing,
-                Err(error) if context::is_kube_not_found(&error) => continue,
-                Err(error) => return context_result(Err(error), ctx, tenant).await,
-            };
-            if existing.metadata.deletion_timestamp.is_some() {
-                return Ok(ServiceReconcileOutcome::Requeue(
-                    SERVICE_RECREATE_REQUEUE_INTERVAL,
-                ));
-            }
-            if !service_primary_ip_family_changed(&existing, desired) {
-                continue;
-            }
-            if !operator_resource_owned_by_tenant_or_predecessor(existing.meta(), tenant) {
-                return types_result(
-                    Err(types::error::Error::ImmutableFieldModified {
-                        name: format!("Service {namespace}/{name}"),
-                        field: "spec.ipFamilies[0]".to_string(),
-                        message: "the existing Service is not managed by this Operator and cannot be safely recreated"
-                            .to_string(),
-                    }),
-                    ctx,
-                    tenant,
-                )
-                .await;
-            }
-            services_to_recreate.push(existing);
+    for desired in &desired_services {
+        let name = desired.name_any();
+        let existing = match ctx.get::<Service>(&name, namespace).await {
+            Ok(existing) => existing,
+            Err(error) if context::is_kube_not_found(&error) => continue,
+            Err(error) => return context_result(Err(error), ctx, tenant).await,
+        };
+        if existing.metadata.deletion_timestamp.is_some() {
+            return Ok(ServiceReconcileOutcome::Requeue(
+                SERVICE_RECREATE_REQUEUE_INTERVAL,
+            ));
         }
+        if !service_ip_families_require_recreation(&existing, desired) {
+            continue;
+        }
+        if !operator_resource_owned_by_tenant_or_predecessor(existing.meta(), tenant) {
+            return types_result(
+                Err(types::error::Error::ImmutableFieldModified {
+                    name: format!("Service {namespace}/{name}"),
+                    field: "spec.ipFamilies[0]".to_string(),
+                    message: "the existing Service is not managed by this Operator and cannot be safely recreated"
+                        .to_string(),
+                }),
+                ctx,
+                tenant,
+            )
+            .await;
+        }
+        services_to_recreate.push(existing);
     }
 
     if !services_to_recreate.is_empty() {
@@ -595,11 +589,29 @@ fn service_primary_ip_family(service: &Service) -> Option<&str> {
         .map(String::as_str)
 }
 
-fn service_primary_ip_family_changed(existing: &Service, desired: &Service) -> bool {
-    let Some(desired_primary) = service_primary_ip_family(desired) else {
-        return false;
-    };
-    service_primary_ip_family(existing).is_some_and(|existing| existing != desired_primary)
+fn service_ip_families_require_recreation(existing: &Service, desired: &Service) -> bool {
+    match service_primary_ip_family(desired) {
+        Some(desired_primary) => {
+            service_primary_ip_family(existing).is_some_and(|existing| existing != desired_primary)
+        }
+        None => service_ip_families_managed_by_operator(existing),
+    }
+}
+
+fn service_ip_families_managed_by_operator(service: &Service) -> bool {
+    service
+        .metadata
+        .managed_fields
+        .as_ref()
+        .is_some_and(|entries| {
+            entries.iter().any(|entry| {
+                entry.manager.as_deref() == Some("rustfs-operator")
+                    && entry
+                        .fields_v1
+                        .as_ref()
+                        .is_some_and(|fields| fields.0.pointer("/f:spec/f:ipFamilies").is_some())
+            })
+        })
 }
 
 pub(super) async fn cleanup_removed_decommissioned_pool_statefulsets(
@@ -1469,7 +1481,9 @@ mod tests {
     use super::*;
     use http::{Method, Request, Response, StatusCode};
     use k8s_openapi::api::rbac::v1::{Role, RoleBinding};
-    use k8s_openapi::apimachinery::pkg::apis::meta::v1::{ManagedFieldsEntry, ObjectMeta};
+    use k8s_openapi::apimachinery::pkg::apis::meta::v1::{
+        FieldsV1, ManagedFieldsEntry, ObjectMeta,
+    };
     use kube::{Client, client::Body};
     use serde_json::{Value, json};
     use std::convert::Infallible;
@@ -1491,6 +1505,19 @@ mod tests {
     fn operator_managed_fields() -> Vec<ManagedFieldsEntry> {
         vec![ManagedFieldsEntry {
             manager: Some("rustfs-operator".to_string()),
+            ..Default::default()
+        }]
+    }
+
+    fn operator_managed_ip_family_fields() -> Vec<ManagedFieldsEntry> {
+        vec![ManagedFieldsEntry {
+            manager: Some("rustfs-operator".to_string()),
+            fields_type: Some("FieldsV1".to_string()),
+            fields_v1: Some(FieldsV1(json!({
+                "f:spec": {
+                    "f:ipFamilies": {}
+                }
+            }))),
             ..Default::default()
         }]
     }
@@ -1645,7 +1672,7 @@ mod tests {
     }
 
     #[test]
-    fn service_primary_ip_family_change_requires_recreation() {
+    fn service_ip_family_change_or_removal_requires_recreation() {
         let tenant = crate::tests::create_test_tenant(None, None);
         let mut existing = tenant.new_io_service();
         existing
@@ -1660,32 +1687,31 @@ mod tests {
             .expect("desired Service should have spec")
             .ip_families = Some(vec!["IPv6".to_string(), "IPv4".to_string()]);
 
-        assert!(service_primary_ip_family_changed(&existing, &desired));
+        assert!(service_ip_families_require_recreation(&existing, &desired));
 
         desired
             .spec
             .as_mut()
             .expect("desired Service should have spec")
             .ip_families = Some(vec!["IPv4".to_string(), "IPv6".to_string()]);
-        assert!(!service_primary_ip_family_changed(&existing, &desired));
+        assert!(!service_ip_families_require_recreation(&existing, &desired));
 
         desired
             .spec
             .as_mut()
             .expect("desired Service should have spec")
             .ip_families = None;
-        assert!(!service_primary_ip_family_changed(&existing, &desired));
+        assert!(!service_ip_families_require_recreation(&existing, &desired));
+
+        existing.metadata.managed_fields = Some(operator_managed_ip_family_fields());
+        assert!(service_ip_families_require_recreation(&existing, &desired));
     }
 
-    #[tokio::test]
-    async fn reconcile_services_recreates_operator_managed_services_for_new_primary_family() {
-        use crate::types::v1alpha1::network::{IpFamily, IpFamilyPolicy, NetworkConfig};
-
-        let mut tenant = crate::tests::create_test_tenant(None, None);
-        tenant.spec.network = Some(NetworkConfig {
-            ip_family_policy: Some(IpFamilyPolicy::SingleStack),
-            ip_families: vec![IpFamily::IPv6],
-        });
+    async fn assert_reconcile_services_recreates(
+        tenant: &Tenant,
+        existing_family: &str,
+        operator_managed_ip_families: bool,
+    ) {
         let mut existing_services = vec![
             tenant.new_io_service(),
             tenant.new_console_service(),
@@ -1694,12 +1720,16 @@ mod tests {
         for (index, service) in existing_services.iter_mut().enumerate() {
             service.metadata.uid = Some(format!("service-uid-{index}"));
             service.metadata.resource_version = Some(format!("{}", index + 10));
-            service.metadata.managed_fields = Some(operator_managed_fields());
+            service.metadata.managed_fields = Some(if operator_managed_ip_families {
+                operator_managed_ip_family_fields()
+            } else {
+                operator_managed_fields()
+            });
             service
                 .spec
                 .as_mut()
                 .expect("Service should have spec")
-                .ip_families = Some(vec!["IPv4".to_string()]);
+                .ip_families = Some(vec![existing_family.to_string()]);
         }
         let existing_services = Arc::new(existing_services);
         let request_count = Arc::new(AtomicUsize::new(0));
@@ -1771,6 +1801,26 @@ mod tests {
             ServiceReconcileOutcome::Requeue(SERVICE_RECREATE_REQUEUE_INTERVAL)
         );
         assert_eq!(request_count.load(Ordering::SeqCst), 6);
+    }
+
+    #[tokio::test]
+    async fn reconcile_services_recreates_operator_managed_services_for_new_primary_family() {
+        use crate::types::v1alpha1::network::{IpFamily, IpFamilyPolicy, NetworkConfig};
+
+        let mut tenant = crate::tests::create_test_tenant(None, None);
+        tenant.spec.network = Some(NetworkConfig {
+            ip_family_policy: Some(IpFamilyPolicy::SingleStack),
+            ip_families: vec![IpFamily::IPv6],
+        });
+
+        assert_reconcile_services_recreates(&tenant, "IPv4", false).await;
+    }
+
+    #[tokio::test]
+    async fn reconcile_services_recreates_when_explicit_ip_families_are_removed() {
+        let tenant = crate::tests::create_test_tenant(None, None);
+
+        assert_reconcile_services_recreates(&tenant, "IPv6", true).await;
     }
 
     #[tokio::test]

--- a/src/reconcile/phases.rs
+++ b/src/reconcile/phases.rs
@@ -30,7 +30,7 @@ use crate::types::v1alpha1::tenant::{
 use crate::types::v1alpha1::tls::TlsPlan;
 use k8s_openapi::NamespaceResourceScope;
 use k8s_openapi::api::apps::v1::StatefulSet;
-use k8s_openapi::api::core::v1::ServiceAccount;
+use k8s_openapi::api::core::v1::{Service, ServiceAccount};
 use k8s_openapi::api::rbac::v1::{Role, RoleBinding};
 use kube::api::{DeleteParams, ListParams, Preconditions, PropagationPolicy};
 use kube::runtime::controller::Action;
@@ -59,6 +59,13 @@ pub(super) struct PoolReconcileSummary {
 
 const REMOVED_POOL_CLEANUP_REQUEUE_INTERVAL: Duration = Duration::from_secs(10);
 const POD_DELETION_POLICY_REQUEUE_INTERVAL: Duration = Duration::from_secs(30);
+const SERVICE_RECREATE_REQUEUE_INTERVAL: Duration = Duration::from_secs(5);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum ServiceReconcileOutcome {
+    Complete,
+    Requeue(Duration),
+}
 
 #[derive(Default)]
 pub(super) struct RemovedDecommissionedPoolCleanup {
@@ -484,32 +491,115 @@ pub(super) async fn reconcile_services(
     tenant: &Tenant,
     namespace: &str,
     tls_plan: &TlsPlan,
-) -> Result<(), Error> {
-    context_result(
-        ctx.apply(&tenant.new_io_service_with_tls_plan(tls_plan), namespace)
-            .await,
-        ctx,
-        tenant,
-    )
-    .await?;
-    context_result(
-        ctx.apply(&tenant.new_console_service(), namespace).await,
-        ctx,
-        tenant,
-    )
-    .await?;
-    context_result(
-        ctx.apply(
-            &tenant.new_headless_service_with_tls_plan(tls_plan),
-            namespace,
-        )
-        .await,
-        ctx,
-        tenant,
-    )
-    .await?;
+) -> Result<ServiceReconcileOutcome, Error> {
+    let desired_services = [
+        tenant.new_io_service_with_tls_plan(tls_plan),
+        tenant.new_console_service(),
+        tenant.new_headless_service_with_tls_plan(tls_plan),
+    ];
+    let mut services_to_recreate = Vec::new();
 
-    Ok(())
+    if desired_services
+        .first()
+        .and_then(service_primary_ip_family)
+        .is_some()
+    {
+        for desired in &desired_services {
+            let name = desired.name_any();
+            let existing = match ctx.get::<Service>(&name, namespace).await {
+                Ok(existing) => existing,
+                Err(error) if context::is_kube_not_found(&error) => continue,
+                Err(error) => return context_result(Err(error), ctx, tenant).await,
+            };
+            if existing.metadata.deletion_timestamp.is_some() {
+                return Ok(ServiceReconcileOutcome::Requeue(
+                    SERVICE_RECREATE_REQUEUE_INTERVAL,
+                ));
+            }
+            if !service_primary_ip_family_changed(&existing, desired) {
+                continue;
+            }
+            if !operator_resource_owned_by_tenant_or_predecessor(existing.meta(), tenant) {
+                return types_result(
+                    Err(types::error::Error::ImmutableFieldModified {
+                        name: format!("Service {namespace}/{name}"),
+                        field: "spec.ipFamilies[0]".to_string(),
+                        message: "the existing Service is not managed by this Operator and cannot be safely recreated"
+                            .to_string(),
+                    }),
+                    ctx,
+                    tenant,
+                )
+                .await;
+            }
+            services_to_recreate.push(existing);
+        }
+    }
+
+    if !services_to_recreate.is_empty() {
+        for service in services_to_recreate {
+            let name = service.name_any();
+            let Some(uid) = service.metadata.uid.clone() else {
+                return types_result(
+                    Err(types::error::Error::ImmutableFieldModified {
+                        name: format!("Service {namespace}/{name}"),
+                        field: "spec.ipFamilies[0]".to_string(),
+                        message: "the existing Service has no UID and cannot be safely recreated"
+                            .to_string(),
+                    }),
+                    ctx,
+                    tenant,
+                )
+                .await;
+            };
+            let delete_params = DeleteParams {
+                preconditions: Some(Preconditions {
+                    uid: Some(uid),
+                    resource_version: service.metadata.resource_version.clone(),
+                }),
+                ..DeleteParams::default()
+            };
+            match ctx
+                .delete_with_params::<Service>(&name, namespace, &delete_params)
+                .await
+            {
+                Ok(()) => info!(
+                    tenant = %tenant.name(),
+                    namespace = %namespace,
+                    service = %name,
+                    "recreating Tenant Service because its primary IP family changed"
+                ),
+                Err(error) if context::is_kube_not_found(&error) => {}
+                Err(error) => return context_result(Err(error), ctx, tenant).await,
+            }
+        }
+        return Ok(ServiceReconcileOutcome::Requeue(
+            SERVICE_RECREATE_REQUEUE_INTERVAL,
+        ));
+    }
+
+    for desired in &desired_services {
+        context_result(ctx.apply(desired, namespace).await, ctx, tenant).await?;
+    }
+
+    Ok(ServiceReconcileOutcome::Complete)
+}
+
+fn service_primary_ip_family(service: &Service) -> Option<&str> {
+    service
+        .spec
+        .as_ref()?
+        .ip_families
+        .as_ref()?
+        .first()
+        .map(String::as_str)
+}
+
+fn service_primary_ip_family_changed(existing: &Service, desired: &Service) -> bool {
+    let Some(desired_primary) = service_primary_ip_family(desired) else {
+        return false;
+    };
+    service_primary_ip_family(existing).is_some_and(|existing| existing != desired_primary)
 }
 
 pub(super) async fn cleanup_removed_decommissioned_pool_statefulsets(
@@ -1552,6 +1642,135 @@ mod tests {
             &user_managed,
             &tenant
         ));
+    }
+
+    #[test]
+    fn service_primary_ip_family_change_requires_recreation() {
+        let tenant = crate::tests::create_test_tenant(None, None);
+        let mut existing = tenant.new_io_service();
+        existing
+            .spec
+            .as_mut()
+            .expect("existing Service should have spec")
+            .ip_families = Some(vec!["IPv4".to_string()]);
+        let mut desired = tenant.new_io_service();
+        desired
+            .spec
+            .as_mut()
+            .expect("desired Service should have spec")
+            .ip_families = Some(vec!["IPv6".to_string(), "IPv4".to_string()]);
+
+        assert!(service_primary_ip_family_changed(&existing, &desired));
+
+        desired
+            .spec
+            .as_mut()
+            .expect("desired Service should have spec")
+            .ip_families = Some(vec!["IPv4".to_string(), "IPv6".to_string()]);
+        assert!(!service_primary_ip_family_changed(&existing, &desired));
+
+        desired
+            .spec
+            .as_mut()
+            .expect("desired Service should have spec")
+            .ip_families = None;
+        assert!(!service_primary_ip_family_changed(&existing, &desired));
+    }
+
+    #[tokio::test]
+    async fn reconcile_services_recreates_operator_managed_services_for_new_primary_family() {
+        use crate::types::v1alpha1::network::{IpFamily, IpFamilyPolicy, NetworkConfig};
+
+        let mut tenant = crate::tests::create_test_tenant(None, None);
+        tenant.spec.network = Some(NetworkConfig {
+            ip_family_policy: Some(IpFamilyPolicy::SingleStack),
+            ip_families: vec![IpFamily::IPv6],
+        });
+        let mut existing_services = vec![
+            tenant.new_io_service(),
+            tenant.new_console_service(),
+            tenant.new_headless_service(),
+        ];
+        for (index, service) in existing_services.iter_mut().enumerate() {
+            service.metadata.uid = Some(format!("service-uid-{index}"));
+            service.metadata.resource_version = Some(format!("{}", index + 10));
+            service.metadata.managed_fields = Some(operator_managed_fields());
+            service
+                .spec
+                .as_mut()
+                .expect("Service should have spec")
+                .ip_families = Some(vec!["IPv4".to_string()]);
+        }
+        let existing_services = Arc::new(existing_services);
+        let request_count = Arc::new(AtomicUsize::new(0));
+        let service = service_fn({
+            let existing_services = Arc::clone(&existing_services);
+            let request_count = Arc::clone(&request_count);
+            move |request: Request<Body>| {
+                let existing_services = Arc::clone(&existing_services);
+                let request_number = request_count.fetch_add(1, Ordering::SeqCst);
+                async move {
+                    let service_index = request_number % existing_services.len();
+                    let existing = &existing_services[service_index];
+                    assert_eq!(
+                        request.uri().path(),
+                        format!(
+                            "/api/v1/namespaces/default/services/{}",
+                            existing.name_any()
+                        )
+                    );
+
+                    if request_number < existing_services.len() {
+                        assert_eq!(request.method(), Method::GET);
+                        return Ok::<_, Infallible>(kube_response(
+                            StatusCode::OK,
+                            serde_json::to_value(existing).expect("Service should serialize"),
+                        ));
+                    }
+
+                    assert_eq!(request.method(), Method::DELETE);
+                    let body: Value = serde_json::from_slice(
+                        &request
+                            .into_body()
+                            .collect_bytes()
+                            .await
+                            .expect("delete body should read"),
+                    )
+                    .expect("delete body should be JSON");
+                    assert_eq!(
+                        body["preconditions"]["uid"],
+                        existing
+                            .metadata
+                            .uid
+                            .as_deref()
+                            .expect("Service should have UID")
+                    );
+                    assert_eq!(
+                        body["preconditions"]["resourceVersion"],
+                        existing
+                            .metadata
+                            .resource_version
+                            .as_deref()
+                            .expect("Service should have resource version")
+                    );
+                    Ok::<_, Infallible>(kube_response(
+                        StatusCode::OK,
+                        json!({"apiVersion":"v1","kind":"Status","status":"Success"}),
+                    ))
+                }
+            }
+        });
+        let ctx = Context::new(Client::new(service, "default"));
+
+        let outcome = reconcile_services(&ctx, &tenant, "default", &TlsPlan::disabled())
+            .await
+            .expect("Service reconciliation should request recreation");
+
+        assert_eq!(
+            outcome,
+            ServiceReconcileOutcome::Requeue(SERVICE_RECREATE_REQUEUE_INTERVAL)
+        );
+        assert_eq!(request_count.load(Ordering::SeqCst), 6);
     }
 
     #[tokio::test]

--- a/src/reconcile/provisioning.rs
+++ b/src/reconcile/provisioning.rs
@@ -2075,6 +2075,21 @@ async fn reconcile_bucket(
         }
     };
 
+    if bucket
+        .anonymous
+        .as_ref()
+        .is_some_and(BucketAnonymousAccess::is_private)
+    {
+        return reconcile_private_bucket_policy(
+            run,
+            client,
+            bucket,
+            previous.as_ref(),
+            created_message,
+        )
+        .await;
+    }
+
     let Some(desired) = desired_bucket_policy(run, bucket).await else {
         let item = run.item(
             previous.as_ref(),
@@ -2121,7 +2136,10 @@ async fn desired_bucket_policy(
             .await,
         );
     }
-    canned_anonymous_bucket_policy(bucket.anonymous, &bucket.name)
+    bucket
+        .anonymous
+        .as_ref()
+        .and_then(|access| canned_anonymous_bucket_policy(*access, &bucket.name))
         .map(|raw| PolicyDocument::parse(&raw))
         .map(|result| {
             result.map_err(|message| SpecLoadError {
@@ -2130,6 +2148,104 @@ async fn desired_bucket_policy(
                 transient: false,
             })
         })
+}
+
+async fn reconcile_private_bucket_policy(
+    run: &mut ProvisioningRun<'_>,
+    client: &RustfsAdminClient,
+    bucket: &ProvisioningBucket,
+    previous: Option<&ProvisioningItemStatus>,
+    created_message: &str,
+) -> ProvisioningItemStatus {
+    let live_document = match client.get_bucket_policy(&bucket.name).await {
+        Ok(document) => document,
+        Err(error) => {
+            return finalize_private_bucket_policy_item(
+                run.item_from_admin_error(
+                    previous,
+                    &bucket.name,
+                    Reason::BucketPolicyApplyFailed,
+                    error,
+                    "failed to read RustFS bucket policy",
+                ),
+                previous,
+                bucket,
+            );
+        }
+    };
+    let Some(live_document) = live_document else {
+        return finalize_private_bucket_policy_item(
+            run.item(
+                previous,
+                &bucket.name,
+                ProvisioningItemState::Ready,
+                Reason::ProvisioningConfigured,
+                format!("{created_message}; RustFS bucket is private"),
+            ),
+            previous,
+            bucket,
+        );
+    };
+    let live_hash = match normalize_policy_document(&live_document) {
+        Ok(normalized) => hash_document(&normalized),
+        Err(message) => {
+            return finalize_private_bucket_policy_item(
+                run.item(
+                    previous,
+                    &bucket.name,
+                    ProvisioningItemState::Failed,
+                    Reason::BucketPolicyApplyFailed,
+                    format!("failed to normalize live RustFS bucket policy: {message}"),
+                ),
+                previous,
+                bucket,
+            );
+        }
+    };
+
+    if previous.and_then(|item| item.last_applied_hash.as_deref()) != Some(live_hash.as_str()) {
+        return finalize_private_bucket_policy_item(
+            run.item(
+                previous,
+                &bucket.name,
+                ProvisioningItemState::Failed,
+                Reason::BucketPolicyConflict,
+                "Live RustFS bucket policy is not owned by this status; refusing to delete it",
+            ),
+            previous,
+            bucket,
+        );
+    }
+
+    let item = match client.delete_bucket_policy(&bucket.name).await {
+        Ok(()) => run.item(
+            previous,
+            &bucket.name,
+            ProvisioningItemState::Ready,
+            Reason::ProvisioningConfigured,
+            format!("{created_message}; RustFS bucket policy was removed"),
+        ),
+        Err(error) => run.item_from_admin_error(
+            previous,
+            &bucket.name,
+            Reason::BucketPolicyApplyFailed,
+            error,
+            "failed to remove RustFS bucket policy",
+        ),
+    };
+    finalize_private_bucket_policy_item(item, previous, bucket)
+}
+
+fn finalize_private_bucket_policy_item(
+    mut item: ProvisioningItemStatus,
+    previous: Option<&ProvisioningItemStatus>,
+    bucket: &ProvisioningBucket,
+) -> ProvisioningItemStatus {
+    item = annotate_bucket_item(item, bucket);
+    if item.state != ProvisioningItemState::Ready.as_str() {
+        item.last_applied_hash = previous.and_then(|item| item.last_applied_hash.clone());
+    }
+    item
 }
 
 async fn sync_bucket_policy(
@@ -4491,7 +4607,7 @@ mod tests {
         let mut run = empty_run(&ctx, &tenant);
         let bucket = ProvisioningBucket {
             name: "app-data".to_string(),
-            anonymous: BucketAnonymousAccess::Download,
+            anonymous: Some(BucketAnonymousAccess::Download),
             ..Default::default()
         };
 
@@ -4505,6 +4621,122 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn explicit_private_removes_operator_managed_anonymous_policy() {
+        let live_policy = canned_anonymous_bucket_policy(BucketAnonymousAccess::Public, "app-data")
+            .expect("public policy");
+        let live_hash = hash_document(
+            &normalize_policy_document(&live_policy).expect("public policy should normalize"),
+        );
+        let delete_count = Arc::new(AtomicUsize::new(0));
+        let route_delete_count = Arc::clone(&delete_count);
+        let route_live_policy = live_policy.clone();
+        let router = Router::new().route(
+            "/app-data",
+            put(|| async { StatusCode::OK })
+                .get(move |req: Request<Body>| {
+                    let live_policy = route_live_policy.clone();
+                    async move {
+                        assert_eq!(req.uri().query().unwrap_or(""), "policy=");
+                        (StatusCode::OK, live_policy)
+                    }
+                })
+                .delete(move |req: Request<Body>| {
+                    let delete_count = Arc::clone(&route_delete_count);
+                    async move {
+                        assert_eq!(req.uri().query().unwrap_or(""), "policy=");
+                        delete_count.fetch_add(1, Ordering::SeqCst);
+                        StatusCode::NO_CONTENT
+                    }
+                }),
+        );
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("test server should bind");
+        let addr = listener.local_addr().expect("listener should have address");
+        let server = tokio::spawn(async move {
+            axum::serve(listener, router)
+                .await
+                .expect("test server should serve")
+        });
+        let client =
+            RustfsAdminClient::new_with_base_url(format!("http://{addr}"), "access", "secret");
+        let ctx = empty_kube_context();
+        let user = provisioning_user("app-user", "app-user-secret", "readwrite");
+        let tenant = provisioning_test_tenant(user, ProvisioningStatus::default());
+        let mut run = empty_run(&ctx, &tenant);
+        let mut previous = ProvisioningItemStatus::new(
+            "app-data",
+            ProvisioningItemState::Ready,
+            Reason::ProvisioningConfigured.as_str(),
+        );
+        previous.last_applied_hash = Some(live_hash);
+        run.previous.buckets.push(previous);
+        let bucket = ProvisioningBucket {
+            name: "app-data".to_string(),
+            anonymous: Some(BucketAnonymousAccess::Private),
+            ..Default::default()
+        };
+
+        let item = reconcile_bucket(&mut run, &client, &bucket).await;
+
+        assert_eq!(item.state, ProvisioningItemState::Ready.as_str());
+        assert_eq!(delete_count.load(Ordering::SeqCst), 1);
+        assert!(item.desired_hash.is_none());
+        assert!(item.last_applied_hash.is_none());
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn explicit_private_preserves_unmanaged_live_policy() {
+        let live_policy = canned_anonymous_bucket_policy(BucketAnonymousAccess::Public, "app-data")
+            .expect("public policy");
+        let delete_count = Arc::new(AtomicUsize::new(0));
+        let route_delete_count = Arc::clone(&delete_count);
+        let router = Router::new().route(
+            "/app-data",
+            put(|| async { StatusCode::OK })
+                .get(move || {
+                    let live_policy = live_policy.clone();
+                    async move { (StatusCode::OK, live_policy) }
+                })
+                .delete(move || {
+                    let delete_count = Arc::clone(&route_delete_count);
+                    async move {
+                        delete_count.fetch_add(1, Ordering::SeqCst);
+                        StatusCode::NO_CONTENT
+                    }
+                }),
+        );
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("test server should bind");
+        let addr = listener.local_addr().expect("listener should have address");
+        let server = tokio::spawn(async move {
+            axum::serve(listener, router)
+                .await
+                .expect("test server should serve")
+        });
+        let client =
+            RustfsAdminClient::new_with_base_url(format!("http://{addr}"), "access", "secret");
+        let ctx = empty_kube_context();
+        let user = provisioning_user("app-user", "app-user-secret", "readwrite");
+        let tenant = provisioning_test_tenant(user, ProvisioningStatus::default());
+        let mut run = empty_run(&ctx, &tenant);
+        let bucket = ProvisioningBucket {
+            name: "app-data".to_string(),
+            anonymous: Some(BucketAnonymousAccess::Private),
+            ..Default::default()
+        };
+
+        let item = reconcile_bucket(&mut run, &client, &bucket).await;
+
+        assert_eq!(item.state, ProvisioningItemState::Failed.as_str());
+        assert_eq!(item.reason, Reason::BucketPolicyConflict.as_str());
+        assert_eq!(delete_count.load(Ordering::SeqCst), 0);
+        server.abort();
+    }
+
+    #[tokio::test]
     async fn mixed_anonymous_and_custom_policy_fails_before_rustfs_calls() {
         let ctx = empty_kube_context();
         let user = provisioning_user("app-user", "app-user-secret", "readwrite");
@@ -4513,7 +4745,7 @@ mod tests {
         let client = RustfsAdminClient::new_with_base_url("http://127.0.0.1:1", "access", "secret");
         let bucket = ProvisioningBucket {
             name: "app-data".to_string(),
-            anonymous: BucketAnonymousAccess::Public,
+            anonymous: Some(BucketAnonymousAccess::Public),
             policy: Some(PolicyDocumentSource {
                 config_map_key_ref: ConfigMapKeyReference {
                     name: "bucket-policy".to_string(),

--- a/src/reconcile/provisioning.rs
+++ b/src/reconcile/provisioning.rs
@@ -1986,13 +1986,13 @@ async fn reconcile_bucket(
         return annotate_bucket_item(item, bucket);
     }
 
-    if bucket.has_custom_policy() && bucket.has_anonymous_access() {
+    if bucket.has_custom_policy() && bucket.has_non_private_anonymous_access() {
         let item = run.item(
             previous.as_ref(),
             &bucket.name,
             ProvisioningItemState::Failed,
             Reason::BucketPolicyConflict,
-            "bucket policy and anonymous access are mutually exclusive",
+            "bucket policy and non-private anonymous access are mutually exclusive",
         );
         return annotate_bucket_item(item, bucket);
     }
@@ -2075,10 +2075,11 @@ async fn reconcile_bucket(
         }
     };
 
-    if bucket
-        .anonymous
-        .as_ref()
-        .is_some_and(BucketAnonymousAccess::is_private)
+    if bucket.policy.is_none()
+        && bucket
+            .anonymous
+            .as_ref()
+            .is_some_and(BucketAnonymousAccess::is_private)
     {
         return reconcile_private_bucket_policy(
             run,
@@ -2091,13 +2092,19 @@ async fn reconcile_bucket(
     }
 
     let Some(desired) = desired_bucket_policy(run, bucket).await else {
-        let item = run.item(
+        let mut item = run.item(
             previous.as_ref(),
             &bucket.name,
             ProvisioningItemState::Ready,
             Reason::ProvisioningConfigured,
             created_message,
         );
+        item.last_applied_hash = previous
+            .as_ref()
+            .and_then(|item| item.last_applied_hash.clone());
+        item.last_applied_generation = previous
+            .as_ref()
+            .and_then(|item| item.last_applied_generation);
         return annotate_bucket_item(item, bucket);
     };
     let desired = match desired {
@@ -4669,8 +4676,22 @@ mod tests {
             ProvisioningItemState::Ready,
             Reason::ProvisioningConfigured.as_str(),
         );
-        previous.last_applied_hash = Some(live_hash);
+        previous.last_applied_hash = Some(live_hash.clone());
         run.previous.buckets.push(previous);
+        let omitted_bucket = ProvisioningBucket {
+            name: "app-data".to_string(),
+            ..Default::default()
+        };
+
+        let omitted_item = reconcile_bucket(&mut run, &client, &omitted_bucket).await;
+
+        assert_eq!(omitted_item.state, ProvisioningItemState::Ready.as_str());
+        assert_eq!(
+            omitted_item.last_applied_hash.as_deref(),
+            Some(live_hash.as_str())
+        );
+        let mut run = empty_run(&ctx, &tenant);
+        run.previous.buckets.push(omitted_item);
         let bucket = ProvisioningBucket {
             name: "app-data".to_string(),
             anonymous: Some(BucketAnonymousAccess::Private),

--- a/src/sts/s3_ops.rs
+++ b/src/sts/s3_ops.rs
@@ -229,4 +229,43 @@ impl RustfsAdminClient {
             status, &body, truncated,
         ))
     }
+
+    pub async fn delete_bucket_policy(&self, bucket: &str) -> Result<(), RustfsClientError> {
+        if bucket.trim().is_empty() {
+            return Err(RustfsClientError::RequestBuildFailed);
+        }
+
+        let path = format!("/{bucket}");
+        let query = build_canonical_query(&[("policy", "")]);
+        let signed = self.sign_request("DELETE", &path, &query, "", None, ADMIN_SIGNING_SERVICE)?;
+        let host = self.host()?;
+
+        let response = self
+            .http_client
+            .delete(format!(
+                "{}{}?{query}",
+                self.base_url.trim_end_matches('/'),
+                path
+            ))
+            .header("x-amz-date", &signed.amz_date)
+            .header("x-amz-content-sha256", &signed.payload_hash)
+            .header("authorization", &signed.authorization)
+            .header("host", host)
+            .send()
+            .await
+            .map_err(|_| RustfsClientError::RequestFailed)?;
+
+        if response.status().is_success() {
+            return Ok(());
+        }
+
+        let status = response.status();
+        let (body, truncated) = RustfsClientError::limited_response_body(response).await;
+        if is_absent_resource(status, &body) {
+            return Ok(());
+        }
+        Err(RustfsClientError::unexpected_status_with_limited_body(
+            status, &body, truncated,
+        ))
+    }
 }

--- a/src/sts/tests.rs
+++ b/src/sts/tests.rs
@@ -19,7 +19,7 @@ use axum::{
     body::Body,
     extract::State,
     http::{Request, StatusCode},
-    routing::{get, post, put},
+    routing::{delete, get, post, put},
 };
 use k8s_openapi::{ByteString, api::core::v1 as corev1};
 use serde_json::Value;
@@ -1315,5 +1315,26 @@ async fn put_bucket_policy_sends_json_document() {
     let policy = r#"{"Version":"2012-10-17","Statement":[]}"#;
     client.put_bucket_policy("app-data", policy).await.unwrap();
     assert_eq!(&*capture.lock().await, policy);
+    server.abort();
+}
+
+#[tokio::test]
+async fn delete_bucket_policy_sends_signed_policy_request() {
+    let router = Router::new().route(
+        "/app-data",
+        delete(|req: Request<Body>| async move {
+            assert_eq!(req.uri().query().unwrap_or(""), "policy=");
+            assert!(req.headers().contains_key("authorization"));
+            StatusCode::NO_CONTENT
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+        .await
+        .unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
+    let client = RustfsAdminClient::new_with_base_url(format!("http://{addr}"), "access", "secret");
+
+    client.delete_bucket_policy("app-data").await.unwrap();
     server.abort();
 }

--- a/src/types/v1alpha1.rs
+++ b/src/types/v1alpha1.rs
@@ -363,7 +363,11 @@ mod tenant_provisioning_crd_tests {
         );
         assert_eq!(
             spec["properties"]["buckets"]["items"]["x-kubernetes-validations"][0]["message"],
-            json!("bucket policy and anonymous access are mutually exclusive")
+            json!("bucket policy and non-private anonymous access are mutually exclusive")
+        );
+        assert_eq!(
+            spec["properties"]["buckets"]["items"]["x-kubernetes-validations"][0]["rule"],
+            json!("!(has(self.policy) && has(self.anonymous) && self.anonymous != 'Private')")
         );
     }
 }

--- a/src/types/v1alpha1.rs
+++ b/src/types/v1alpha1.rs
@@ -349,8 +349,17 @@ mod tenant_provisioning_crd_tests {
             json!(["IPv4", "IPv6"])
         );
         assert_eq!(
+            spec["properties"]["network"]["properties"]["ipFamilies"]["x-kubernetes-list-type"],
+            json!("atomic")
+        );
+        assert_eq!(
+            spec["properties"]["network"]["properties"]["ipFamilies"]["x-kubernetes-validations"]
+                [0]["message"],
+            json!("ipFamilies must not contain duplicates")
+        );
+        assert_eq!(
             spec["properties"]["buckets"]["items"]["properties"]["anonymous"]["enum"],
-            json!(["Private", "Download", "Upload", "Public"])
+            json!(["Private", "Download", "Upload", "Public", null])
         );
         assert_eq!(
             spec["properties"]["buckets"]["items"]["x-kubernetes-validations"][0]["message"],

--- a/src/types/v1alpha1/network.rs
+++ b/src/types/v1alpha1/network.rs
@@ -66,7 +66,8 @@ pub struct NetworkConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ip_family_policy: Option<IpFamilyPolicy>,
 
-    #[schemars(length(max = 2), extend("x-kubernetes-list-type" = "set"))]
+    #[schemars(length(max = 2), extend("x-kubernetes-list-type" = "atomic"))]
+    #[x_kube(validation = Rule::new("self.size() != 2 || self[0] != self[1]").message("ipFamilies must not contain duplicates"))]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub ip_families: Vec<IpFamily>,
 }

--- a/src/types/v1alpha1/provisioning.rs
+++ b/src/types/v1alpha1/provisioning.rs
@@ -139,13 +139,9 @@ impl BucketAnonymousAccess {
     }
 }
 
-fn skip_private_anonymous(value: &BucketAnonymousAccess) -> bool {
-    value.is_private()
-}
-
 #[derive(Deserialize, Serialize, Clone, Debug, KubeSchema, ToSchema, Default, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
-#[x_kube(validation = Rule::new("!(has(self.policy) && has(self.anonymous) && self.anonymous != 'Private')").message("bucket policy and anonymous access are mutually exclusive"))]
+#[x_kube(validation = Rule::new("!(has(self.policy) && has(self.anonymous))").message("bucket policy and anonymous access are mutually exclusive"))]
 pub struct ProvisioningBucket {
     #[schemars(
         length(min = MIN_BUCKET_NAME_LENGTH, max = MAX_BUCKET_NAME_LENGTH),
@@ -160,9 +156,10 @@ pub struct ProvisioningBucket {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub object_lock: Option<bool>,
 
-    /// Canned anonymous access for this bucket. Mutually exclusive with `policy`.
-    #[serde(default, skip_serializing_if = "skip_private_anonymous")]
-    pub anonymous: BucketAnonymousAccess,
+    /// Canned anonymous access for this bucket. Mutually exclusive with `policy`. Explicit
+    /// `Private` removes an operator-managed bucket policy; omission leaves the live policy alone.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub anonymous: Option<BucketAnonymousAccess>,
 
     /// Custom bucket policy document sourced from a ConfigMap. Mutually exclusive with `anonymous`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -182,7 +179,7 @@ impl ProvisioningBucket {
     }
 
     pub(crate) fn has_anonymous_access(&self) -> bool {
-        !self.anonymous.is_private()
+        self.anonymous.is_some()
     }
 }
 
@@ -249,7 +246,7 @@ mod tests {
     }
 
     #[test]
-    fn private_anonymous_access_is_omitted_from_serialized_bucket() {
+    fn omitted_and_explicit_private_anonymous_access_remain_distinct() {
         let bucket = super::ProvisioningBucket {
             name: "app-data".to_string(),
             ..Default::default()
@@ -257,6 +254,20 @@ mod tests {
         let value = serde_json::to_value(&bucket).expect("bucket serializes");
         assert!(value.get("anonymous").is_none());
         assert!(value.get("policy").is_none());
+
+        let private: super::ProvisioningBucket = serde_json::from_value(serde_json::json!({
+            "name": "app-data",
+            "anonymous": "Private"
+        }))
+        .expect("private anonymous deserializes");
+        assert_eq!(
+            private.anonymous,
+            Some(super::BucketAnonymousAccess::Private)
+        );
+        assert_eq!(
+            serde_json::to_value(&private).expect("private bucket serializes")["anonymous"],
+            "Private"
+        );
 
         let public: super::ProvisioningBucket = serde_json::from_value(serde_json::json!({
             "name": "app-data",

--- a/src/types/v1alpha1/provisioning.rs
+++ b/src/types/v1alpha1/provisioning.rs
@@ -141,7 +141,7 @@ impl BucketAnonymousAccess {
 
 #[derive(Deserialize, Serialize, Clone, Debug, KubeSchema, ToSchema, Default, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
-#[x_kube(validation = Rule::new("!(has(self.policy) && has(self.anonymous))").message("bucket policy and anonymous access are mutually exclusive"))]
+#[x_kube(validation = Rule::new("!(has(self.policy) && has(self.anonymous) && self.anonymous != 'Private')").message("bucket policy and non-private anonymous access are mutually exclusive"))]
 pub struct ProvisioningBucket {
     #[schemars(
         length(min = MIN_BUCKET_NAME_LENGTH, max = MAX_BUCKET_NAME_LENGTH),
@@ -156,12 +156,14 @@ pub struct ProvisioningBucket {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub object_lock: Option<bool>,
 
-    /// Canned anonymous access for this bucket. Mutually exclusive with `policy`. Explicit
-    /// `Private` removes an operator-managed bucket policy; omission leaves the live policy alone.
+    /// Canned anonymous access for this bucket. Non-private values are mutually exclusive with
+    /// `policy`. Explicit `Private` removes an operator-managed bucket policy when `policy` is
+    /// absent; omission leaves the live policy alone.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub anonymous: Option<BucketAnonymousAccess>,
 
-    /// Custom bucket policy document sourced from a ConfigMap. Mutually exclusive with `anonymous`.
+    /// Custom bucket policy document sourced from a ConfigMap. Mutually exclusive with non-private
+    /// `anonymous`; legacy `Private` plus `policy` configurations keep the custom policy.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub policy: Option<PolicyDocumentSource>,
 
@@ -178,8 +180,10 @@ impl ProvisioningBucket {
         self.policy.is_some()
     }
 
-    pub(crate) fn has_anonymous_access(&self) -> bool {
-        self.anonymous.is_some()
+    pub(crate) fn has_non_private_anonymous_access(&self) -> bool {
+        self.anonymous
+            .as_ref()
+            .is_some_and(|access| !access.is_private())
     }
 }
 
@@ -274,7 +278,22 @@ mod tests {
             "anonymous": "Public"
         }))
         .expect("public anonymous deserializes");
-        assert!(public.has_anonymous_access());
+        assert!(public.has_non_private_anonymous_access());
         assert!(!public.has_custom_policy());
+
+        let legacy_private_policy: super::ProvisioningBucket =
+            serde_json::from_value(serde_json::json!({
+                "name": "app-data",
+                "anonymous": "Private",
+                "policy": {
+                    "configMapKeyRef": {
+                        "name": "bucket-policy",
+                        "key": "policy.json"
+                    }
+                }
+            }))
+            .expect("legacy private plus policy configuration deserializes");
+        assert!(legacy_private_policy.has_custom_policy());
+        assert!(!legacy_private_policy.has_non_private_anonymous_access());
     }
 }


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
Follow-up to #233.

## Summary of Changes
- Distinguish omitted bucket anonymous access from explicit `Private`, and delete only bucket policies proven to be operator-managed.
- Preserve `ipFamilies` ordering in the Tenant CRD and safely recreate managed Services when the primary IP family changes.
- Add S3 policy deletion, reconciliation coverage, CRD assertions, upgrade documentation, and changelog entries.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit` (fmt-check + clippy + test + console-lint + console-fmt-check)
- [x] Added/updated necessary tests
- [x] Documentation updated (if needed)
- [x] CHANGELOG.md updated under `[Unreleased]` (if user-visible change)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (CRD/API compatibility)
- [x] Requires doc/config/deployment update
- [x] Other impact: changing the primary IP family briefly interrupts Tenant Service endpoints while managed Services are recreated.

## Verification
```bash
make pre-commit
```

## Additional Notes
Apply the updated Tenant CRD before upgrading the controller. Existing bucket policies without matching operator ownership status are preserved and reported as conflicts instead of being deleted.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
