### PR TITLE
fix: reject single-disk pools in multi-pool tenants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ All notable changes to RustFS Operator are documented in this file. The format i
 
 ### Fixed
 
+- Reject multi-pool Tenants containing a single-node single-disk pool before applying pool workloads, matching RustFS startup constraints.
+
 - Explicit private bucket access now removes operator-managed policies, and primary Service IP
   family changes recreate managed Services instead of repeatedly failing immutable-field updates.
 - Provisioning now requeues transient RustFS admin/S3 and Kubernetes failures instead of leaving

--- a/docs/operator-user-guide.md
+++ b/docs/operator-user-guide.md
@@ -655,6 +655,8 @@ The operator reserves these environment variables and manages them automatically
 
 For a single-pool single-node single-disk Tenant, `RUSTFS_VOLUMES` is rendered as the local data path, for example `/data/rustfs0`. Multi-pool tenants and other layouts render peer DNS URLs through the Tenant headless Service and are validated by RustFS at runtime. Set the Helm chart `clusterDomain` value when the Kubernetes cluster DNS domain is not `cluster.local`; the same domain is used for generated TLS SANs.
 
+Multi-pool Tenants cannot contain a single-node single-disk pool. The Operator rejects this topology before applying pool workloads, including expansion from a standalone single-node single-disk Tenant. Every pool in a multi-pool Tenant must have at least two storage endpoints (`servers × volumesPerServer >= 2`); different pool sizes and single-node multi-disk pools remain allowed, subject to RustFS erasure-set and parity validation.
+
 `podDeletionPolicyWhenNodeIsDown` accepts:
 
 - `DoNothing`: do not delete pods automatically.

--- a/docs/operator-user-guide.zh-CN.md
+++ b/docs/operator-user-guide.zh-CN.md
@@ -611,6 +611,8 @@ Operator 会自动管理以下环境变量：
 
 对于单 pool 的单节点单盘 Tenant，`RUSTFS_VOLUMES` 会渲染为本地数据路径，例如 `/data/rustfs0`。多 pool Tenant 和其他布局仍会通过 Tenant headless Service 渲染 peer DNS URL，并由 RustFS 在运行时校验。当 Kubernetes 集群 DNS 域不是 `cluster.local` 时，请设置 Helm chart 的 `clusterDomain`；自动生成的 TLS SAN 也会使用同一个域。
 
+多 pool Tenant 不能包含单节点单盘 pool。Operator 会在应用 pool 工作负载前拒绝这种拓扑，包括从独立单节点单盘 Tenant 新增 pool 的扩容操作。多 pool Tenant 中每个 pool 至少需要两个存储端点（`servers × volumesPerServer >= 2`）；不同大小的 pool 和单节点多盘 pool 仍然允许，但仍需满足 RustFS 的纠删码集合及 parity 校验。
+
 `podDeletionPolicyWhenNodeIsDown` 支持以下值：
 
 - `DoNothing`：不自动删除 Pod。

--- a/src/console/handlers/pools.rs
+++ b/src/console/handlers/pools.rs
@@ -1024,6 +1024,25 @@ mod tests {
     }
 
     #[test]
