### PR TITLE
feat(provisioning): manage bucket lifecycle rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to RustFS Operator are documented in this file. The format i
   for operator observability, STS, and Console sockets.
 - Tenant `spec.hostUsers` and OpenShift `hostUsers: false` defaults for `restricted-v3`.
 - Tenant bucket canned anonymous access and ConfigMap-sourced bucket policies.
+- Declarative Tenant bucket lifecycle rules with drift-aware ownership and explicit removal.
 - Helm chart `cosiDriver.enabled` to deploy the RustFS COSI (`rustfs.objectstorage.k8s.io`)
   driver alongside the upstream provisioner sidecar, with dedicated ServiceAccount/RBAC.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2208,6 +2208,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
 
 [[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2549,6 +2558,7 @@ dependencies = [
  "chrono",
  "hex",
  "hmac",
+ "quick-xml",
  "reqwest",
  "serde",
  "serde_json",

--- a/console-web/types/api.ts
+++ b/console-web/types/api.ts
@@ -126,7 +126,29 @@ export interface ProvisioningBucket {
   name: string
   region?: string
   objectLock?: boolean
+  anonymous?: "Private" | "Download" | "Upload" | "Public"
+  policy?: PolicyDocumentSource
+  lifecycle?: BucketLifecycleSpec
   deletionPolicy?: ProvisioningDeletionPolicy
+}
+
+export interface BucketLifecycleSpec {
+  state: "Present" | "Absent"
+  rules?: BucketLifecycleRule[]
+}
+
+export interface BucketLifecycleRule {
+  id: string
+  status: "Enabled" | "Disabled"
+  filter: {
+    prefix: string
+  }
+  expiration?: {
+    days: number
+  }
+  abortIncompleteMultipartUpload?: {
+    daysAfterInitiation: number
+  }
 }
 
 export interface ProvisioningItemStatus {
@@ -146,12 +168,17 @@ export interface ProvisioningItemStatus {
   objectLock?: boolean | null
 }
 
+export interface ProvisioningBucketStatus extends ProvisioningItemStatus {
+  lifecycleDesiredHash?: string | null
+  lifecycleLastAppliedHash?: string | null
+}
+
 export interface ProvisioningStatus {
   observedGeneration?: number | null
   phase?: "Pending" | "Ready" | "Failed"
   policies?: ProvisioningItemStatus[]
   users?: ProvisioningItemStatus[]
-  buckets?: ProvisioningItemStatus[]
+  buckets?: ProvisioningBucketStatus[]
 }
 
 export interface CreatePoolRequest {

--- a/crates/rustfs-admin/Cargo.toml
+++ b/crates/rustfs-admin/Cargo.toml
@@ -23,6 +23,7 @@ publish = false
 chrono = "0.4"
 hex = "0.4"
 hmac = "0.12"
+quick-xml = "0.38"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/rustfs-admin/src/lib.rs
+++ b/crates/rustfs-admin/src/lib.rs
@@ -32,6 +32,11 @@ mod pool_ops;
 /// s3_ops: bucket/object-lock operations for S3-compatible endpoints.
 #[path = "s3_ops.rs"]
 mod s3_ops;
+pub use s3_ops::{
+    BucketLifecycleAbortIncompleteMultipartUpload, BucketLifecycleConfiguration,
+    BucketLifecycleExpiration, BucketLifecycleRule, BucketLifecycleRuleStatus,
+    canonicalize_bucket_lifecycle_xml,
+};
 /// sts_ops: temporary credential flows.
 #[path = "sts_ops.rs"]
 mod sts_ops;
@@ -227,6 +232,7 @@ pub enum RustfsClientError {
         status: StatusCode,
         detail: Option<String>,
     },
+    InvalidLifecycleConfigurationResponse,
     ParseResponseFailed,
     SigningFailed,
 }
@@ -267,6 +273,9 @@ impl std::fmt::Display for RustfsClientError {
                     write!(f, ": {detail}")?;
                 }
                 Ok(())
+            }
+            Self::InvalidLifecycleConfigurationResponse => {
+                write!(f, "invalid bucket lifecycle configuration response")
             }
             Self::ParseResponseFailed => write!(f, "failed to parse AssumeRole response"),
             Self::SigningFailed => write!(f, "failed to compute request signature"),
@@ -312,6 +321,7 @@ impl RustfsClientError {
             | Self::InvalidTenantTlsCa
             | Self::TlsClientBuildFailed
             | Self::RequestBuildFailed
+            | Self::InvalidLifecycleConfigurationResponse
             | Self::SigningFailed => false,
         }
     }

--- a/crates/rustfs-admin/src/s3_ops.rs
+++ b/crates/rustfs-admin/src/s3_ops.rs
@@ -18,10 +18,229 @@
 
 use super::helpers::{
     BucketConflictKind, body_mentions_not_found, bucket_conflict_kind, build_canonical_query,
-    create_bucket_body, is_absent_resource,
+    create_bucket_body, escape_xml, is_absent_resource,
 };
 use super::{ADMIN_SIGNING_SERVICE, CreateBucketResult, RustfsAdminClient, RustfsClientError};
+use quick_xml::Reader;
+use quick_xml::events::{BytesStart, Event};
 use reqwest::StatusCode;
+
+const S3_XML_NAMESPACE: &str = "http://s3.amazonaws.com/doc/2006-03-01/";
+const MAX_BUCKET_LIFECYCLE_RESPONSE_BYTES: usize = 4 * 1024 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BucketLifecycleRuleStatus {
+    Enabled,
+    Disabled,
+}
+
+impl BucketLifecycleRuleStatus {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Enabled => "Enabled",
+            Self::Disabled => "Disabled",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BucketLifecycleExpiration {
+    pub days: i32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BucketLifecycleAbortIncompleteMultipartUpload {
+    pub days_after_initiation: i32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BucketLifecycleRule {
+    pub id: String,
+    pub status: BucketLifecycleRuleStatus,
+    pub prefix: String,
+    pub expiration: Option<BucketLifecycleExpiration>,
+    pub abort_incomplete_multipart_upload: Option<BucketLifecycleAbortIncompleteMultipartUpload>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BucketLifecycleConfiguration {
+    pub rules: Vec<BucketLifecycleRule>,
+}
+
+impl BucketLifecycleConfiguration {
+    pub fn to_xml(&self) -> String {
+        let mut rules = self.rules.iter().collect::<Vec<_>>();
+        rules.sort_unstable_by(|left, right| left.id.cmp(&right.id));
+
+        let mut xml = format!("<LifecycleConfiguration xmlns=\"{S3_XML_NAMESPACE}\">");
+        for rule in rules {
+            xml.push_str("<Rule>");
+            if let Some(abort) = &rule.abort_incomplete_multipart_upload {
+                xml.push_str("<AbortIncompleteMultipartUpload><DaysAfterInitiation>");
+                xml.push_str(&abort.days_after_initiation.to_string());
+                xml.push_str("</DaysAfterInitiation></AbortIncompleteMultipartUpload>");
+            }
+            if let Some(expiration) = &rule.expiration {
+                xml.push_str("<Expiration><Days>");
+                xml.push_str(&expiration.days.to_string());
+                xml.push_str("</Days></Expiration>");
+            }
+            xml.push_str("<Filter>");
+            if !rule.prefix.is_empty() {
+                xml.push_str("<Prefix>");
+                xml.push_str(&escape_xml(&rule.prefix));
+                xml.push_str("</Prefix>");
+            }
+            xml.push_str("</Filter><ID>");
+            xml.push_str(&escape_xml(&rule.id));
+            xml.push_str("</ID><Status>");
+            xml.push_str(rule.status.as_str());
+            xml.push_str("</Status></Rule>");
+        }
+        xml.push_str("</LifecycleConfiguration>");
+        xml
+    }
+}
+
+/// Produces a stable representation for lifecycle ownership checks. Namespace declarations,
+/// formatting whitespace, and empty-element spelling are normalized, while unknown lifecycle
+/// elements and attributes remain part of the result so the operator cannot silently adopt them.
+pub fn canonicalize_bucket_lifecycle_xml(xml: &str) -> Result<String, RustfsClientError> {
+    let mut reader = Reader::from_str(xml);
+    let mut canonical = String::new();
+    let mut elements = Vec::new();
+    let mut saw_root = false;
+
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(element)) => {
+                let name = element_local_name(element.name().as_ref())?;
+                if elements.is_empty() {
+                    if saw_root || name != "LifecycleConfiguration" {
+                        return Err(RustfsClientError::InvalidLifecycleConfigurationResponse);
+                    }
+                    saw_root = true;
+                }
+                append_start_element(&mut canonical, &element, &reader)?;
+                elements.push(name);
+            }
+            Ok(Event::Empty(element)) => {
+                let name = element_local_name(element.name().as_ref())?;
+                if elements.is_empty() {
+                    if saw_root || name != "LifecycleConfiguration" {
+                        return Err(RustfsClientError::InvalidLifecycleConfigurationResponse);
+                    }
+                    saw_root = true;
+                }
+                append_start_element(&mut canonical, &element, &reader)?;
+                canonical.push_str("</");
+                canonical.push_str(&name);
+                canonical.push('>');
+            }
+            Ok(Event::End(element)) => {
+                let name = element_local_name(element.name().as_ref())?;
+                if elements.pop().as_deref() != Some(name.as_str()) {
+                    return Err(RustfsClientError::InvalidLifecycleConfigurationResponse);
+                }
+                canonical.push_str("</");
+                canonical.push_str(&name);
+                canonical.push('>');
+            }
+            Ok(Event::Text(text)) => {
+                let text = std::str::from_utf8(text.as_ref())
+                    .map_err(|_| RustfsClientError::InvalidLifecycleConfigurationResponse)?;
+                if !text.trim().is_empty() {
+                    if elements.is_empty() {
+                        return Err(RustfsClientError::InvalidLifecycleConfigurationResponse);
+                    }
+                    canonical.push_str(text);
+                }
+            }
+            Ok(Event::CData(text)) => {
+                if elements.is_empty() {
+                    return Err(RustfsClientError::InvalidLifecycleConfigurationResponse);
+                }
+                let text = std::str::from_utf8(text.as_ref())
+                    .map_err(|_| RustfsClientError::InvalidLifecycleConfigurationResponse)?;
+                canonical.push_str("<![CDATA[");
+                canonical.push_str(text);
+                canonical.push_str("]]>");
+            }
+            Ok(Event::Decl(_) | Event::Comment(_) | Event::PI(_)) => {}
+            Ok(Event::DocType(_) | Event::GeneralRef(_)) => {
+                return Err(RustfsClientError::InvalidLifecycleConfigurationResponse);
+            }
+            Ok(Event::Eof) => break,
+            Err(_) => return Err(RustfsClientError::InvalidLifecycleConfigurationResponse),
+        }
+    }
+
+    if !saw_root || !elements.is_empty() {
+        return Err(RustfsClientError::InvalidLifecycleConfigurationResponse);
+    }
+    Ok(canonical)
+}
+
+async fn read_bucket_lifecycle_response(
+    mut response: reqwest::Response,
+) -> Result<String, RustfsClientError> {
+    let mut body = Vec::new();
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|_| RustfsClientError::RequestFailed)?
+    {
+        if body.len().saturating_add(chunk.len()) > MAX_BUCKET_LIFECYCLE_RESPONSE_BYTES {
+            return Err(RustfsClientError::InvalidLifecycleConfigurationResponse);
+        }
+        body.extend_from_slice(&chunk);
+    }
+    String::from_utf8(body).map_err(|_| RustfsClientError::InvalidLifecycleConfigurationResponse)
+}
+
+fn append_start_element(
+    canonical: &mut String,
+    element: &BytesStart<'_>,
+    reader: &Reader<&[u8]>,
+) -> Result<(), RustfsClientError> {
+    let name = element_local_name(element.name().as_ref())?;
+    let attributes = element
+        .attributes()
+        .map(|attribute| {
+            let attribute =
+                attribute.map_err(|_| RustfsClientError::InvalidLifecycleConfigurationResponse)?;
+            if attribute.key.as_ref() == b"xmlns" || attribute.key.as_ref().starts_with(b"xmlns:") {
+                return Ok(None);
+            }
+            let key = element_local_name(attribute.key.as_ref())?;
+            let value = attribute
+                .decode_and_unescape_value(reader.decoder())
+                .map_err(|_| RustfsClientError::InvalidLifecycleConfigurationResponse)?;
+            Ok(Some((key, value.into_owned())))
+        })
+        .collect::<Result<Vec<_>, RustfsClientError>>()?;
+    let mut attributes = attributes.into_iter().flatten().collect::<Vec<_>>();
+    attributes.sort_unstable();
+
+    canonical.push('<');
+    canonical.push_str(&name);
+    for (key, value) in attributes {
+        canonical.push(' ');
+        canonical.push_str(&key);
+        canonical.push_str("=\"");
+        canonical.push_str(&escape_xml(&value));
+        canonical.push('"');
+    }
+    canonical.push('>');
+    Ok(())
+}
+
+fn element_local_name(name: &[u8]) -> Result<String, RustfsClientError> {
+    let name = name.rsplit(|byte| *byte == b':').next().unwrap_or(name);
+    std::str::from_utf8(name)
+        .map(str::to_string)
+        .map_err(|_| RustfsClientError::InvalidLifecycleConfigurationResponse)
+}
 
 impl RustfsAdminClient {
     // S3 duties: bucket operations exposed by the RustFS/S3-compatible endpoint.
@@ -309,5 +528,259 @@ impl RustfsAdminClient {
         Err(RustfsClientError::unexpected_status_with_limited_body(
             status, &body, truncated,
         ))
+    }
+
+    pub async fn put_bucket_lifecycle_configuration(
+        &self,
+        bucket: &str,
+        configuration: &BucketLifecycleConfiguration,
+    ) -> Result<(), RustfsClientError> {
+        if bucket.trim().is_empty() || configuration.rules.is_empty() {
+            return Err(RustfsClientError::RequestBuildFailed);
+        }
+
+        let path = format!("/{bucket}");
+        let query = build_canonical_query(&[("lifecycle", "")]);
+        let body = configuration.to_xml();
+        let signed = self.sign_request(
+            "PUT",
+            &path,
+            &query,
+            &body,
+            Some("application/xml"),
+            ADMIN_SIGNING_SERVICE,
+        )?;
+        let host = self.host()?;
+        let response = self
+            .http_client
+            .put(format!(
+                "{}{}?{query}",
+                self.base_url.trim_end_matches('/'),
+                path
+            ))
+            .header("x-amz-date", &signed.amz_date)
+            .header("x-amz-content-sha256", &signed.payload_hash)
+            .header("authorization", &signed.authorization)
+            .header("host", host)
+            .header("content-type", "application/xml")
+            .body(body)
+            .send()
+            .await
+            .map_err(|_| RustfsClientError::RequestFailed)?;
+
+        if response.status().is_success() {
+            return Ok(());
+        }
+        Err(RustfsClientError::unexpected_response(response).await)
+    }
+
+    pub async fn get_bucket_lifecycle_configuration(
+        &self,
+        bucket: &str,
+    ) -> Result<Option<String>, RustfsClientError> {
+        if bucket.trim().is_empty() {
+            return Err(RustfsClientError::RequestBuildFailed);
+        }
+
+        let path = format!("/{bucket}");
+        let query = build_canonical_query(&[("lifecycle", "")]);
+        let signed = self.sign_request("GET", &path, &query, "", None, ADMIN_SIGNING_SERVICE)?;
+        let host = self.host()?;
+        let response = self
+            .http_client
+            .get(format!(
+                "{}{}?{query}",
+                self.base_url.trim_end_matches('/'),
+                path
+            ))
+            .header("x-amz-date", &signed.amz_date)
+            .header("x-amz-content-sha256", &signed.payload_hash)
+            .header("authorization", &signed.authorization)
+            .header("host", host)
+            .send()
+            .await
+            .map_err(|_| RustfsClientError::RequestFailed)?;
+
+        if response.status().is_success() {
+            let body = read_bucket_lifecycle_response(response).await?;
+            if body.trim().is_empty() {
+                return Ok(None);
+            }
+            return Ok(Some(body));
+        }
+
+        let status = response.status();
+        let (body, truncated) = RustfsClientError::limited_response_body(response).await;
+        if is_absent_resource(status, &body) {
+            return Ok(None);
+        }
+        Err(RustfsClientError::unexpected_status_with_limited_body(
+            status, &body, truncated,
+        ))
+    }
+
+    pub async fn delete_bucket_lifecycle_configuration(
+        &self,
+        bucket: &str,
+    ) -> Result<(), RustfsClientError> {
+        if bucket.trim().is_empty() {
+            return Err(RustfsClientError::RequestBuildFailed);
+        }
+
+        let path = format!("/{bucket}");
+        let query = build_canonical_query(&[("lifecycle", "")]);
+        let signed = self.sign_request("DELETE", &path, &query, "", None, ADMIN_SIGNING_SERVICE)?;
+        let host = self.host()?;
+        let response = self
+            .http_client
+            .delete(format!(
+                "{}{}?{query}",
+                self.base_url.trim_end_matches('/'),
+                path
+            ))
+            .header("x-amz-date", &signed.amz_date)
+            .header("x-amz-content-sha256", &signed.payload_hash)
+            .header("authorization", &signed.authorization)
+            .header("host", host)
+            .send()
+            .await
+            .map_err(|_| RustfsClientError::RequestFailed)?;
+
+        if response.status().is_success() {
+            return Ok(());
+        }
+        let status = response.status();
+        let (body, truncated) = RustfsClientError::limited_response_body(response).await;
+        if is_absent_resource(status, &body) {
+            return Ok(());
+        }
+        Err(RustfsClientError::unexpected_status_with_limited_body(
+            status, &body, truncated,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lifecycle_xml_is_stable_and_escapes_values() {
+        let configuration = BucketLifecycleConfiguration {
+            rules: vec![
+                BucketLifecycleRule {
+                    id: "z<&".to_string(),
+                    status: BucketLifecycleRuleStatus::Enabled,
+                    prefix: "logs/<".to_string(),
+                    expiration: Some(BucketLifecycleExpiration { days: 30 }),
+                    abort_incomplete_multipart_upload: None,
+                },
+                BucketLifecycleRule {
+                    id: "a".to_string(),
+                    status: BucketLifecycleRuleStatus::Disabled,
+                    prefix: String::new(),
+                    expiration: None,
+                    abort_incomplete_multipart_upload: Some(
+                        BucketLifecycleAbortIncompleteMultipartUpload {
+                            days_after_initiation: 1,
+                        },
+                    ),
+                },
+            ],
+        };
+
+        let xml = configuration.to_xml();
+        assert!(xml.find("<ID>a</ID>").unwrap() < xml.find("<ID>z&lt;&amp;</ID>").unwrap());
+        assert!(xml.contains("<Filter></Filter><ID>a</ID>"));
+        assert!(xml.contains("<Prefix>logs/&lt;</Prefix>"));
+    }
+
+    #[test]
+    fn lifecycle_xml_matches_rustfs_get_response_shape() {
+        let configuration = BucketLifecycleConfiguration {
+            rules: vec![
+                BucketLifecycleRule {
+                    id: "expire-old-logs".to_string(),
+                    status: BucketLifecycleRuleStatus::Enabled,
+                    prefix: "logs/".to_string(),
+                    expiration: Some(BucketLifecycleExpiration { days: 30 }),
+                    abort_incomplete_multipart_upload: None,
+                },
+                BucketLifecycleRule {
+                    id: "cleanup-incomplete-uploads".to_string(),
+                    status: BucketLifecycleRuleStatus::Enabled,
+                    prefix: String::new(),
+                    expiration: None,
+                    abort_incomplete_multipart_upload: Some(
+                        BucketLifecycleAbortIncompleteMultipartUpload {
+                            days_after_initiation: 1,
+                        },
+                    ),
+                },
+            ],
+        };
+        let rustfs_get_fixture = concat!(
+            "<LifecycleConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">",
+            "<Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>1</DaysAfterInitiation>",
+            "</AbortIncompleteMultipartUpload><Filter></Filter>",
+            "<ID>cleanup-incomplete-uploads</ID><Status>Enabled</Status></Rule>",
+            "<Rule><Expiration><Days>30</Days></Expiration>",
+            "<Filter><Prefix>logs/</Prefix></Filter><ID>expire-old-logs</ID>",
+            "<Status>Enabled</Status></Rule></LifecycleConfiguration>"
+        );
+
+        assert_eq!(
+            canonicalize_bucket_lifecycle_xml(&configuration.to_xml()).unwrap(),
+            canonicalize_bucket_lifecycle_xml(rustfs_get_fixture).unwrap()
+        );
+    }
+
+    #[test]
+    fn lifecycle_canonicalization_normalizes_transport_formatting() {
+        let compact = concat!(
+            "<LifecycleConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">",
+            "<Rule><Filter></Filter><ID>all</ID><Status>Enabled</Status></Rule>",
+            "</LifecycleConfiguration>"
+        );
+        let formatted = concat!(
+            "<?xml version=\"1.0\"?>\n",
+            "<s3:LifecycleConfiguration xmlns:s3=\"http://s3.amazonaws.com/doc/2006-03-01/\">\n",
+            "  <s3:Rule><s3:Filter/><s3:ID>all</s3:ID><s3:Status>Enabled</s3:Status></s3:Rule>\n",
+            "</s3:LifecycleConfiguration>"
+        );
+
+        assert_eq!(
+            canonicalize_bucket_lifecycle_xml(compact).unwrap(),
+            canonicalize_bucket_lifecycle_xml(formatted).unwrap()
+        );
+    }
+
+    #[test]
+    fn lifecycle_canonicalization_preserves_unknown_actions() {
+        let desired = concat!(
+            "<LifecycleConfiguration><Rule><Filter></Filter><ID>all</ID>",
+            "<Status>Enabled</Status></Rule></LifecycleConfiguration>"
+        );
+        let live = concat!(
+            "<LifecycleConfiguration><Rule><Filter></Filter><ID>all</ID>",
+            "<Status>Enabled</Status><Transition><Days>7</Days>",
+            "<StorageClass>WARM</StorageClass></Transition></Rule></LifecycleConfiguration>"
+        );
+
+        assert_ne!(
+            canonicalize_bucket_lifecycle_xml(desired).unwrap(),
+            canonicalize_bucket_lifecycle_xml(live).unwrap()
+        );
+    }
+
+    #[test]
+    fn lifecycle_canonicalization_rejects_malformed_or_wrong_root_xml() {
+        assert!(canonicalize_bucket_lifecycle_xml("<Rule></Rule>").is_err());
+        assert!(
+            canonicalize_bucket_lifecycle_xml(
+                "<LifecycleConfiguration><Rule></LifecycleConfiguration>",
+            )
+            .is_err()
+        );
     }
 }

--- a/crates/rustfs-admin/src/s3_ops.rs
+++ b/crates/rustfs-admin/src/s3_ops.rs
@@ -22,7 +22,8 @@ use super::helpers::{
 };
 use super::{ADMIN_SIGNING_SERVICE, CreateBucketResult, RustfsAdminClient, RustfsClientError};
 use quick_xml::Reader;
-use quick_xml::events::{BytesStart, Event};
+use quick_xml::escape::resolve_xml_entity;
+use quick_xml::events::{BytesCData, BytesRef, BytesStart, BytesText, Event};
 use reqwest::StatusCode;
 
 const S3_XML_NAMESPACE: &str = "http://s3.amazonaws.com/doc/2006-03-01/";
@@ -108,7 +109,7 @@ impl BucketLifecycleConfiguration {
 pub fn canonicalize_bucket_lifecycle_xml(xml: &str) -> Result<String, RustfsClientError> {
     let mut reader = Reader::from_str(xml);
     let mut canonical = String::new();
-    let mut elements = Vec::new();
+    let mut elements = Vec::<CanonicalElement>::new();
     let mut saw_root = false;
 
     loop {
@@ -120,9 +121,11 @@ pub fn canonicalize_bucket_lifecycle_xml(xml: &str) -> Result<String, RustfsClie
                         return Err(RustfsClientError::InvalidLifecycleConfigurationResponse);
                     }
                     saw_root = true;
+                } else if let Some(parent) = elements.last_mut() {
+                    parent.start_child(&mut canonical);
                 }
                 append_start_element(&mut canonical, &element, &reader)?;
-                elements.push(name);
+                elements.push(CanonicalElement::new(name));
             }
             Ok(Event::Empty(element)) => {
                 let name = element_local_name(element.name().as_ref())?;
@@ -131,6 +134,8 @@ pub fn canonicalize_bucket_lifecycle_xml(xml: &str) -> Result<String, RustfsClie
                         return Err(RustfsClientError::InvalidLifecycleConfigurationResponse);
                     }
                     saw_root = true;
+                } else if let Some(parent) = elements.last_mut() {
+                    parent.start_child(&mut canonical);
                 }
                 append_start_element(&mut canonical, &element, &reader)?;
                 canonical.push_str("</");
@@ -139,35 +144,43 @@ pub fn canonicalize_bucket_lifecycle_xml(xml: &str) -> Result<String, RustfsClie
             }
             Ok(Event::End(element)) => {
                 let name = element_local_name(element.name().as_ref())?;
-                if elements.pop().as_deref() != Some(name.as_str()) {
+                let Some(mut current) = elements.pop() else {
+                    return Err(RustfsClientError::InvalidLifecycleConfigurationResponse);
+                };
+                if current.name != name {
                     return Err(RustfsClientError::InvalidLifecycleConfigurationResponse);
                 }
+                current.finish(&mut canonical);
                 canonical.push_str("</");
                 canonical.push_str(&name);
                 canonical.push('>');
             }
             Ok(Event::Text(text)) => {
-                let text = std::str::from_utf8(text.as_ref())
-                    .map_err(|_| RustfsClientError::InvalidLifecycleConfigurationResponse)?;
-                if !text.trim().is_empty() {
-                    if elements.is_empty() {
-                        return Err(RustfsClientError::InvalidLifecycleConfigurationResponse);
-                    }
-                    canonical.push_str(text);
-                }
+                append_canonical_text(
+                    &mut canonical,
+                    elements.last_mut(),
+                    decode_text(&text)?,
+                    false,
+                )?;
             }
             Ok(Event::CData(text)) => {
-                if elements.is_empty() {
-                    return Err(RustfsClientError::InvalidLifecycleConfigurationResponse);
-                }
-                let text = std::str::from_utf8(text.as_ref())
-                    .map_err(|_| RustfsClientError::InvalidLifecycleConfigurationResponse)?;
-                canonical.push_str("<![CDATA[");
-                canonical.push_str(text);
-                canonical.push_str("]]>");
+                append_canonical_text(
+                    &mut canonical,
+                    elements.last_mut(),
+                    decode_cdata(&text)?,
+                    true,
+                )?;
+            }
+            Ok(Event::GeneralRef(reference)) => {
+                append_canonical_text(
+                    &mut canonical,
+                    elements.last_mut(),
+                    decode_reference(&reference)?,
+                    true,
+                )?;
             }
             Ok(Event::Decl(_) | Event::Comment(_) | Event::PI(_)) => {}
-            Ok(Event::DocType(_) | Event::GeneralRef(_)) => {
+            Ok(Event::DocType(_)) => {
                 return Err(RustfsClientError::InvalidLifecycleConfigurationResponse);
             }
             Ok(Event::Eof) => break,
@@ -179,6 +192,98 @@ pub fn canonicalize_bucket_lifecycle_xml(xml: &str) -> Result<String, RustfsClie
         return Err(RustfsClientError::InvalidLifecycleConfigurationResponse);
     }
     Ok(canonical)
+}
+
+struct CanonicalElement {
+    name: String,
+    has_child: bool,
+    has_text: bool,
+    pending_whitespace: String,
+}
+
+impl CanonicalElement {
+    fn new(name: String) -> Self {
+        Self {
+            name,
+            has_child: false,
+            has_text: false,
+            pending_whitespace: String::new(),
+        }
+    }
+
+    fn start_child(&mut self, canonical: &mut String) {
+        self.has_child = true;
+        if self.has_text {
+            canonical.push_str(&self.pending_whitespace);
+        }
+        self.pending_whitespace.clear();
+    }
+
+    fn finish(&mut self, canonical: &mut String) {
+        if !self.has_child || self.has_text {
+            canonical.push_str(&self.pending_whitespace);
+        }
+    }
+}
+
+fn append_canonical_text(
+    canonical: &mut String,
+    element: Option<&mut CanonicalElement>,
+    text: String,
+    explicit_text: bool,
+) -> Result<(), RustfsClientError> {
+    let Some(element) = element else {
+        return if !explicit_text && is_xml_whitespace(&text) {
+            Ok(())
+        } else {
+            Err(RustfsClientError::InvalidLifecycleConfigurationResponse)
+        };
+    };
+
+    let is_whitespace = is_xml_whitespace(&text);
+    let text = escape_xml(&text);
+    if is_whitespace && !explicit_text {
+        element.pending_whitespace.push_str(&text);
+    } else {
+        canonical.push_str(&element.pending_whitespace);
+        element.pending_whitespace.clear();
+        canonical.push_str(&text);
+        element.has_text = true;
+    }
+    Ok(())
+}
+
+fn is_xml_whitespace(text: &str) -> bool {
+    text.chars()
+        .all(|character| matches!(character, ' ' | '\t' | '\r' | '\n'))
+}
+
+fn decode_text(text: &BytesText<'_>) -> Result<String, RustfsClientError> {
+    text.xml10_content()
+        .map(|text| text.into_owned())
+        .map_err(|_| RustfsClientError::InvalidLifecycleConfigurationResponse)
+}
+
+fn decode_cdata(text: &BytesCData<'_>) -> Result<String, RustfsClientError> {
+    text.xml10_content()
+        .map(|text| text.into_owned())
+        .map_err(|_| RustfsClientError::InvalidLifecycleConfigurationResponse)
+}
+
+fn decode_reference(reference: &BytesRef<'_>) -> Result<String, RustfsClientError> {
+    if let Some(character) = reference
+        .resolve_char_ref()
+        .map_err(|_| RustfsClientError::InvalidLifecycleConfigurationResponse)?
+    {
+        return Ok(character.to_string());
+    }
+
+    let name = reference
+        .xml10_content()
+        .map_err(|_| RustfsClientError::InvalidLifecycleConfigurationResponse)?;
+    resolve_xml_entity(&name)
+        .map(str::to_string)
+        .ok_or(RustfsClientError::InvalidLifecycleConfigurationResponse)
 }
 
 async fn read_bucket_lifecycle_response(
@@ -770,6 +875,79 @@ mod tests {
         assert_ne!(
             canonicalize_bucket_lifecycle_xml(desired).unwrap(),
             canonicalize_bucket_lifecycle_xml(live).unwrap()
+        );
+    }
+
+    #[test]
+    fn lifecycle_canonicalization_preserves_leaf_whitespace_and_decodes_text() {
+        let prefix_with_one_space = concat!(
+            "<LifecycleConfiguration><Rule><Filter><Prefix> </Prefix></Filter>",
+            "<ID>all</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>"
+        );
+        let prefix_with_two_spaces = concat!(
+            "<LifecycleConfiguration><Rule><Filter><Prefix>  </Prefix></Filter>",
+            "<ID>all</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>"
+        );
+        let escaped_text = concat!(
+            "<LifecycleConfiguration><Rule><Filter><Prefix>logs/&apos;</Prefix></Filter>",
+            "<ID>all</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>"
+        );
+        let literal_text = concat!(
+            "<LifecycleConfiguration><Rule><Filter><Prefix>logs/'</Prefix></Filter>",
+            "<ID>all</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>"
+        );
+        let cdata_text = concat!(
+            "<LifecycleConfiguration><Rule><Filter><Prefix><![CDATA[logs/']]></Prefix></Filter>",
+            "<ID>all</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>"
+        );
+        let numeric_reference = concat!(
+            "<LifecycleConfiguration><Rule><Filter><Prefix>logs/&#39;</Prefix></Filter>",
+            "<ID>all</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>"
+        );
+        let non_xml_whitespace = concat!(
+            "<LifecycleConfiguration><Rule><Filter></Filter>\u{a0}<ID>all</ID>",
+            "<Status>Enabled</Status></Rule></LifecycleConfiguration>"
+        );
+        let no_interstitial_text = concat!(
+            "<LifecycleConfiguration><Rule><Filter></Filter><ID>all</ID>",
+            "<Status>Enabled</Status></Rule></LifecycleConfiguration>"
+        );
+        let explicit_whitespace = concat!(
+            "<LifecycleConfiguration><Rule><Filter></Filter><![CDATA[ ]]><ID>all</ID>",
+            "<Status>Enabled</Status></Rule></LifecycleConfiguration>"
+        );
+        let referenced_whitespace = concat!(
+            "<LifecycleConfiguration><Rule><Filter></Filter>&#32;<ID>all</ID>",
+            "<Status>Enabled</Status></Rule></LifecycleConfiguration>"
+        );
+
+        assert_ne!(
+            canonicalize_bucket_lifecycle_xml(prefix_with_one_space).unwrap(),
+            canonicalize_bucket_lifecycle_xml(prefix_with_two_spaces).unwrap()
+        );
+        assert_eq!(
+            canonicalize_bucket_lifecycle_xml(escaped_text).unwrap(),
+            canonicalize_bucket_lifecycle_xml(literal_text).unwrap()
+        );
+        assert_eq!(
+            canonicalize_bucket_lifecycle_xml(literal_text).unwrap(),
+            canonicalize_bucket_lifecycle_xml(cdata_text).unwrap()
+        );
+        assert_eq!(
+            canonicalize_bucket_lifecycle_xml(literal_text).unwrap(),
+            canonicalize_bucket_lifecycle_xml(numeric_reference).unwrap()
+        );
+        assert_ne!(
+            canonicalize_bucket_lifecycle_xml(non_xml_whitespace).unwrap(),
+            canonicalize_bucket_lifecycle_xml(no_interstitial_text).unwrap()
+        );
+        assert_ne!(
+            canonicalize_bucket_lifecycle_xml(explicit_whitespace).unwrap(),
+            canonicalize_bucket_lifecycle_xml(no_interstitial_text).unwrap()
+        );
+        assert_eq!(
+            canonicalize_bucket_lifecycle_xml(explicit_whitespace).unwrap(),
+            canonicalize_bucket_lifecycle_xml(referenced_whitespace).unwrap()
         );
     }
 

--- a/deploy/rustfs-operator/README.md
+++ b/deploy/rustfs-operator/README.md
@@ -219,9 +219,18 @@ spec:
   buckets:
     - name: app-data
       objectLock: true
+      lifecycle:
+        state: Present
+        rules:
+          - id: expire-logs
+            status: Enabled
+            filter:
+              prefix: logs/
+            expiration:
+              days: 30
 ```
 
-Policy ConfigMaps and user Secrets must live in the Tenant namespace. `users[].credsSecret.name` selects the credentials Secret; when omitted, the operator falls back to a Secret named after `users[].name` for compatibility with existing manifests. The operator indexes references from Tenant specs, so creating or updating a referenced object enqueues every referencing Tenant without requiring or mutating labels or requiring write access to that object. Provisioned resources are retained when removed from the Tenant spec.
+Policy ConfigMaps and user Secrets must live in the Tenant namespace. `users[].credsSecret.name` selects the credentials Secret; when omitted, the operator falls back to a Secret named after `users[].name` for compatibility with existing manifests. Bucket lifecycle supports expiration and incomplete multipart upload cleanup rules. Omission leaves lifecycle unmanaged; `state: Absent` deletes only a configuration whose live hash still matches the Operator's ownership record. The operator indexes references from Tenant specs, so creating or updating a referenced object enqueues every referencing Tenant without requiring or mutating labels or requiring write access to that object. Provisioned resources are retained when removed from the Tenant spec.
 
 ### RBAC Configuration
 

--- a/deploy/rustfs-operator/crds/tenant-crd.yaml
+++ b/deploy/rustfs-operator/crds/tenant-crd.yaml
@@ -47,6 +47,77 @@ spec:
                       enum:
                       - Retain
                       type: string
+                    lifecycle:
+                      description: |-
+                        Declarative S3 bucket lifecycle configuration. Omission leaves the live lifecycle
+                        configuration unmanaged; `Absent` removes only a configuration previously owned by the
+                        operator.
+                      nullable: true
+                      properties:
+                        rules:
+                          items:
+                            properties:
+                              abortIncompleteMultipartUpload:
+                                nullable: true
+                                properties:
+                                  daysAfterInitiation:
+                                    format: int32
+                                    minimum: 1.0
+                                    type: integer
+                                required:
+                                - daysAfterInitiation
+                                type: object
+                              expiration:
+                                nullable: true
+                                properties:
+                                  days:
+                                    format: int32
+                                    minimum: 1.0
+                                    type: integer
+                                required:
+                                - days
+                                type: object
+                              filter:
+                                properties:
+                                  prefix:
+                                    description: Object-key prefix selected by this rule. An empty prefix selects all objects.
+                                    type: string
+                                required:
+                                - prefix
+                                type: object
+                              id:
+                                maxLength: 255
+                                minLength: 1
+                                type: string
+                              status:
+                                enum:
+                                - Enabled
+                                - Disabled
+                                type: string
+                            required:
+                            - filter
+                            - id
+                            - status
+                            type: object
+                            x-kubernetes-validations:
+                            - message: lifecycle rule must configure expiration or abortIncompleteMultipartUpload
+                              rule: has(self.expiration) || has(self.abortIncompleteMultipartUpload)
+                          maxItems: 1000
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - id
+                          x-kubernetes-list-type: map
+                        state:
+                          enum:
+                          - Present
+                          - Absent
+                          type: string
+                      required:
+                      - state
+                      type: object
+                      x-kubernetes-validations:
+                      - message: Present lifecycle requires rules and Absent lifecycle forbids rules
+                        rule: 'self.state == ''Present'' ? has(self.rules) && self.rules.size() > 0 : !has(self.rules) || self.rules.size() == 0'
                     name:
                       maxLength: 63
                       minLength: 3
@@ -2565,6 +2636,9 @@ spec:
                 properties:
                   buckets:
                     items:
+                      description: |-
+                        Bucket-specific provisioning status. Lifecycle ownership hashes are separate from the
+                        existing bucket-policy hashes while preserving the established flattened wire format.
                       properties:
                         desiredHash:
                           nullable: true
@@ -2580,6 +2654,12 @@ spec:
                           nullable: true
                           type: string
                         lastTransitionTime:
+                          nullable: true
+                          type: string
+                        lifecycleDesiredHash:
+                          nullable: true
+                          type: string
+                        lifecycleLastAppliedHash:
                           nullable: true
                           type: string
                         message:

--- a/docs/operator-user-guide.md
+++ b/docs/operator-user-guide.md
@@ -860,6 +860,8 @@ The operator can create RustFS policies, users, and buckets after the Tenant wor
 - `spec.users` for regular users. Each user must have at least one direct policy mapping.
 - `spec.buckets` for buckets, optional object lock, canned anonymous access (`Private`, `Download`, `Upload`, `Public`), or a custom bucket policy ConfigMap. Non-private `anonymous` values and `policy` are mutually exclusive. Explicit `anonymous: Private` without `policy` removes a bucket policy previously applied by the Operator; it reports a conflict instead of deleting an unowned live policy. For compatibility, legacy `Private` plus `policy` configurations keep the custom policy. When both fields are omitted, the Operator does not change a live bucket policy and retains its ownership record for a later explicit `Private` transition.
 
+Each bucket may also declare `lifecycle.state: Present` with one or more S3 lifecycle rules. The current schema supports expiration after a positive number of days and aborting incomplete multipart uploads after a positive number of days; every rule has a unique ID, an `Enabled` or `Disabled` status, and an explicit prefix filter (use `prefix: ""` for all objects). `lifecycle.state: Absent` requests deletion and cannot include rules. The Operator adopts an identical live configuration, but never replaces or deletes a different configuration without a matching ownership hash in `status.provisioning.buckets`. Omitting `lifecycle` performs no lifecycle API calls and leaves the live configuration untouched.
+
 Transient Kubernetes and RustFS admin/S3 failures (timeouts, 429, 5xx, connection errors, TLS not ready) leave provisioning items `Pending` and requeue instead of marking the Tenant `Failed`. Permanent 4xx configuration errors still fail and wait for a spec or object change.
 
 ConfigMaps and user Secrets must live in the Tenant namespace. The Operator indexes references from Tenant specs, so creating or updating a referenced object enqueues every referencing Tenant without requiring or mutating labels or requiring write access to that object.
@@ -930,6 +932,21 @@ spec:
     - name: app-data
       objectLock: true
       anonymous: Download
+      lifecycle:
+        state: Present
+        rules:
+          - id: expire-old-logs
+            status: Enabled
+            filter:
+              prefix: logs/
+            expiration:
+              days: 30
+          - id: cleanup-incomplete-uploads
+            status: Enabled
+            filter:
+              prefix: ""
+            abortIncompleteMultipartUpload:
+              daysAfterInitiation: 1
 ```
 
 Deletion behavior is conservative: provisioned resources are retained when removed from the Tenant spec.

--- a/docs/operator-user-guide.zh-CN.md
+++ b/docs/operator-user-guide.zh-CN.md
@@ -816,6 +816,8 @@ Operator 可以在 Tenant workload Ready 后自动创建 RustFS policy、user �
 - `spec.users`：普通用户。每个 user 必须至少直接绑定一个 policy。
 - `spec.buckets`：bucket，以及可选的 object lock、匿名访问（`Private` / `Download` / `Upload` / `Public`）或来自 ConfigMap 的自定义 bucket policy。非 `Private` 的 `anonymous` 值与 `policy` 互斥。未设置 `policy` 时，显式设置 `anonymous: Private` 会删除此前由 Operator 应用的 bucket policy；若现有 policy 不归 Operator 管理，则报告冲突而不删除。为兼容旧对象，`Private` 与 `policy` 同时存在时继续以自定义 policy 为准。两者都省略时，Operator 不会改写已有 bucket policy，并会保留所有权记录供后续显式切换为 `Private` 时校验。
 
+每个 bucket 还可以通过 `lifecycle.state: Present` 声明一个或多个 S3 生命周期规则。当前 schema 支持按正整数天数过期对象，以及按正整数天数清理未完成的分片上传；每条规则必须有唯一 ID、`Enabled` 或 `Disabled` 状态，并显式指定 prefix filter（`prefix: ""` 表示全部对象）。`lifecycle.state: Absent` 表示请求删除，且不能包含规则。Operator 可以接管与声明完全相同的现有配置，但没有 `status.provisioning.buckets` 中匹配的所有权哈希时，不会覆盖或删除不同的现有配置。省略 `lifecycle` 时不会调用 Lifecycle API，也不会改动现有配置。
+
 Kubernetes 或 RustFS 管理/S3 API 的瞬时失败（超时、429、5xx、连接错误、TLS 未就绪）会把 provisioning 条目保持为 `Pending` 并重新入队，而不会把 Tenant 标为 `Failed`。永久性 4xx 配置错误仍会失败并等待 spec 或对象变更。
 
 ConfigMap 和 user Secret 必须位于 Tenant namespace。Operator 会从 Tenant spec 建立反向引用索引，因此被引用资源的创建或更新会触发所有引用它的 Tenant reconcile；无需要求或修改资源标签，也不需要对这些资源拥有写权限。
@@ -886,6 +888,21 @@ spec:
     - name: app-data
       objectLock: true
       anonymous: Download
+      lifecycle:
+        state: Present
+        rules:
+          - id: expire-old-logs
+            status: Enabled
+            filter:
+              prefix: logs/
+            expiration:
+              days: 30
+          - id: cleanup-incomplete-uploads
+            status: Enabled
+            filter:
+              prefix: ""
+            abortIncompleteMultipartUpload:
+              daysAfterInitiation: 1
 ```
 
 删除行为是保守的：从 Tenant spec 移除已 provisioning 的资源时，实际 RustFS 资源会保留。

--- a/e2e/Cargo.lock
+++ b/e2e/Cargo.lock
@@ -2901,6 +2901,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3214,6 +3223,7 @@ dependencies = [
  "chrono",
  "hex",
  "hmac 0.12.1",
+ "quick-xml",
  "reqwest",
  "serde",
  "serde_json",

--- a/examples/provisioning-tenant.yaml
+++ b/examples/provisioning-tenant.yaml
@@ -86,3 +86,18 @@ spec:
     - name: provisioning-demo-data
       objectLock: true
       anonymous: Download
+      lifecycle:
+        state: Present
+        rules:
+          - id: expire-old-logs
+            status: Enabled
+            filter:
+              prefix: logs/
+            expiration:
+              days: 30
+          - id: cleanup-incomplete-uploads
+            status: Enabled
+            filter:
+              prefix: ""
+            abortIncompleteMultipartUpload:
+              daysAfterInitiation: 1

--- a/src/console/openapi.rs
+++ b/src/console/openapi.rs
@@ -55,11 +55,15 @@ use crate::console::models::topology::{
     TopologyOverviewResponse, TopologyPod, TopologyPool, TopologyTenant, TopologyTenantSummary,
 };
 use crate::types::v1alpha1::provisioning::{
-    BucketAnonymousAccess, ConfigMapKeyReference, PolicyDocumentSource, ProvisioningBucket,
-    ProvisioningDeletionPolicy, ProvisioningPolicy, ProvisioningUser, UserCredentialsSecretRef,
+    BucketAnonymousAccess, BucketLifecycleAbortIncompleteMultipartUpload,
+    BucketLifecycleExpiration, BucketLifecycleRule, BucketLifecycleRuleFilter,
+    BucketLifecycleRuleStatus, BucketLifecycleSpec, BucketLifecycleState, ConfigMapKeyReference,
+    PolicyDocumentSource, ProvisioningBucket, ProvisioningDeletionPolicy, ProvisioningPolicy,
+    ProvisioningUser, UserCredentialsSecretRef,
 };
 use crate::types::v1alpha1::status::provisioning::{
-    ProvisioningItemState, ProvisioningItemStatus, ProvisioningPhase, ProvisioningStatus,
+    ProvisioningBucketStatus, ProvisioningItemState, ProvisioningItemStatus, ProvisioningPhase,
+    ProvisioningStatus,
 };
 
 #[derive(OpenApi)]
@@ -117,6 +121,7 @@ use crate::types::v1alpha1::status::provisioning::{
         ProvisioningStatus,
         ProvisioningPhase,
         ProvisioningItemStatus,
+        ProvisioningBucketStatus,
         ProvisioningItemState,
         ProvisioningPolicy,
         ProvisioningUser,
@@ -126,6 +131,13 @@ use crate::types::v1alpha1::status::provisioning::{
         PolicyDocumentSource,
         ConfigMapKeyReference,
         BucketAnonymousAccess,
+        BucketLifecycleSpec,
+        BucketLifecycleState,
+        BucketLifecycleRule,
+        BucketLifecycleRuleStatus,
+        BucketLifecycleRuleFilter,
+        BucketLifecycleExpiration,
+        BucketLifecycleAbortIncompleteMultipartUpload,
         CreateTenantRequest,
         CreatePoolRequest,
         PoolInfo,
@@ -773,6 +785,8 @@ mod tests {
             .expect("schemas exist");
 
         assert!(schemas.contains_key("ProvisioningStatus"));
+        assert!(schemas.contains_key("ProvisioningBucketStatus"));
+        assert!(schemas.contains_key("BucketLifecycleSpec"));
         assert!(schemas.contains_key("UserCredentialsSecretRef"));
         assert_eq!(
             spec.pointer("/components/schemas/TenantDetailsResponse/properties/provisioning/$ref")
@@ -795,6 +809,18 @@ mod tests {
             )
             .and_then(Value::as_str),
             Some("#/components/schemas/UserCredentialsSecretRef")
+        );
+        assert_eq!(
+            spec.pointer(
+                "/components/schemas/ProvisioningBucket/properties/lifecycle/oneOf/1/$ref",
+            )
+            .and_then(Value::as_str),
+            Some("#/components/schemas/BucketLifecycleSpec")
+        );
+        assert_eq!(
+            spec.pointer("/components/schemas/ProvisioningStatus/properties/buckets/items/$ref")
+                .and_then(Value::as_str),
+            Some("#/components/schemas/ProvisioningBucketStatus")
         );
     }
 

--- a/src/reconcile/provisioning.rs
+++ b/src/reconcile/provisioning.rs
@@ -13,15 +13,25 @@
 // limitations under the License.
 
 use crate::context::{self, Context};
-use crate::sts::rustfs_client::{CreateBucketResult, RustfsAdminClient, RustfsClientError};
+use crate::sts::rustfs_client::{
+    BucketLifecycleAbortIncompleteMultipartUpload as AdminLifecycleAbort,
+    BucketLifecycleConfiguration as AdminLifecycleConfiguration,
+    BucketLifecycleExpiration as AdminLifecycleExpiration,
+    BucketLifecycleRule as AdminLifecycleRule,
+    BucketLifecycleRuleStatus as AdminLifecycleRuleStatus, CreateBucketResult, RustfsAdminClient,
+    RustfsClientError, canonicalize_bucket_lifecycle_xml,
+};
 use crate::types::v1alpha1::provisioning::{
-    BucketAnonymousAccess, PolicyDocumentSource, ProvisioningBucket, ProvisioningPolicy,
-    ProvisioningUser, duplicate_user_credentials_secret_names,
+    BucketAnonymousAccess, BucketLifecycleRuleStatus, BucketLifecycleSpec, BucketLifecycleState,
+    MAX_BUCKET_LIFECYCLE_RULE_ID_LENGTH, MAX_BUCKET_LIFECYCLE_RULES, PolicyDocumentSource,
+    ProvisioningBucket, ProvisioningPolicy, ProvisioningUser,
+    duplicate_user_credentials_secret_names,
 };
 use crate::types::v1alpha1::status::Reason;
 use crate::types::v1alpha1::status::provisioning::{
-    ProvisioningItemState, ProvisioningItemStatus, ProvisioningPhase, ProvisioningStatus,
-    ProvisioningUserOwnershipState, ProvisioningUserOwnershipStatus, ProvisioningUserStatus,
+    ProvisioningBucketStatus, ProvisioningItemState, ProvisioningItemStatus, ProvisioningPhase,
+    ProvisioningStatus, ProvisioningUserOwnershipState, ProvisioningUserOwnershipStatus,
+    ProvisioningUserStatus,
 };
 use crate::types::v1alpha1::tenant::Tenant;
 use k8s_openapi::ByteString;
@@ -131,6 +141,14 @@ enum PolicyReconcileAction {
     Failed(Reason, &'static str),
 }
 
+#[derive(Debug, PartialEq, Eq)]
+enum LifecycleReconcileAction {
+    Ready(&'static str),
+    Apply,
+    Delete,
+    Failed(&'static str),
+}
+
 impl PolicyDocument {
     fn parse(raw: &str) -> Result<Self, String> {
         Ok(Self {
@@ -153,8 +171,12 @@ impl ProvisioningRun<'_> {
         self.previous.users.iter().find(|item| item.name == name)
     }
 
-    fn previous_bucket(&self, name: &str) -> Option<&ProvisioningItemStatus> {
+    fn previous_bucket_status(&self, name: &str) -> Option<&ProvisioningBucketStatus> {
         self.previous.buckets.iter().find(|item| item.name == name)
+    }
+
+    fn previous_bucket(&self, name: &str) -> Option<&ProvisioningItemStatus> {
+        self.previous_bucket_status(name).map(AsRef::as_ref)
     }
 
     fn push_policy(&mut self, item: ProvisioningItemStatus) {
@@ -179,8 +201,8 @@ impl ProvisioningRun<'_> {
         self.status.users.push(item);
     }
 
-    fn push_bucket(&mut self, item: ProvisioningItemStatus) {
-        self.log_item_transition("bucket", self.previous_bucket(&item.name), &item);
+    fn push_bucket(&mut self, item: ProvisioningBucketStatus) {
+        self.log_item_transition("bucket", self.previous_bucket(&item.name), item.as_ref());
         if item.state == ProvisioningItemState::Failed.as_str() {
             self.failures
                 .push((reason_from_str(&item.reason), item_message(&item)));
@@ -339,9 +361,14 @@ impl ProvisioningRun<'_> {
         self.status
             .policies
             .iter()
-            .chain(self.status.buckets.iter())
             .find(|item| item.state == ProvisioningItemState::Pending.as_str())
             .map(item_message)
+            .or_else(|| {
+                self.status.buckets.iter().find_map(|item| {
+                    (item.state == ProvisioningItemState::Pending.as_str())
+                        .then(|| item_message(item))
+                })
+            })
             .or_else(|| {
                 self.status.users.iter().find_map(|item| {
                     (item.state == ProvisioningItemState::Pending.as_str())
@@ -376,6 +403,13 @@ impl ProvisioningRun<'_> {
     fn retained_user(&self, previous: &ProvisioningUserStatus) -> ProvisioningUserStatus {
         let mut item = ProvisioningUserStatus::new(self.retained_item(previous.as_ref()));
         item.ownership = previous.ownership.clone();
+        item
+    }
+
+    fn retained_bucket(&self, previous: &ProvisioningBucketStatus) -> ProvisioningBucketStatus {
+        let mut item = ProvisioningBucketStatus::new(self.retained_item(previous.as_ref()));
+        item.lifecycle_desired_hash = previous.lifecycle_desired_hash.clone();
+        item.lifecycle_last_applied_hash = previous.lifecycle_last_applied_hash.clone();
         item
     }
 
@@ -424,6 +458,11 @@ impl ProvisioningRun<'_> {
                 reason,
                 message,
             );
+            let mut item = ProvisioningBucketStatus::new(item);
+            if let Some(previous) = self.previous_bucket_status(&bucket.name) {
+                item.lifecycle_desired_hash = previous.lifecycle_desired_hash.clone();
+                item.lifecycle_last_applied_hash = previous.lifecycle_last_applied_hash.clone();
+            }
             self.push_bucket(item);
         }
     }
@@ -450,7 +489,7 @@ impl ProvisioningRun<'_> {
         let buckets = desired_names(self.tenant.spec.buckets.iter().map(|bucket| &bucket.name));
         for previous in &self.previous.buckets {
             if !buckets.contains(&previous.name) {
-                self.status.buckets.push(self.retained_item(previous));
+                self.status.buckets.push(self.retained_bucket(previous));
             }
         }
     }
@@ -1620,7 +1659,7 @@ async fn persist_user_ownership_checkpoints(
         .unwrap_or_default();
     merge_provisioning_items(&mut provisioning.policies, &run.status.policies);
     merge_provisioning_user_items(&mut provisioning.users, &run.status.users);
-    merge_provisioning_items(&mut provisioning.buckets, &run.status.buckets);
+    merge_provisioning_bucket_items(&mut provisioning.buckets, &run.status.buckets);
     merge_provisioning_user_items(&mut provisioning.users, checkpoints);
     provisioning.observed_generation = run.tenant.metadata.generation;
     provisioning.phase = Some(ProvisioningPhase::Pending);
@@ -1737,6 +1776,19 @@ fn merge_provisioning_items(
 fn merge_provisioning_user_items(
     destination: &mut Vec<ProvisioningUserStatus>,
     updates: &[ProvisioningUserStatus],
+) {
+    for update in updates {
+        if let Some(item) = destination.iter_mut().find(|item| item.name == update.name) {
+            *item = update.clone();
+        } else {
+            destination.push(update.clone());
+        }
+    }
+}
+
+fn merge_provisioning_bucket_items(
+    destination: &mut Vec<ProvisioningBucketStatus>,
+    updates: &[ProvisioningBucketStatus],
 ) {
     for update in updates {
         if let Some(item) = destination.iter_mut().find(|item| item.name == update.name) {
@@ -1973,6 +2025,21 @@ async fn reconcile_bucket(
     run: &mut ProvisioningRun<'_>,
     client: &RustfsAdminClient,
     bucket: &ProvisioningBucket,
+) -> ProvisioningBucketStatus {
+    let previous = run.previous_bucket_status(&bucket.name).cloned();
+    let item = reconcile_bucket_policy(run, client, bucket).await;
+    if item.state != ProvisioningItemState::Ready.as_str() {
+        let mut status = bucket_status_with_preserved_lifecycle(item, previous.as_ref());
+        status.lifecycle_desired_hash = bucket.lifecycle.as_ref().and_then(lifecycle_desired_hash);
+        return status;
+    }
+    reconcile_bucket_lifecycle(run, client, bucket, previous.as_ref(), item).await
+}
+
+async fn reconcile_bucket_policy(
+    run: &mut ProvisioningRun<'_>,
+    client: &RustfsAdminClient,
+    bucket: &ProvisioningBucket,
 ) -> ProvisioningItemStatus {
     let previous = run.previous_bucket(&bucket.name).cloned();
     if let Err(message) = validate_bucket_name(&bucket.name) {
@@ -2126,6 +2193,426 @@ async fn reconcile_bucket(
         created_message,
     )
     .await
+}
+
+async fn reconcile_bucket_lifecycle(
+    run: &mut ProvisioningRun<'_>,
+    client: &RustfsAdminClient,
+    bucket: &ProvisioningBucket,
+    previous: Option<&ProvisioningBucketStatus>,
+    base_item: ProvisioningItemStatus,
+) -> ProvisioningBucketStatus {
+    let Some(spec) = bucket.lifecycle.as_ref() else {
+        let mut status = bucket_status_with_preserved_lifecycle(base_item, previous);
+        status.lifecycle_desired_hash = None;
+        return status;
+    };
+
+    let desired = match lifecycle_configuration(spec) {
+        Ok(configuration) => configuration,
+        Err(message) => {
+            let item = replace_bucket_item_state(
+                run,
+                previous,
+                &base_item,
+                ProvisioningItemState::Failed,
+                Reason::BucketLifecycleApplyFailed,
+                message,
+            );
+            let mut status = bucket_status_with_preserved_lifecycle(item, previous);
+            status.lifecycle_desired_hash = None;
+            return status;
+        }
+    };
+    let desired_document = desired.as_ref().map(AdminLifecycleConfiguration::to_xml);
+    let desired_hash = match desired_document.as_deref() {
+        Some(document) => match canonicalize_bucket_lifecycle_xml(document) {
+            Ok(document) => Some(hash_document(&document)),
+            Err(error) => {
+                let item = replace_bucket_item_state(
+                    run,
+                    previous,
+                    &base_item,
+                    ProvisioningItemState::Failed,
+                    Reason::BucketLifecycleApplyFailed,
+                    format!("failed to encode RustFS bucket lifecycle configuration: {error}"),
+                );
+                return bucket_status_with_preserved_lifecycle(item, previous);
+            }
+        },
+        None => None,
+    };
+
+    let live_document = match client
+        .get_bucket_lifecycle_configuration(&bucket.name)
+        .await
+    {
+        Ok(document) => document,
+        Err(error) => {
+            let item = bucket_item_from_admin_error(
+                run,
+                previous,
+                &base_item,
+                Reason::BucketLifecycleApplyFailed,
+                error,
+                "failed to read RustFS bucket lifecycle configuration",
+            );
+            return finalize_bucket_lifecycle_status(item, previous, desired_hash, false);
+        }
+    };
+    let live_hash = match live_document.as_deref() {
+        Some(document) => match canonicalize_bucket_lifecycle_xml(document) {
+            Ok(document) => Some(hash_document(&document)),
+            Err(error) => {
+                let item = bucket_item_from_admin_error(
+                    run,
+                    previous,
+                    &base_item,
+                    Reason::BucketLifecycleApplyFailed,
+                    error,
+                    "failed to normalize live RustFS bucket lifecycle configuration",
+                );
+                return finalize_bucket_lifecycle_status(item, previous, desired_hash, false);
+            }
+        },
+        None => None,
+    };
+
+    let action = lifecycle_reconcile_action(
+        previous.and_then(|item| item.lifecycle_last_applied_hash.as_deref()),
+        live_hash.as_deref(),
+        desired_hash.as_deref(),
+    );
+    let (item, applied) = match action {
+        LifecycleReconcileAction::Ready(message) => (
+            replace_bucket_item_state(
+                run,
+                previous,
+                &base_item,
+                ProvisioningItemState::Ready,
+                Reason::ProvisioningConfigured,
+                append_bucket_message(&base_item, message),
+            ),
+            true,
+        ),
+        LifecycleReconcileAction::Apply => {
+            if let Some(configuration) = desired.as_ref() {
+                match client
+                    .put_bucket_lifecycle_configuration(&bucket.name, configuration)
+                    .await
+                {
+                    Ok(()) => (
+                        replace_bucket_item_state(
+                            run,
+                            previous,
+                            &base_item,
+                            ProvisioningItemState::Ready,
+                            Reason::ProvisioningConfigured,
+                            append_bucket_message(
+                                &base_item,
+                                "RustFS bucket lifecycle configuration was applied",
+                            ),
+                        ),
+                        true,
+                    ),
+                    Err(error) => (
+                        bucket_item_from_admin_error(
+                            run,
+                            previous,
+                            &base_item,
+                            Reason::BucketLifecycleApplyFailed,
+                            error,
+                            "failed to apply RustFS bucket lifecycle configuration",
+                        ),
+                        false,
+                    ),
+                }
+            } else {
+                (
+                    replace_bucket_item_state(
+                        run,
+                        previous,
+                        &base_item,
+                        ProvisioningItemState::Failed,
+                        Reason::BucketLifecycleApplyFailed,
+                        "bucket lifecycle apply action is missing a desired configuration",
+                    ),
+                    false,
+                )
+            }
+        }
+        LifecycleReconcileAction::Delete => {
+            match client
+                .delete_bucket_lifecycle_configuration(&bucket.name)
+                .await
+            {
+                Ok(()) => (
+                    replace_bucket_item_state(
+                        run,
+                        previous,
+                        &base_item,
+                        ProvisioningItemState::Ready,
+                        Reason::ProvisioningConfigured,
+                        append_bucket_message(
+                            &base_item,
+                            "RustFS bucket lifecycle configuration was removed",
+                        ),
+                    ),
+                    true,
+                ),
+                Err(error) => (
+                    bucket_item_from_admin_error(
+                        run,
+                        previous,
+                        &base_item,
+                        Reason::BucketLifecycleApplyFailed,
+                        error,
+                        "failed to remove RustFS bucket lifecycle configuration",
+                    ),
+                    false,
+                ),
+            }
+        }
+        LifecycleReconcileAction::Failed(message) => (
+            replace_bucket_item_state(
+                run,
+                previous,
+                &base_item,
+                ProvisioningItemState::Failed,
+                Reason::BucketLifecycleConflict,
+                message,
+            ),
+            false,
+        ),
+    };
+
+    finalize_bucket_lifecycle_status(item, previous, desired_hash, applied)
+}
+
+fn lifecycle_configuration(
+    spec: &BucketLifecycleSpec,
+) -> Result<Option<AdminLifecycleConfiguration>, String> {
+    match spec.state {
+        BucketLifecycleState::Absent => {
+            if spec.rules.is_empty() {
+                return Ok(None);
+            }
+            return Err("Absent bucket lifecycle must not contain rules".to_string());
+        }
+        BucketLifecycleState::Present if spec.rules.is_empty() => {
+            return Err("Present bucket lifecycle must contain at least one rule".to_string());
+        }
+        BucketLifecycleState::Present => {}
+    }
+    if spec.rules.len() > MAX_BUCKET_LIFECYCLE_RULES as usize {
+        return Err(format!(
+            "bucket lifecycle cannot contain more than {MAX_BUCKET_LIFECYCLE_RULES} rules"
+        ));
+    }
+
+    let mut ids = BTreeSet::new();
+    let mut rules = Vec::with_capacity(spec.rules.len());
+    for rule in &spec.rules {
+        let id_length = rule.id.len();
+        if id_length == 0 || id_length > MAX_BUCKET_LIFECYCLE_RULE_ID_LENGTH as usize {
+            return Err(format!(
+                "bucket lifecycle rule ID must contain between 1 and {MAX_BUCKET_LIFECYCLE_RULE_ID_LENGTH} UTF-8 bytes"
+            ));
+        }
+        if !is_valid_xml_text(&rule.id) {
+            return Err(format!(
+                "bucket lifecycle rule ID '{}' contains characters that cannot be represented in S3 XML",
+                rule.id
+            ));
+        }
+        if !is_valid_xml_text(&rule.filter.prefix) {
+            return Err(format!(
+                "bucket lifecycle rule '{}' prefix contains characters that cannot be represented in S3 XML",
+                rule.id
+            ));
+        }
+        if !ids.insert(rule.id.as_str()) {
+            return Err(format!(
+                "bucket lifecycle rule ID '{}' must be unique",
+                rule.id
+            ));
+        }
+        if rule.expiration.is_none() && rule.abort_incomplete_multipart_upload.is_none() {
+            return Err(format!(
+                "bucket lifecycle rule '{}' must configure expiration or abortIncompleteMultipartUpload",
+                rule.id
+            ));
+        }
+        if rule
+            .expiration
+            .as_ref()
+            .is_some_and(|value| value.days <= 0)
+        {
+            return Err(format!(
+                "bucket lifecycle rule '{}' expiration.days must be greater than zero",
+                rule.id
+            ));
+        }
+        if rule
+            .abort_incomplete_multipart_upload
+            .as_ref()
+            .is_some_and(|value| value.days_after_initiation <= 0)
+        {
+            return Err(format!(
+                "bucket lifecycle rule '{}' abortIncompleteMultipartUpload.daysAfterInitiation must be greater than zero",
+                rule.id
+            ));
+        }
+
+        rules.push(AdminLifecycleRule {
+            id: rule.id.clone(),
+            status: match rule.status {
+                BucketLifecycleRuleStatus::Enabled => AdminLifecycleRuleStatus::Enabled,
+                BucketLifecycleRuleStatus::Disabled => AdminLifecycleRuleStatus::Disabled,
+            },
+            prefix: rule.filter.prefix.clone(),
+            expiration: rule
+                .expiration
+                .as_ref()
+                .map(|value| AdminLifecycleExpiration { days: value.days }),
+            abort_incomplete_multipart_upload: rule.abort_incomplete_multipart_upload.as_ref().map(
+                |value| AdminLifecycleAbort {
+                    days_after_initiation: value.days_after_initiation,
+                },
+            ),
+        });
+    }
+    Ok(Some(AdminLifecycleConfiguration { rules }))
+}
+
+fn lifecycle_desired_hash(spec: &BucketLifecycleSpec) -> Option<String> {
+    lifecycle_configuration(spec)
+        .ok()
+        .flatten()
+        .map(|configuration| configuration.to_xml())
+        .and_then(|document| canonicalize_bucket_lifecycle_xml(&document).ok())
+        .map(|document| hash_document(&document))
+}
+
+fn is_valid_xml_text(value: &str) -> bool {
+    value.chars().all(|character| {
+        matches!(character, '\u{9}' | '\u{A}' | '\u{D}')
+            || ('\u{20}'..='\u{D7FF}').contains(&character)
+            || ('\u{E000}'..='\u{FFFD}').contains(&character)
+            || ('\u{10000}'..='\u{10FFFF}').contains(&character)
+    })
+}
+
+fn lifecycle_reconcile_action(
+    last_applied_hash: Option<&str>,
+    live_hash: Option<&str>,
+    desired_hash: Option<&str>,
+) -> LifecycleReconcileAction {
+    match (desired_hash, last_applied_hash, live_hash) {
+        (Some(_), _, None) => LifecycleReconcileAction::Apply,
+        (Some(desired), None, Some(live)) if desired == live => {
+            LifecycleReconcileAction::Ready("RustFS bucket lifecycle configuration matches spec")
+        }
+        (Some(_), None, Some(_)) => LifecycleReconcileAction::Failed(
+            "Live RustFS bucket lifecycle configuration is not owned by this status; refusing to replace it",
+        ),
+        (Some(desired), Some(last), Some(live)) if last == live && desired != live => {
+            LifecycleReconcileAction::Apply
+        }
+        (Some(desired), Some(_), Some(live)) if desired == live => {
+            LifecycleReconcileAction::Ready("RustFS bucket lifecycle configuration matches spec")
+        }
+        (Some(_), Some(_), Some(_)) => LifecycleReconcileAction::Failed(
+            "Live RustFS bucket lifecycle configuration changed since the operator last applied it",
+        ),
+        (None, _, None) => {
+            LifecycleReconcileAction::Ready("RustFS bucket lifecycle configuration is absent")
+        }
+        (None, Some(last), Some(live)) if last == live => LifecycleReconcileAction::Delete,
+        (None, None, Some(_)) => LifecycleReconcileAction::Failed(
+            "Live RustFS bucket lifecycle configuration is not owned by this status; refusing to delete it",
+        ),
+        (None, Some(_), Some(_)) => LifecycleReconcileAction::Failed(
+            "Live RustFS bucket lifecycle configuration changed since the operator last applied it",
+        ),
+    }
+}
+
+fn bucket_status_with_preserved_lifecycle(
+    item: ProvisioningItemStatus,
+    previous: Option<&ProvisioningBucketStatus>,
+) -> ProvisioningBucketStatus {
+    let mut status = ProvisioningBucketStatus::new(item);
+    status.lifecycle_desired_hash = previous.and_then(|item| item.lifecycle_desired_hash.clone());
+    status.lifecycle_last_applied_hash =
+        previous.and_then(|item| item.lifecycle_last_applied_hash.clone());
+    status
+}
+
+fn finalize_bucket_lifecycle_status(
+    item: ProvisioningItemStatus,
+    previous: Option<&ProvisioningBucketStatus>,
+    desired_hash: Option<String>,
+    applied: bool,
+) -> ProvisioningBucketStatus {
+    let mut status = ProvisioningBucketStatus::new(item);
+    status.lifecycle_desired_hash = desired_hash.clone();
+    status.lifecycle_last_applied_hash = if applied {
+        desired_hash
+    } else {
+        previous.and_then(|item| item.lifecycle_last_applied_hash.clone())
+    };
+    status
+}
+
+fn replace_bucket_item_state(
+    run: &ProvisioningRun<'_>,
+    previous: Option<&ProvisioningBucketStatus>,
+    base_item: &ProvisioningItemStatus,
+    state: ProvisioningItemState,
+    reason: Reason,
+    message: impl Into<String>,
+) -> ProvisioningItemStatus {
+    let mut item = run.item(
+        previous.map(AsRef::as_ref),
+        &base_item.name,
+        state,
+        reason,
+        message,
+    );
+    copy_bucket_configuration_status(&mut item, base_item);
+    item
+}
+
+fn bucket_item_from_admin_error(
+    run: &mut ProvisioningRun<'_>,
+    previous: Option<&ProvisioningBucketStatus>,
+    base_item: &ProvisioningItemStatus,
+    reason: Reason,
+    error: RustfsClientError,
+    context: &'static str,
+) -> ProvisioningItemStatus {
+    let mut item = run.item_from_admin_error(previous, &base_item.name, reason, error, context);
+    copy_bucket_configuration_status(&mut item, base_item);
+    item
+}
+
+fn copy_bucket_configuration_status(
+    target: &mut ProvisioningItemStatus,
+    source: &ProvisioningItemStatus,
+) {
+    target.desired_hash = source.desired_hash.clone();
+    target.last_applied_hash = source.last_applied_hash.clone();
+    target.last_applied_generation = source.last_applied_generation;
+    target.region = source.region.clone();
+    target.object_lock = source.object_lock;
+}
+
+fn append_bucket_message(item: &ProvisioningItemStatus, lifecycle_message: &str) -> String {
+    item.message
+        .as_deref()
+        .map(|message| format!("{message}; {lifecycle_message}"))
+        .unwrap_or_else(|| lifecycle_message.to_string())
 }
 
 async fn desired_bucket_policy(
@@ -2613,6 +3100,8 @@ fn reason_from_str(reason: &str) -> Reason {
         "BucketObjectLockConflict" => Reason::BucketObjectLockConflict,
         "BucketPolicyApplyFailed" => Reason::BucketPolicyApplyFailed,
         "BucketPolicyConflict" => Reason::BucketPolicyConflict,
+        "BucketLifecycleApplyFailed" => Reason::BucketLifecycleApplyFailed,
+        "BucketLifecycleConflict" => Reason::BucketLifecycleConflict,
         _ => Reason::ProvisioningFailed,
     }
 }
@@ -2626,6 +3115,7 @@ mod tests {
         body::Body,
         extract::State,
         http::{Request, StatusCode},
+        response::{IntoResponse, Response},
         routing::{any, get, put},
     };
     use http_body_util::BodyExt;
@@ -2648,6 +3138,105 @@ mod tests {
     #[derive(Clone, Default)]
     struct UserCredentialCapture {
         body: Arc<Mutex<String>>,
+    }
+
+    #[derive(Clone, Default)]
+    struct LifecycleCapture {
+        live: Arc<Mutex<Option<String>>>,
+        put_body: Arc<Mutex<String>>,
+        get_count: Arc<AtomicUsize>,
+        put_count: Arc<AtomicUsize>,
+        delete_count: Arc<AtomicUsize>,
+        get_error_status: Arc<AtomicUsize>,
+    }
+
+    async fn lifecycle_bucket_handler(
+        State(capture): State<LifecycleCapture>,
+        request: Request<Body>,
+    ) -> Response {
+        let method = request.method().clone();
+        let lifecycle = request.uri().query().unwrap_or("") == "lifecycle=";
+        if !lifecycle {
+            return StatusCode::OK.into_response();
+        }
+        match method {
+            axum::http::Method::GET => {
+                capture.get_count.fetch_add(1, Ordering::SeqCst);
+                let error_status = capture.get_error_status.load(Ordering::SeqCst);
+                if error_status != 0 {
+                    return StatusCode::from_u16(error_status as u16)
+                        .expect("configured test status is valid")
+                        .into_response();
+                }
+                match capture.live.lock().await.clone() {
+                    Some(document) => (StatusCode::OK, document).into_response(),
+                    None => (
+                        StatusCode::NOT_FOUND,
+                        "<Error><Code>NoSuchLifecycleConfiguration</Code></Error>",
+                    )
+                        .into_response(),
+                }
+            }
+            axum::http::Method::PUT => {
+                capture.put_count.fetch_add(1, Ordering::SeqCst);
+                let body = axum::body::to_bytes(request.into_body(), usize::MAX)
+                    .await
+                    .expect("lifecycle request body");
+                *capture.put_body.lock().await =
+                    String::from_utf8(body.to_vec()).expect("lifecycle body is UTF-8");
+                StatusCode::OK.into_response()
+            }
+            axum::http::Method::DELETE => {
+                capture.delete_count.fetch_add(1, Ordering::SeqCst);
+                StatusCode::NO_CONTENT.into_response()
+            }
+            _ => StatusCode::METHOD_NOT_ALLOWED.into_response(),
+        }
+    }
+
+    async fn lifecycle_test_client(
+        capture: LifecycleCapture,
+    ) -> (RustfsAdminClient, tokio::task::JoinHandle<()>) {
+        let router = Router::new()
+            .route("/app-data", any(lifecycle_bucket_handler))
+            .with_state(capture);
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("test server should bind");
+        let addr = listener.local_addr().expect("listener should have address");
+        let server = tokio::spawn(async move {
+            axum::serve(listener, router)
+                .await
+                .expect("test server should serve")
+        });
+        (
+            RustfsAdminClient::new_with_base_url(format!("http://{addr}"), "access", "secret"),
+            server,
+        )
+    }
+
+    fn present_lifecycle_bucket(days: i32) -> ProvisioningBucket {
+        serde_json::from_value(serde_json::json!({
+            "name": "app-data",
+            "lifecycle": {
+                "state": "Present",
+                "rules": [{
+                    "id": "expire-logs",
+                    "status": "Enabled",
+                    "filter": {"prefix": "logs/"},
+                    "expiration": {"days": days}
+                }]
+            }
+        }))
+        .expect("lifecycle bucket should deserialize")
+    }
+
+    fn absent_lifecycle_bucket() -> ProvisioningBucket {
+        serde_json::from_value(serde_json::json!({
+            "name": "app-data",
+            "lifecycle": {"state": "Absent"}
+        }))
+        .expect("Absent lifecycle bucket should deserialize")
     }
 
     #[test]
@@ -4452,13 +5041,15 @@ mod tests {
         let user = provisioning_user("app-user", "app-user-secret", "readwrite");
         let tenant = provisioning_test_tenant(user, ProvisioningStatus::default());
         let mut run = empty_run(&ctx, &tenant);
-        run.status.buckets.push(run.item(
-            None::<&ProvisioningItemStatus>,
-            "app-data",
-            ProvisioningItemState::Pending,
-            Reason::ProvisioningPending,
-            "failed to create RustFS bucket: upstream returned 503",
-        ));
+        run.status
+            .buckets
+            .push(ProvisioningBucketStatus::new(run.item(
+                None::<&ProvisioningItemStatus>,
+                "app-data",
+                ProvisioningItemState::Pending,
+                Reason::ProvisioningPending,
+                "failed to create RustFS bucket: upstream returned 503",
+            )));
 
         match run.finish().outcome {
             ProvisioningOutcome::Retry { persist_status, .. } => {
@@ -4562,6 +5153,290 @@ mod tests {
             _ => panic!("permanent bucket create errors must not retry"),
         }
         server.abort();
+    }
+
+    #[tokio::test]
+    async fn present_bucket_lifecycle_is_applied_when_live_configuration_is_missing() {
+        let capture = LifecycleCapture::default();
+        let (client, server) = lifecycle_test_client(capture.clone()).await;
+        let ctx = empty_kube_context();
+        let user = provisioning_user("app-user", "app-user-secret", "readwrite");
+        let tenant = provisioning_test_tenant(user, ProvisioningStatus::default());
+        let mut run = empty_run(&ctx, &tenant);
+
+        let item = reconcile_bucket(&mut run, &client, &present_lifecycle_bucket(30)).await;
+
+        assert_eq!(item.state, ProvisioningItemState::Ready.as_str());
+        assert_eq!(capture.get_count.load(Ordering::SeqCst), 1);
+        assert_eq!(capture.put_count.load(Ordering::SeqCst), 1);
+        assert_eq!(capture.delete_count.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            item.lifecycle_desired_hash,
+            item.lifecycle_last_applied_hash
+        );
+        assert!(item.lifecycle_desired_hash.is_some());
+        let body = capture.put_body.lock().await;
+        assert!(body.contains("<ID>expire-logs</ID>"));
+        assert!(body.contains("<Prefix>logs/</Prefix>"));
+        assert!(body.contains("<Days>30</Days>"));
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn present_bucket_lifecycle_refuses_to_replace_unmanaged_live_configuration() {
+        let capture = LifecycleCapture::default();
+        *capture.live.lock().await = Some(
+            concat!(
+                "<LifecycleConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">",
+                "<Rule><Expiration><Days>7</Days></Expiration><Filter></Filter>",
+                "<ID>external</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>"
+            )
+            .to_string(),
+        );
+        let (client, server) = lifecycle_test_client(capture.clone()).await;
+        let ctx = empty_kube_context();
+        let user = provisioning_user("app-user", "app-user-secret", "readwrite");
+        let tenant = provisioning_test_tenant(user, ProvisioningStatus::default());
+        let mut run = empty_run(&ctx, &tenant);
+
+        let item = reconcile_bucket(&mut run, &client, &present_lifecycle_bucket(30)).await;
+
+        assert_eq!(item.state, ProvisioningItemState::Failed.as_str());
+        assert_eq!(item.reason, Reason::BucketLifecycleConflict.as_str());
+        assert_eq!(capture.put_count.load(Ordering::SeqCst), 0);
+        assert_eq!(capture.delete_count.load(Ordering::SeqCst), 0);
+        assert!(item.lifecycle_desired_hash.is_some());
+        assert!(item.lifecycle_last_applied_hash.is_none());
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn matching_live_bucket_lifecycle_is_adopted_without_write() {
+        let bucket = present_lifecycle_bucket(30);
+        let live = lifecycle_configuration(bucket.lifecycle.as_ref().expect("lifecycle spec"))
+            .expect("valid lifecycle")
+            .expect("Present lifecycle")
+            .to_xml();
+        let capture = LifecycleCapture::default();
+        *capture.live.lock().await = Some(live);
+        let (client, server) = lifecycle_test_client(capture.clone()).await;
+        let ctx = empty_kube_context();
+        let user = provisioning_user("app-user", "app-user-secret", "readwrite");
+        let tenant = provisioning_test_tenant(user, ProvisioningStatus::default());
+        let mut run = empty_run(&ctx, &tenant);
+
+        let item = reconcile_bucket(&mut run, &client, &bucket).await;
+
+        assert_eq!(item.state, ProvisioningItemState::Ready.as_str());
+        assert_eq!(capture.get_count.load(Ordering::SeqCst), 1);
+        assert_eq!(capture.put_count.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            item.lifecycle_desired_hash,
+            item.lifecycle_last_applied_hash
+        );
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn transient_bucket_lifecycle_read_preserves_ownership_and_retries() {
+        let capture = LifecycleCapture::default();
+        capture.get_error_status.store(
+            StatusCode::SERVICE_UNAVAILABLE.as_u16() as usize,
+            Ordering::SeqCst,
+        );
+        let (client, server) = lifecycle_test_client(capture.clone()).await;
+        let ctx = empty_kube_context();
+        let user = provisioning_user("app-user", "app-user-secret", "readwrite");
+        let tenant = provisioning_test_tenant(user, ProvisioningStatus::default());
+        let mut run = empty_run(&ctx, &tenant);
+        let mut previous = ProvisioningBucketStatus::new(ProvisioningItemStatus::new(
+            "app-data",
+            ProvisioningItemState::Ready,
+            Reason::ProvisioningConfigured.as_str(),
+        ));
+        previous.lifecycle_last_applied_hash = Some("owned-live".to_string());
+        run.previous.buckets.push(previous);
+
+        let item = reconcile_bucket(&mut run, &client, &present_lifecycle_bucket(30)).await;
+
+        assert_eq!(item.state, ProvisioningItemState::Pending.as_str());
+        assert_eq!(item.reason, Reason::ProvisioningPending.as_str());
+        assert_eq!(
+            item.lifecycle_last_applied_hash.as_deref(),
+            Some("owned-live")
+        );
+        assert!(run.retry.is_some());
+        assert_eq!(capture.put_count.load(Ordering::SeqCst), 0);
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn oversized_bucket_lifecycle_response_fails_without_write() {
+        let capture = LifecycleCapture::default();
+        *capture.live.lock().await = Some(format!(
+            "<LifecycleConfiguration>{}</LifecycleConfiguration>",
+            "x".repeat(4 * 1024 * 1024)
+        ));
+        let (client, server) = lifecycle_test_client(capture.clone()).await;
+        let ctx = empty_kube_context();
+        let user = provisioning_user("app-user", "app-user-secret", "readwrite");
+        let tenant = provisioning_test_tenant(user, ProvisioningStatus::default());
+        let mut run = empty_run(&ctx, &tenant);
+
+        let item = reconcile_bucket(&mut run, &client, &present_lifecycle_bucket(30)).await;
+
+        assert_eq!(item.state, ProvisioningItemState::Failed.as_str());
+        assert_eq!(item.reason, Reason::BucketLifecycleApplyFailed.as_str());
+        assert_eq!(capture.put_count.load(Ordering::SeqCst), 0);
+        assert!(run.retry.is_none());
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn absent_bucket_lifecycle_deletes_only_matching_owned_configuration() {
+        let live = concat!(
+            "<LifecycleConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">",
+            "<Rule><Expiration><Days>30</Days></Expiration><Filter><Prefix>logs/</Prefix></Filter>",
+            "<ID>expire-logs</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>"
+        );
+        let live_hash = hash_document(
+            &canonicalize_bucket_lifecycle_xml(live).expect("live lifecycle should normalize"),
+        );
+        let capture = LifecycleCapture::default();
+        *capture.live.lock().await = Some(live.to_string());
+        let (client, server) = lifecycle_test_client(capture.clone()).await;
+        let ctx = empty_kube_context();
+        let user = provisioning_user("app-user", "app-user-secret", "readwrite");
+        let tenant = provisioning_test_tenant(user, ProvisioningStatus::default());
+        let mut run = empty_run(&ctx, &tenant);
+        let mut previous = ProvisioningBucketStatus::new(ProvisioningItemStatus::new(
+            "app-data",
+            ProvisioningItemState::Ready,
+            Reason::ProvisioningConfigured.as_str(),
+        ));
+        previous.lifecycle_desired_hash = Some(live_hash.clone());
+        previous.lifecycle_last_applied_hash = Some(live_hash);
+        run.previous.buckets.push(previous);
+
+        let item = reconcile_bucket(&mut run, &client, &absent_lifecycle_bucket()).await;
+
+        assert_eq!(item.state, ProvisioningItemState::Ready.as_str());
+        assert_eq!(capture.delete_count.load(Ordering::SeqCst), 1);
+        assert!(item.lifecycle_desired_hash.is_none());
+        assert!(item.lifecycle_last_applied_hash.is_none());
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn omitted_bucket_lifecycle_performs_no_lifecycle_request_and_preserves_ownership() {
+        let capture = LifecycleCapture::default();
+        let (client, server) = lifecycle_test_client(capture.clone()).await;
+        let ctx = empty_kube_context();
+        let user = provisioning_user("app-user", "app-user-secret", "readwrite");
+        let tenant = provisioning_test_tenant(user, ProvisioningStatus::default());
+        let mut run = empty_run(&ctx, &tenant);
+        let mut previous = ProvisioningBucketStatus::new(ProvisioningItemStatus::new(
+            "app-data",
+            ProvisioningItemState::Ready,
+            Reason::ProvisioningConfigured.as_str(),
+        ));
+        previous.lifecycle_desired_hash = Some("old-desired".to_string());
+        previous.lifecycle_last_applied_hash = Some("owned-live".to_string());
+        run.previous.buckets.push(previous);
+        let bucket = ProvisioningBucket {
+            name: "app-data".to_string(),
+            ..Default::default()
+        };
+
+        let item = reconcile_bucket(&mut run, &client, &bucket).await;
+
+        assert_eq!(item.state, ProvisioningItemState::Ready.as_str());
+        assert_eq!(capture.get_count.load(Ordering::SeqCst), 0);
+        assert_eq!(capture.put_count.load(Ordering::SeqCst), 0);
+        assert_eq!(capture.delete_count.load(Ordering::SeqCst), 0);
+        assert!(item.lifecycle_desired_hash.is_none());
+        assert_eq!(
+            item.lifecycle_last_applied_hash.as_deref(),
+            Some("owned-live")
+        );
+        server.abort();
+    }
+
+    #[test]
+    fn lifecycle_reconcile_action_protects_owned_and_unmanaged_configurations() {
+        assert_eq!(
+            lifecycle_reconcile_action(None, None, Some("desired")),
+            LifecycleReconcileAction::Apply
+        );
+        assert_eq!(
+            lifecycle_reconcile_action(None, Some("desired"), Some("desired")),
+            LifecycleReconcileAction::Ready("RustFS bucket lifecycle configuration matches spec")
+        );
+        assert!(matches!(
+            lifecycle_reconcile_action(None, Some("external"), Some("desired")),
+            LifecycleReconcileAction::Failed(_)
+        ));
+        assert_eq!(
+            lifecycle_reconcile_action(Some("owned"), Some("owned"), Some("changed")),
+            LifecycleReconcileAction::Apply
+        );
+        assert_eq!(
+            lifecycle_reconcile_action(Some("owned"), Some("owned"), None),
+            LifecycleReconcileAction::Delete
+        );
+        assert!(matches!(
+            lifecycle_reconcile_action(None, Some("external"), None),
+            LifecycleReconcileAction::Failed(_)
+        ));
+
+        let mut bucket = present_lifecycle_bucket(30);
+        bucket.lifecycle.as_mut().expect("lifecycle").rules[0]
+            .filter
+            .prefix = "invalid\0prefix".to_string();
+        assert!(
+            lifecycle_configuration(bucket.lifecycle.as_ref().expect("lifecycle")).is_err(),
+            "invalid XML characters must fail before an S3 request"
+        );
+    }
+
+    #[test]
+    fn lifecycle_configuration_validates_empty_and_exact_boundaries() {
+        let mut bucket = present_lifecycle_bucket(1);
+        let spec = bucket.lifecycle.as_mut().expect("lifecycle");
+        let template = spec.rules[0].clone();
+        spec.rules = (0..MAX_BUCKET_LIFECYCLE_RULES)
+            .map(|index| {
+                let mut rule = template.clone();
+                rule.id = format!("rule-{index}");
+                rule
+            })
+            .collect();
+        assert!(lifecycle_configuration(spec).is_ok());
+        let mut overflow = template.clone();
+        overflow.id = "overflow".to_string();
+        spec.rules.push(overflow);
+        assert!(lifecycle_configuration(spec).is_err());
+
+        spec.rules = vec![template.clone()];
+        spec.rules[0].id = "x".repeat(MAX_BUCKET_LIFECYCLE_RULE_ID_LENGTH as usize);
+        assert!(lifecycle_configuration(spec).is_ok());
+        spec.rules[0].id.push('x');
+        assert!(lifecycle_configuration(spec).is_err());
+        spec.rules[0].id = "界".repeat(86);
+        assert!(
+            lifecycle_configuration(spec).is_err(),
+            "RustFS enforces the lifecycle rule ID limit in UTF-8 bytes"
+        );
+
+        spec.rules.clear();
+        assert!(lifecycle_configuration(spec).is_err());
+        spec.state = BucketLifecycleState::Absent;
+        assert_eq!(lifecycle_configuration(spec), Ok(None));
+        spec.rules.push(template);
+        assert!(lifecycle_configuration(spec).is_err());
+
+        let zero_days = present_lifecycle_bucket(0);
+        assert!(lifecycle_configuration(zero_days.lifecycle.as_ref().expect("lifecycle")).is_err());
     }
 
     #[tokio::test]
@@ -4677,7 +5552,7 @@ mod tests {
             Reason::ProvisioningConfigured.as_str(),
         );
         previous.last_applied_hash = Some(live_hash.clone());
-        run.previous.buckets.push(previous);
+        run.previous.buckets.push(previous.into());
         let omitted_bucket = ProvisioningBucket {
             name: "app-data".to_string(),
             ..Default::default()

--- a/src/sts/rustfs_client.rs
+++ b/src/sts/rustfs_client.rs
@@ -21,9 +21,11 @@ use crate::Tenant;
 use crate::cluster_dns;
 
 pub use rustfs_admin::{
-    CreateBucketResult, RustfsClientError, RustfsCredentials, RustfsErasureBackend,
-    RustfsErasureSetInfo, RustfsPoolDecommissionInfo, RustfsPoolListItem, RustfsPoolStatus,
-    RustfsServerInfo, RustfsServerUsage, RustfsUserInfo,
+    BucketLifecycleAbortIncompleteMultipartUpload, BucketLifecycleConfiguration,
+    BucketLifecycleExpiration, BucketLifecycleRule, BucketLifecycleRuleStatus, CreateBucketResult,
+    RustfsClientError, RustfsCredentials, RustfsErasureBackend, RustfsErasureSetInfo,
+    RustfsPoolDecommissionInfo, RustfsPoolListItem, RustfsPoolStatus, RustfsServerInfo,
+    RustfsServerUsage, RustfsUserInfo, canonicalize_bucket_lifecycle_xml,
 };
 
 /// Tenant-aware wrapper around the kube-agnostic RustFS admin client.

--- a/src/types/v1alpha1.rs
+++ b/src/types/v1alpha1.rs
@@ -141,7 +141,9 @@ mod policy_binding_tests {
 mod tenant_provisioning_crd_tests {
     use super::{
         pool_lifecycle::MAX_DECOMMISSION_REQUESTS,
-        provisioning::MAX_POLICIES_PER_USER,
+        provisioning::{
+            MAX_BUCKET_LIFECYCLE_RULE_ID_LENGTH, MAX_BUCKET_LIFECYCLE_RULES, MAX_POLICIES_PER_USER,
+        },
         tenant::{
             MAX_TENANT_BUCKETS, MAX_TENANT_POLICIES, MAX_TENANT_POOLS, MAX_TENANT_USERS, Tenant,
         },
@@ -368,6 +370,56 @@ mod tenant_provisioning_crd_tests {
         assert_eq!(
             spec["properties"]["buckets"]["items"]["x-kubernetes-validations"][0]["rule"],
             json!("!(has(self.policy) && has(self.anonymous) && self.anonymous != 'Private')")
+        );
+        let lifecycle = &spec["properties"]["buckets"]["items"]["properties"]["lifecycle"];
+        assert_eq!(
+            lifecycle["properties"]["state"]["enum"],
+            json!(["Present", "Absent"])
+        );
+        assert_eq!(
+            lifecycle["properties"]["rules"]["maxItems"],
+            json!(MAX_BUCKET_LIFECYCLE_RULES)
+        );
+        assert_eq!(
+            lifecycle["properties"]["rules"]["x-kubernetes-list-type"],
+            json!("map")
+        );
+        assert_eq!(
+            lifecycle["properties"]["rules"]["x-kubernetes-list-map-keys"],
+            json!(["id"])
+        );
+        assert_eq!(
+            lifecycle["properties"]["rules"]["items"]["properties"]["id"]["maxLength"],
+            json!(MAX_BUCKET_LIFECYCLE_RULE_ID_LENGTH)
+        );
+        assert_eq!(
+            lifecycle["properties"]["rules"]["items"]["properties"]["expiration"]["properties"]["days"]
+                ["minimum"]
+                .as_f64(),
+            Some(1.0)
+        );
+        assert_eq!(
+            lifecycle["properties"]["rules"]["items"]["properties"]["abortIncompleteMultipartUpload"]
+                ["properties"]["daysAfterInitiation"]["minimum"]
+                .as_f64(),
+            Some(1.0)
+        );
+        assert_eq!(
+            lifecycle["x-kubernetes-validations"][0]["message"],
+            json!("Present lifecycle requires rules and Absent lifecycle forbids rules")
+        );
+        assert_eq!(
+            lifecycle["properties"]["rules"]["items"]["x-kubernetes-validations"][0]["message"],
+            json!("lifecycle rule must configure expiration or abortIncompleteMultipartUpload")
+        );
+        let bucket_status = &status["properties"]["provisioning"]["properties"]["buckets"]["items"];
+        assert_eq!(
+            bucket_status["properties"]["lifecycleDesiredHash"]["type"],
+            json!("string")
+        );
+        assert_eq!(
+            bucket_status["properties"]["lifecycleLastAppliedHash"]["nullable"],
+            json!(true)
         );
     }
 }

--- a/src/types/v1alpha1/provisioning.rs
+++ b/src/types/v1alpha1/provisioning.rs
@@ -27,6 +27,8 @@ pub(crate) const MAX_POLICIES_PER_USER: u32 = 64;
 pub(crate) const MAX_USER_POLICY_NAME_LENGTH: u32 = 253;
 pub(crate) const MIN_BUCKET_NAME_LENGTH: u32 = 3;
 pub(crate) const MAX_BUCKET_NAME_LENGTH: u32 = 63;
+pub(crate) const MAX_BUCKET_LIFECYCLE_RULES: u32 = 1_000;
+pub(crate) const MAX_BUCKET_LIFECYCLE_RULE_ID_LENGTH: u32 = 255;
 
 #[derive(Deserialize, Serialize, Clone, Debug, JsonSchema, ToSchema, Default, PartialEq, Eq)]
 #[serde(rename_all = "PascalCase")]
@@ -133,6 +135,73 @@ pub enum BucketAnonymousAccess {
     Public,
 }
 
+#[derive(Deserialize, Serialize, Clone, Copy, Debug, JsonSchema, ToSchema, PartialEq, Eq)]
+#[serde(rename_all = "PascalCase")]
+pub enum BucketLifecycleState {
+    Present,
+    Absent,
+}
+
+#[derive(Deserialize, Serialize, Clone, Copy, Debug, JsonSchema, ToSchema, PartialEq, Eq)]
+#[serde(rename_all = "PascalCase")]
+pub enum BucketLifecycleRuleStatus {
+    Enabled,
+    Disabled,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, KubeSchema, ToSchema, Default, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct BucketLifecycleRuleFilter {
+    /// Object-key prefix selected by this rule. An empty prefix selects all objects.
+    pub prefix: String,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, KubeSchema, ToSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct BucketLifecycleExpiration {
+    #[schemars(range(min = 1))]
+    pub days: i32,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, KubeSchema, ToSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct BucketLifecycleAbortIncompleteMultipartUpload {
+    #[schemars(range(min = 1))]
+    pub days_after_initiation: i32,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, KubeSchema, ToSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+#[x_kube(validation = Rule::new("has(self.expiration) || has(self.abortIncompleteMultipartUpload)").message("lifecycle rule must configure expiration or abortIncompleteMultipartUpload"))]
+pub struct BucketLifecycleRule {
+    #[schemars(length(min = 1, max = MAX_BUCKET_LIFECYCLE_RULE_ID_LENGTH))]
+    pub id: String,
+
+    pub status: BucketLifecycleRuleStatus,
+
+    pub filter: BucketLifecycleRuleFilter,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expiration: Option<BucketLifecycleExpiration>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub abort_incomplete_multipart_upload: Option<BucketLifecycleAbortIncompleteMultipartUpload>,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, KubeSchema, ToSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+#[x_kube(validation = Rule::new("self.state == 'Present' ? has(self.rules) && self.rules.size() > 0 : !has(self.rules) || self.rules.size() == 0").message("Present lifecycle requires rules and Absent lifecycle forbids rules"))]
+pub struct BucketLifecycleSpec {
+    pub state: BucketLifecycleState,
+
+    #[schemars(
+        length(max = MAX_BUCKET_LIFECYCLE_RULES),
+        extend("x-kubernetes-list-type" = "map", "x-kubernetes-list-map-keys" = ["id"])
+    )]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub rules: Vec<BucketLifecycleRule>,
+}
+
 impl BucketAnonymousAccess {
     pub(crate) fn is_private(&self) -> bool {
         matches!(self, Self::Private)
@@ -166,6 +235,12 @@ pub struct ProvisioningBucket {
     /// `anonymous`; legacy `Private` plus `policy` configurations keep the custom policy.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub policy: Option<PolicyDocumentSource>,
+
+    /// Declarative S3 bucket lifecycle configuration. Omission leaves the live lifecycle
+    /// configuration unmanaged; `Absent` removes only a configuration previously owned by the
+    /// operator.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lifecycle: Option<BucketLifecycleSpec>,
 
     #[serde(default, skip_serializing_if = "is_retain")]
     pub deletion_policy: ProvisioningDeletionPolicy,
@@ -295,5 +370,39 @@ mod tests {
             .expect("legacy private plus policy configuration deserializes");
         assert!(legacy_private_policy.has_custom_policy());
         assert!(!legacy_private_policy.has_non_private_anonymous_access());
+    }
+
+    #[test]
+    fn bucket_lifecycle_deserializes_present_and_absent_states() {
+        let present: super::ProvisioningBucket = serde_json::from_value(serde_json::json!({
+            "name": "app-data",
+            "lifecycle": {
+                "state": "Present",
+                "rules": [{
+                    "id": "expire-logs",
+                    "status": "Enabled",
+                    "filter": {"prefix": "logs/"},
+                    "expiration": {"days": 30},
+                    "abortIncompleteMultipartUpload": {"daysAfterInitiation": 1}
+                }]
+            }
+        }))
+        .expect("Present lifecycle should deserialize");
+        let lifecycle = present.lifecycle.expect("lifecycle is present");
+        assert_eq!(lifecycle.state, super::BucketLifecycleState::Present);
+        assert_eq!(lifecycle.rules[0].filter.prefix, "logs/");
+
+        let absent: super::ProvisioningBucket = serde_json::from_value(serde_json::json!({
+            "name": "app-data",
+            "lifecycle": {"state": "Absent"}
+        }))
+        .expect("Absent lifecycle should deserialize without rules");
+        assert!(
+            absent
+                .lifecycle
+                .expect("lifecycle is present")
+                .rules
+                .is_empty()
+        );
     }
 }

--- a/src/types/v1alpha1/status.rs
+++ b/src/types/v1alpha1/status.rs
@@ -177,6 +177,8 @@ pub enum Reason {
     BucketObjectLockConflict,
     BucketPolicyApplyFailed,
     BucketPolicyConflict,
+    BucketLifecycleApplyFailed,
+    BucketLifecycleConflict,
     KubernetesApiError,
     StatusPatchFailed,
     ObservedGenerationStale,
@@ -250,6 +252,8 @@ impl Reason {
             Self::BucketObjectLockConflict => "BucketObjectLockConflict",
             Self::BucketPolicyApplyFailed => "BucketPolicyApplyFailed",
             Self::BucketPolicyConflict => "BucketPolicyConflict",
+            Self::BucketLifecycleApplyFailed => "BucketLifecycleApplyFailed",
+            Self::BucketLifecycleConflict => "BucketLifecycleConflict",
             Self::KubernetesApiError => "KubernetesApiError",
             Self::StatusPatchFailed => "StatusPatchFailed",
             Self::ObservedGenerationStale => "ObservedGenerationStale",
@@ -526,6 +530,8 @@ pub fn is_blocked_reason(reason: &str) -> bool {
             | "BucketObjectLockConflict"
             | "BucketPolicyApplyFailed"
             | "BucketPolicyConflict"
+            | "BucketLifecycleApplyFailed"
+            | "BucketLifecycleConflict"
     )
 }
 
@@ -624,6 +630,10 @@ pub fn next_actions_for_reason(reason: &str) -> Vec<&'static str> {
         "BucketObjectLockConflict" => vec!["createObjectLockBucket", "fixBucketSpec"],
         "BucketPolicyApplyFailed" => vec!["fixBucketPolicy", "inspectOperatorLogs"],
         "BucketPolicyConflict" => vec!["inspectLiveBucketPolicy", "updateBucketSpec"],
+        "BucketLifecycleApplyFailed" => vec!["fixBucketLifecycle", "inspectOperatorLogs"],
+        "BucketLifecycleConflict" => {
+            vec!["inspectLiveBucketLifecycle", "updateBucketSpec"]
+        }
         "KubernetesApiError" => vec!["retry", "inspectOperatorLogs"],
         "ObservedGenerationStale" => vec!["waitForReconcile"],
         _ => Vec::new(),
@@ -722,6 +732,16 @@ mod tests {
         assert_eq!(
             next_actions_for_reason("BucketPolicyConflict"),
             vec!["inspectLiveBucketPolicy", "updateBucketSpec"]
+        );
+        assert!(is_blocked_reason("BucketLifecycleApplyFailed"));
+        assert!(is_blocked_reason("BucketLifecycleConflict"));
+        assert_eq!(
+            next_actions_for_reason("BucketLifecycleApplyFailed"),
+            vec!["fixBucketLifecycle", "inspectOperatorLogs"]
+        );
+        assert_eq!(
+            next_actions_for_reason("BucketLifecycleConflict"),
+            vec!["inspectLiveBucketLifecycle", "updateBucketSpec"]
         );
     }
 

--- a/src/types/v1alpha1/status/provisioning.rs
+++ b/src/types/v1alpha1/status/provisioning.rs
@@ -33,7 +33,7 @@ pub struct ProvisioningStatus {
     pub users: Vec<ProvisioningUserStatus>,
 
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub buckets: Vec<ProvisioningItemStatus>,
+    pub buckets: Vec<ProvisioningBucketStatus>,
 }
 
 impl ProvisioningStatus {
@@ -117,6 +117,57 @@ impl AsRef<ProvisioningItemStatus> for ProvisioningUserStatus {
     }
 }
 
+/// Bucket-specific provisioning status. Lifecycle ownership hashes are separate from the
+/// existing bucket-policy hashes while preserving the established flattened wire format.
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema, ToSchema, Default, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ProvisioningBucketStatus {
+    #[serde(flatten)]
+    pub item: ProvisioningItemStatus,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lifecycle_desired_hash: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lifecycle_last_applied_hash: Option<String>,
+}
+
+impl ProvisioningBucketStatus {
+    pub fn new(item: ProvisioningItemStatus) -> Self {
+        Self {
+            item,
+            lifecycle_desired_hash: None,
+            lifecycle_last_applied_hash: None,
+        }
+    }
+}
+
+impl Deref for ProvisioningBucketStatus {
+    type Target = ProvisioningItemStatus;
+
+    fn deref(&self) -> &Self::Target {
+        &self.item
+    }
+}
+
+impl DerefMut for ProvisioningBucketStatus {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.item
+    }
+}
+
+impl AsRef<ProvisioningItemStatus> for ProvisioningBucketStatus {
+    fn as_ref(&self) -> &ProvisioningItemStatus {
+        &self.item
+    }
+}
+
+impl From<ProvisioningItemStatus> for ProvisioningBucketStatus {
+    fn from(item: ProvisioningItemStatus) -> Self {
+        Self::new(item)
+    }
+}
+
 impl ProvisioningItemState {
     pub const fn as_str(&self) -> &'static str {
         match self {
@@ -189,5 +240,30 @@ impl ProvisioningItemStatus {
 impl AsRef<ProvisioningItemStatus> for ProvisioningItemStatus {
     fn as_ref(&self) -> &ProvisioningItemStatus {
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_bucket_status_deserializes_without_lifecycle_hashes() {
+        let status: ProvisioningStatus = serde_json::from_value(serde_json::json!({
+            "buckets": [{
+                "name": "app-data",
+                "state": "Ready",
+                "reason": "ProvisioningConfigured",
+                "lastAppliedHash": "bucket-policy-hash"
+            }]
+        }))
+        .expect("legacy bucket status should deserialize");
+
+        assert_eq!(
+            status.buckets[0].last_applied_hash.as_deref(),
+            Some("bucket-policy-hash")
+        );
+        assert!(status.buckets[0].lifecycle_desired_hash.is_none());
+        assert!(status.buckets[0].lifecycle_last_applied_hash.is_none());
     }
 }


### PR DESCRIPTION
## Type of Change
- [x] New Feature
- [ ] Bug Fix
- [x] Documentation
- [ ] Performance Improvement
- [ ] Test/CI
- [ ] Refactor
- [ ] Other:

## Related Issues
Closes #249

## Summary of Changes
- Add declarative `spec.buckets[].lifecycle` configuration with explicit `Present` and `Absent` states.
- Reconcile S3 bucket lifecycle rules with separate desired and last-applied ownership hashes, drift detection, and conflict-safe deletion.
- Add signed Lifecycle GET, PUT, and DELETE operations with strict, bounded XML handling and canonical comparison.
- Publish the schema through the Tenant CRD, OpenAPI, console types, examples, user guides, and changelog.

## Checklist
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines
- [x] Passed `make pre-commit` (fmt-check + clippy + test + console-lint + console-fmt-check)
- [x] Added/updated necessary tests
- [x] Documentation updated (if needed)
- [x] CHANGELOG.md updated under `[Unreleased]` (if user-visible change)
- [ ] CI/CD passed (if applicable)

## Impact
- [ ] Breaking change (CRD/API compatibility)
- [x] Requires doc/config/deployment update
- [x] Other impact: Existing bucket specifications remain unchanged when `lifecycle` is omitted.

## Verification
```bash
make pre-commit
```

## Additional Notes
- Omitting `lifecycle` performs no Lifecycle API requests and preserves existing ownership status.
- `Absent` deletes a live lifecycle configuration only when its hash matches the operator's last-applied hash.
- Canonical XML comparison ignores transport formatting while retaining unknown lifecycle elements in drift detection.
- Rollback can remove lifecycle declarations and deploy the previous operator and CRD; omission leaves live bucket lifecycle configuration untouched.

---

Thank you for your contribution! Please ensure your PR follows the community standards ([CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) and sign the CLA if this is your first contribution.