+    fn pool_addition_rejects_single_disk_pool_in_either_position() {
+        for (existing_disks, added_disks, rejected_name) in
+            [(1, 2, "pool-0"), (2, 1, "pool-1"), (1, 1, "pool-0")]
+        {
+            let mut tenant = crate::tests::create_test_tenant(None, None);
+            tenant.spec.pools[0].servers = 1;
+            tenant.spec.pools[0].persistence.volumes_per_server = existing_disks;
+            let mut new_pool = tenant.spec.pools[0].clone();
+            new_pool.name = "pool-1".to_string();
+            new_pool.persistence.volumes_per_server = added_disks;
+            let error = push_pool_and_validate_tenant(&mut tenant, new_pool)
+                .expect_err("unsupported expansion must be rejected before replace");
+            assert!(matches!(&error, Error::BadRequest { message }
+                if message.contains(rejected_name) && message.contains("at least two storage endpoints")));
+            assert_eq!(error.into_response().status(), StatusCode::BAD_REQUEST);
+        }
+    }
+
+    #[test]
     fn pool_addition_rejects_legacy_images_that_would_inherit_runtime_default_seccomp() {
         for image in ["rustfs/rustfs:1.0.0-alpha.99", "rustfs/rustfs:1.0.0-beta.8"] {
             let mut tenant = crate::tests::create_test_tenant(None, None);

--- a/src/console/handlers/tenants.rs
+++ b/src/console/handlers/tenants.rs
@@ -1002,6 +1002,40 @@ spec:
     }
 
     #[test]
+    fn json_create_rejects_single_disk_multi_pool_tenant() {
+        let mut request = minimal_create_request(None);
+        request.pools.push(CreatePoolRequest {
+            name: "pool-1".to_string(),
+            servers: 2,
+            volumes_per_server: 1,
+            storage_size: "1Gi".to_string(),
+            storage_class: None,
+        });
+        let error = tenant_from_create_request(request)
+            .expect_err("unsupported topology must be rejected before Kubernetes work");
+        assert!(matches!(error, Error::BadRequest { message }
+            if message.contains("pool-0") && message.contains("at least two storage endpoints")));
+    }
+
+    #[test]
+    fn yaml_create_and_update_reject_single_disk_multi_pool_tenant() {
+        let yaml = format!(
+            "{MINIMAL_TENANT_YAML}    - name: pool-1\n      servers: 1\n      persistence:\n        volumesPerServer: 1\n"
+        );
+        assert!(bad_request_message(&yaml).contains("at least two storage endpoints"));
+        let mut current = parse_tenant_yaml_for_create(MINIMAL_TENANT_YAML)
+            .expect("standalone single-disk tenant should be valid");
+        let mut incoming = current.clone();
+        let mut pool = incoming.spec.pools[0].clone();
+        pool.name = "pool-1".to_string();
+        incoming.spec.pools.push(pool);
+        let error = apply_tenant_yaml_update(&mut current, incoming)
+            .expect_err("unsupported expansion must be rejected before replace");
+        assert!(matches!(error, Error::BadRequest { message }
+            if message.contains("at least two storage endpoints")));
+    }
+
+    #[test]
     fn json_create_rejects_invalid_tenant_before_kubernetes_work() {
         let error = tenant_from_create_request(minimal_create_request(Some(
             "rustfs/rustfs:1.0.0-alpha.99",

--- a/src/reconcile/phases.rs
+++ b/src/reconcile/phases.rs
@@ -1502,6 +1502,69 @@ mod tests {
             .expect("response should build")
     }
 
+    #[tokio::test]
+    async fn single_disk_multi_pool_prerequisites_report_invalid_spec() {
+        use http_body_util::BodyExt;
+
+        let mut tenant = crate::tests::create_test_tenant(None, None);
+        tenant.spec.pools[0].servers = 1;
+        tenant.spec.pools[0].persistence.volumes_per_server = 1;
+        let mut pool = tenant.spec.pools[0].clone();
+        pool.name = "pool-1".to_string();
+        tenant.spec.pools.push(pool);
+        let status_patches = Arc::new(AtomicUsize::new(0));
+        let service = service_fn({
+            let tenant = tenant.clone();
+            let status_patches = Arc::clone(&status_patches);
+            move |request: Request<Body>| {
+                let tenant = tenant.clone();
+                let status_patches = Arc::clone(&status_patches);
+                async move {
+                    let path = request.uri().path().to_string();
+                    let is_status = path.ends_with("/tenants/test-tenant/status");
+                    assert!(
+                        is_status || path.contains("/events"),
+                        "unexpected prerequisite request: {path}"
+                    );
+                    let body = request.into_body().collect().await.unwrap().to_bytes();
+                    let payload: Value = serde_json::from_slice(&body).unwrap();
+                    if is_status {
+                        assert!(
+                            payload["status"]["conditions"]
+                                .as_array()
+                                .unwrap()
+                                .iter()
+                                .any(|condition| {
+                                    condition["type"] == "SpecValid"
+                                        && condition["status"] == "False"
+                                        && condition["reason"] == "InvalidPoolSpec"
+                                        && condition["message"].as_str().unwrap().contains("pool-0")
+                                })
+                        );
+                        status_patches.fetch_add(1, Ordering::SeqCst);
+                        Ok::<_, Infallible>(kube_response(
+                            StatusCode::OK,
+                            serde_json::to_value(tenant).unwrap(),
+                        ))
+                    } else {
+                        Ok(kube_response(StatusCode::OK, payload))
+                    }
+                }
+            }
+        });
+        let ctx = Context::new(Client::new(service, "default"));
+        let error = validate_tenant_prerequisites(&ctx, &tenant)
+            .await
+            .expect_err("unsupported topology must stop reconciliation");
+        assert!(matches!(
+            error,
+            Error::Types {
+                source: crate::types::error::Error::InvalidPoolSpec { .. }
+            }
+        ));
+        assert_eq!(status_patches.load(Ordering::SeqCst), 1);
+    }
+
     fn operator_managed_fields() -> Vec<ManagedFieldsEntry> {
         vec![ManagedFieldsEntry {
             manager: Some("rustfs-operator".to_string()),

--- a/src/types/v1alpha1/pool.rs
+++ b/src/types/v1alpha1/pool.rs
@@ -141,6 +141,17 @@ pub fn validate_pool_collection(tenant_name: &str, pools: &[Pool]) -> Result<(),
         validate_rustfs_peer_dns_label(tenant_name, pool)?;
     }
 
+    // RustFS permits a single disk only through its standalone local-path layout.
+    // Multi-pool URL layouts require at least two storage endpoints in each pool.
+    if pools.len() > 1
+        && let Some(pool) = pools.iter().find(|pool| pool.is_single_node_single_disk())
+    {
+        return Err(format!(
+            "pool '{}' has only one storage endpoint; RustFS does not support single-node single-disk pools in a multi-pool tenant. Each pool must contain at least two storage endpoints",
+            pool.name
+        ));
+    }
+
     Ok(())
 }
 
@@ -218,6 +229,35 @@ mod tests {
         ];
 
         assert!(validate_pool_collection("tenant", &pools).is_ok());
+    }
+
+    #[test]
+    fn allows_standalone_single_disk_pool() {
+        assert!(validate_pool_collection("tenant", &[test_pool("pool-0", 1, 1)]).is_ok());
+    }
+
+    #[test]
+    fn rejects_single_disk_pools_in_multi_pool_layouts() {
+        for shapes in [
+            vec![(1, 1), (1, 1)],
+            vec![(1, 1), (2, 1)],
+            vec![(2, 1), (3, 1), (1, 1), (1, 1)],
+        ] {
+            let pools: Vec<_> = shapes
+                .iter()
+                .enumerate()
+                .map(|(index, &(servers, disks))| {
+                    test_pool(&format!("pool-{index}"), servers, disks)
+                })
+                .collect();
+            let rejected = pools
+                .iter()
+                .find(|pool| pool.is_single_node_single_disk())
+                .unwrap();
+            let err = validate_pool_collection("tenant", &pools).unwrap_err();
+            assert!(err.contains(&format!("pool '{}'", rejected.name)));
+            assert!(err.contains("at least two storage endpoints"));
+        }
     }
 
     #[test]

--- a/src/types/v1alpha1/tenant/workloads.rs
+++ b/src/types/v1alpha1/tenant/workloads.rs
@@ -968,6 +968,7 @@ impl Tenant {
         scheme: &str,
         cluster_domain: &str,
     ) -> Result<String, types::error::Error> {
+        self.validate_pools()?;
         let namespace = self.namespace()?;
         let volume_specs = self
             .spec
@@ -3029,32 +3030,24 @@ mod tests {
     }
 
     #[test]
-    fn mixed_pool_single_node_single_disk_uses_peer_dns_volume() {
+    fn mixed_pool_single_node_single_disk_rejects_statefulset_generation() {
         let mut tenant = crate::tests::create_test_tenant(None, None);
         tenant.spec.pools[0].servers = 1;
         tenant.spec.pools[0].persistence.volumes_per_server = 1;
         let mut second_pool = tenant.spec.pools[0].clone();
         second_pool.name = "pool-1".to_string();
         second_pool.servers = 2;
-        second_pool.persistence.volumes_per_server = 1;
         tenant.spec.pools.push(second_pool);
-        let pool = &tenant.spec.pools[1];
 
-        let statefulset = tenant
-            .new_statefulset(pool)
-            .expect("Should create StatefulSet for mixed pools");
-
-        let pod_spec = statefulset.spec.unwrap().template.spec.unwrap();
-        let container = &pod_spec.containers[0];
-        let rustfs_volumes =
-            env_value(container, "RUSTFS_VOLUMES").expect("RUSTFS_VOLUMES should be configured");
-        assert!(!rustfs_volumes.starts_with("/data/rustfs0"));
-        assert!(rustfs_volumes.contains(
-            "http://test-tenant-pool-0-{0...0}.test-tenant-hl.default.svc.cluster.local:9000/data/rustfs{0...0}"
-        ));
-        assert!(rustfs_volumes.contains(
-            "http://test-tenant-pool-1-{0...1}.test-tenant-hl.default.svc.cluster.local:9000/data/rustfs{0...0}"
-        ));
+        for pool in &tenant.spec.pools {
+            let error = tenant
+                .new_statefulset(pool)
+                .expect_err("invalid topology must not render workloads for either pool");
+            assert!(
+                matches!(error, crate::types::error::Error::InvalidPoolSpec { message, .. }
+                if message.contains("pool-0") && message.contains("at least two storage endpoints"))
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [x] Documentation
- [ ] Performance Improvement
- [x] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues

Related to rustfs/rustfs#6186. This addresses Operator validation; it does not add single-disk multi-pool support to RustFS.

## Summary of Changes

A Tenant containing a single-node single-disk pool alongside another pool currently renders URLs that RustFS rejects with `Incorrect number of endpoints provided, size 1`. Adding a second pool to a standalone single-disk Tenant has the same problem.

Reject these topologies in the existing pool collection validator, shared by Console create/update/pool-add operations and reconciliation. Validate at the volume rendering boundary as well so StatefulSet generation cannot emit the unsupported configuration. Preserve standalone single-disk Tenants, heterogeneous multi-disk pools, and RustFS runtime validation of other erasure-set and parity constraints.

Add regression coverage for JSON/YAML creation, YAML expansion, pool addition in either direction, workload generation, and the reconcile `SpecValid=False` / `InvalidPoolSpec` status. Document the restriction in both user guides and the changelog.

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit` (fmt-check + clippy + test + console-lint + console-fmt-check)
- [x] Added/updated necessary tests
- [x] Documentation updated (if needed)
- [x] CHANGELOG.md updated under `[Unreleased]` (if user-visible change)
- [ ] CI/CD passed (if applicable)

## Impact

- [ ] Breaking change (CRD/API compatibility)
- [x] Requires doc/config/deployment update
- [x] Other impact: previously accepted but unsupported single-disk multi-pool specifications are rejected before pool workloads are applied.

No CRD schema or RustFS changes. Console writes return a bad request. Direct Kubernetes submissions are reported as invalid by reconciliation before pool creation or volume configuration updates. Existing standalone single-disk Tenants remain supported; expanding them by adding a pool is rejected.

## Verification

```bash
make -j4 pre-commit
git diff --check
```

The full local gate includes Rust tests, Clippy, formatting, e2e harness checks, and frontend tests/lint/build/format checks. Live Kubernetes tests were not run; the reconcile regression uses a mocked Kubernetes API.

## Additional Notes

The rule mirrors RustFS's current layout parser: expanded pools require at least two endpoints, while standalone single-disk deployments use the local-path exception. It deliberately does not impose equal pool sizes or duplicate the full RustFS erasure layout algorithm.
